### PR TITLE
design: light-theme redesign — landing + board + report (v1.0.158)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "great_cto",
   "id": "great_cto",
   "description": "Engineering process for solo founders and teams up to 50 engineers. Agents do architecture, code review, QA, and security. You make two decisions per feature.",
-  "version": "1.0.157",
+  "version": "1.0.158",
   "author": {
     "name": "Great CTO",
     "url": "https://github.com/avelikiy/great_cto"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to great_cto are documented here.
 
 ---
 
+## v1.0.158 — 2026-04-30
+
+### Light-theme redesign + new landing page
+
+Full Ghibli-inspired light-theme redesign — replaces the dark Linear/Notion aesthetic across all surfaces.
+
+- **New `site/`** — public landing page deployed to GitHub Pages (already wired via `.github/workflows/pages.yml`). Hero with hand-drawn SVG landscape (dawn variant), dashboard preview, "How it works" 3-step, six headline metrics, founder/VP-eng quotes, 17-agent table, terminal CTA. Pure static HTML/CSS — no build step.
+- **`packages/board/public/index.html`** — board admin rewritten in light theme. Sidebar with project switcher + nav (Tasks/Metrics/Share/Agents), Fraunces-serif headings, soft pastel landscape background, kanban columns with ring/half/filled status dots, redesigned Metrics page (3 hero + 4 secondary cards + agent utilization + activity feed), Share tab with toggle. All `/api/tasks`, `/api/metrics`, `/api/share`, `/api/sse` wiring preserved.
+- **`packages/board/public/share.html`** — public report on light landscape background, glass card with serif headline, three hero stats (Tasks shipped / LLM spend / vs FTE) + three secondary (AI time / QA pass rate / In progress), recently shipped list, paused state. Server template placeholders (`{{PROJECT}}`, `{{DATE}}`, `{{METRICS_JSON}}`, `{{TASKS_JSON}}`, `{{PAUSED}}`) unchanged — server.mjs and Cloudflare worker unaffected.
+
+Stack: vanilla HTML/CSS/JS — zero deps for client install.
+
+---
+
 ## v1.0.157 — 2026-04-30
 
 ### great_cto board — Kanban + CTO Dashboard + Shareable report URL

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 <p align="center">
   <a href="https://github.com/avelikiy/great_cto/stargazers"><img src="https://img.shields.io/github/stars/avelikiy/great_cto?style=flat" alt="Stars" /></a>
-  <img src="https://img.shields.io/badge/version-1.0.157-blue" alt="Version" />
+  <img src="https://img.shields.io/badge/version-1.0.158-blue" alt="Version" />
   <a href="https://www.npmjs.com/package/great-cto"><img src="https://img.shields.io/npm/v/great-cto?label=npx%20great-cto&color=cb3837" alt="npm" /></a>
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License" />
   <a href="https://claude.com/plugins"><img src="https://img.shields.io/badge/Claude_Code-Plugin-blueviolet" alt="Claude Code" /></a>
@@ -488,6 +488,7 @@ Spawned agents inherit the parent session's permission mode. If you started the 
 - Example projects: [`demo/saas-api.md`](demo/saas-api.md) · [`demo/smart-contract.md`](demo/smart-contract.md) · [`demo/trading-bot.md`](demo/trading-bot.md)
 - Production smoke test: [`docs/smoke-test.md`](docs/smoke-test.md) — 7-phase runbook to verify everything works on your real project
 - Changelog: [`CHANGELOG.md`](CHANGELOG.md) · [Website](https://greatcto.systems)
+- Landing site source: [`site/`](site/) — deployed to GitHub Pages on push to `main`
 
 ---
 

--- a/packages/board/public/index.html
+++ b/packages/board/public/index.html
@@ -3,670 +3,808 @@
 <head>
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<meta name="color-scheme" content="dark" />
+<meta name="color-scheme" content="light" />
 <title>great_cto board</title>
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400..700;1,9..144,400..700&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
 <style>
-/* ── Tokens ─────────────────────────────────────────────────────────────────── */
 :root {
-  --bg0: #0f0f0f;
-  --bg1: #161616;
-  --bg2: #1c1c1c;
-  --bg3: #242424;
-  --bg4: #2c2c2c;
-  --border: rgba(255,255,255,0.08);
-  --border-strong: rgba(255,255,255,0.14);
-  --text:  #f1f1f1;
-  --text2: #8b8b8b;
-  --text3: #b0b0b0;
-  --accent: #5e6ad2;
-  --accent-hover: #6b77e5;
-  --green: #26b066;
-  --green-bg: rgba(38,176,102,.12);
-  --yellow: #f0b429;
-  --yellow-bg: rgba(240,180,41,.12);
-  --red: #e5484d;
-  --red-bg: rgba(229,72,77,.12);
-  --purple: #8b5cf6;
-  --purple-bg: rgba(139,92,246,.12);
-  --orange: #f97316;
-  --mono: 'JetBrains Mono', 'Fira Code', monospace;
-  --font: 'Inter', system-ui, -apple-system, sans-serif;
-  --r: 5px;
-  --r-sm: 3px;
+  --bg-page: transparent;
+  --bg-panel: rgba(255, 255, 255, 0.92);
+  --bg-card: #ffffff;
+  --bg-muted: #f7f8fa;
+  --bg-strong: #ecedf0;
+
+  --border: rgba(15, 17, 21, 0.08);
+  --border-strong: rgba(15, 17, 21, 0.14);
+
+  --text: #0f1115;
+  --text2: #5b6573;
+  --text3: #828b97;
+
+  --accent: #2540d4;
+  --accent-2: #6b81ff;
+  --accent-soft: #e8edff;
+
+  --status-backlog: #94a3b8;
+  --status-todo: #64748b;
+  --status-progress: #f59e0b;
+  --status-review: #16a34a;
+  --status-done: #2563eb;
+  --status-blocked: #dc2626;
+  --status-gate: #7c3aed;
+
+  --p0-bg: #fee2e2; --p0-fg: #b91c1c;
+  --p1-bg: #ffedd5; --p1-fg: #c2410c;
+  --p2-bg: #fef3c7; --p2-fg: #92400e;
+  --p3-bg: #f1f5f9; --p3-fg: #475569;
+
+  --serif: "Fraunces", Georgia, serif;
+  --sans: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --mono: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, monospace;
+
+  --shadow-card: 0 1px 2px rgba(15, 17, 21, 0.04);
+  --shadow-card-hover: 0 1px 2px rgba(15, 17, 21, 0.06), 0 8px 24px rgba(15, 17, 21, 0.08);
 }
-*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
-html { height: 100%; }
+* { box-sizing: border-box; margin: 0; padding: 0; }
+html, body { height: 100%; }
 body {
-  background: var(--bg0);
+  font-family: var(--sans);
   color: var(--text);
-  font-family: var(--font);
-  font-size: 13px;
+  font-size: 14px;
   line-height: 1.5;
-  height: 100%;
   -webkit-font-smoothing: antialiased;
-}
-
-/* ── Layout ─────────────────────────────────────────────────────────────────── */
-.app { display: flex; flex-direction: column; height: 100vh; }
-
-/* ── Topbar ─────────────────────────────────────────────────────────────────── */
-.topbar {
-  height: 44px;
-  background: var(--bg1);
-  border-bottom: 1px solid var(--border);
-  display: flex;
-  align-items: center;
-  padding: 0 12px 0 16px;
-  gap: 0;
-  flex-shrink: 0;
-  user-select: none;
-}
-.breadcrumb {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  font-size: 13px;
-  font-weight: 500;
-  color: var(--text3);
-  margin-right: 16px;
-  flex-shrink: 0;
-}
-.breadcrumb-icon {
-  width: 18px; height: 18px;
-  background: var(--accent);
-  border-radius: 4px;
-  display: flex; align-items: center; justify-content: center;
-  font-size: 10px; color: white; font-weight: 700;
-  letter-spacing: -0.02em;
-}
-.breadcrumb-sep { color: var(--bg4); font-size: 16px; font-weight: 300; }
-.breadcrumb-project { color: var(--text); font-weight: 600; }
-
-/* ── Tabs ───────────────────────────────────────────────────────────────────── */
-.tabs { display: flex; align-items: center; gap: 2px; }
-.tab {
-  height: 28px;
-  padding: 0 10px;
-  display: flex; align-items: center; gap: 6px;
-  font-size: 13px;
-  color: var(--text2);
-  cursor: pointer;
-  border-radius: var(--r);
-  transition: color .12s, background .12s;
-  font-weight: 500;
-  white-space: nowrap;
-}
-.tab svg { opacity: .7; }
-.tab:hover { color: var(--text3); background: var(--bg3); }
-.tab.active { color: var(--text); background: var(--bg3); }
-.tab.active svg { opacity: 1; }
-
-.topbar-right {
-  margin-left: auto;
-  display: flex;
-  align-items: center;
-  gap: 10px;
-}
-.live-indicator {
-  display: flex; align-items: center; gap: 5px;
-  font-size: 11px;
-  font-family: var(--mono);
-  color: var(--text2);
-}
-.live-dot {
-  width: 6px; height: 6px;
-  background: var(--green);
-  border-radius: 50%;
-}
-.live-dot.pulse { animation: lp 2s infinite; }
-@keyframes lp { 0%,100%{opacity:1} 50%{opacity:.3} }
-.live-dot.error { background: var(--red); animation: none; }
-
-/* ── Content ────────────────────────────────────────────────────────────────── */
-.content { flex: 1; overflow: hidden; position: relative; }
-.panel { display: none; height: 100%; overflow: auto; }
-.panel.active { display: flex; flex-direction: column; }
-
-/* ── Kanban ─────────────────────────────────────────────────────────────────── */
-.kanban-wrap {
-  flex: 1;
-  overflow-x: auto;
-  overflow-y: hidden;
-  padding: 16px 16px 0;
-}
-.kanban {
-  display: flex;
-  gap: 8px;
-  height: 100%;
-  min-width: max-content;
-}
-.column {
-  width: 260px;
-  flex-shrink: 0;
-  display: flex;
-  flex-direction: column;
-  background: var(--bg1);
-  border: 1px solid var(--border);
-  border-radius: var(--r);
-  overflow: hidden;
-  max-height: calc(100vh - 90px);
-}
-.col-header {
-  padding: 8px 10px;
-  display: flex;
-  align-items: center;
-  gap: 7px;
-  border-bottom: 1px solid var(--border);
-  flex-shrink: 0;
-}
-.col-indicator {
-  width: 8px; height: 8px;
-  border-radius: 2px;
-  flex-shrink: 0;
-}
-.col-gate    .col-indicator { background: var(--purple); }
-.col-backlog .col-indicator { background: var(--text2); opacity: .6; }
-.col-in_progress .col-indicator { background: var(--accent); }
-.col-done    .col-indicator { background: var(--green); }
-.col-blocked .col-indicator { background: var(--red); }
-
-.col-title {
-  font-size: 12px;
-  font-weight: 600;
-  color: var(--text3);
-  letter-spacing: .01em;
-  flex: 1;
-}
-.col-count {
-  font-size: 11px;
-  font-family: var(--mono);
-  color: var(--text2);
-  background: var(--bg3);
-  border-radius: var(--r-sm);
-  padding: 0 5px;
-  line-height: 18px;
-}
-.col-body {
-  flex: 1;
-  overflow-y: auto;
-  padding: 6px;
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-}
-
-/* ── Task cards ─────────────────────────────────────────────────────────────── */
-.card {
-  background: transparent;
-  border: 1px solid transparent;
-  border-radius: var(--r);
-  padding: 8px 10px;
-  cursor: pointer;
-  transition: background .1s, border-color .1s;
-}
-.card:hover {
-  background: var(--bg2);
-  border-color: var(--border);
-}
-.card-row1 {
-  display: flex;
-  align-items: flex-start;
-  gap: 7px;
-  margin-bottom: 5px;
-}
-.priority-dot {
-  width: 8px; height: 8px;
-  border-radius: 2px;
-  flex-shrink: 0;
-  margin-top: 4px;
-}
-.p0 { background: var(--red); }
-.p1 { background: var(--yellow); }
-.p2 { background: var(--accent); }
-.p3 { background: var(--bg4); border: 1px solid var(--border-strong); }
-
-.card-title {
-  font-size: 13px;
-  font-weight: 400;
-  color: var(--text);
-  line-height: 1.45;
-  word-break: break-word;
-  flex: 1;
-}
-.card-footer {
-  display: flex;
-  align-items: center;
-  gap: 5px;
-  flex-wrap: wrap;
-  padding-left: 15px;
-}
-.chip {
-  font-size: 11px;
-  font-family: var(--mono);
-  color: var(--text2);
-  background: var(--bg3);
-  border-radius: var(--r-sm);
-  padding: 1px 5px;
-  line-height: 16px;
-  white-space: nowrap;
-}
-.chip-agent { color: var(--text3); }
-.chip-gate  { color: #c4b5fd; background: var(--purple-bg); }
-.chip-label { color: var(--text2); }
-.card-time  { margin-left: auto; font-size: 10px; font-family: var(--mono); color: var(--text2); }
-
-/* ── Dashboard ──────────────────────────────────────────────────────────────── */
-.dash-inner { padding: 20px 20px; max-width: 1100px; }
-.dash-grid {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 8px;
-  margin-bottom: 28px;
-}
-@media (max-width: 600px) {
-  .dash-grid { grid-template-columns: repeat(2, 1fr); }
-}
-.stat-card {
-  background: var(--bg1);
-  border: 1px solid var(--border);
-  border-radius: var(--r);
-  padding: 14px 16px;
-  position: relative;
-  overflow: hidden;
-}
-.stat-card::before {
-  content: '';
-  position: absolute;
-  top: 0; left: 0; right: 0;
-  height: 2px;
-  background: var(--stat-color, var(--accent));
-  border-radius: var(--r) var(--r) 0 0;
-}
-.stat-value {
-  font-size: 26px;
-  font-weight: 600;
-  font-family: var(--mono);
-  color: var(--stat-color, var(--text));
-  line-height: 1.2;
-  margin-bottom: 3px;
-  letter-spacing: -.02em;
-}
-.stat-label { font-size: 12px; color: var(--text3); font-weight: 500; margin-bottom: 2px; }
-.stat-sub   { font-size: 11px; color: var(--text2); font-family: var(--mono); line-height: 1.7; }
-.stat-cost  { display: inline-flex; align-items: center; gap: 4px; margin-top: 4px;
-              font-size: 10px; font-family: var(--mono); color: var(--text2);
-              background: var(--bg3); border-radius: 3px; padding: 1px 6px; }
-
-.section-hd {
-  font-size: 11px;
-  font-weight: 600;
-  color: var(--text2);
-  text-transform: uppercase;
-  letter-spacing: .07em;
-  margin-bottom: 10px;
-  margin-top: 20px;
-  padding-top: 16px;
-  border-top: 1px solid var(--border);
-}
-.section-hd:first-of-type { margin-top: 0; padding-top: 0; border-top: none; }
-
-/* Agent bars */
-.agent-list { display: flex; flex-direction: column; gap: 5px; margin-bottom: 4px; }
-.agent-row  { display: flex; align-items: center; gap: 10px; height: 24px; }
-.agent-name {
-  font-size: 12px; font-family: var(--mono);
-  color: var(--text3); width: 150px; flex-shrink: 0;
-  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
-}
-.bar-wrap { flex: 1; background: var(--bg3); border-radius: 2px; height: 4px; overflow: hidden; }
-.bar { height: 100%; background: var(--accent); border-radius: 2px; transition: width .4s ease; }
-.agent-n { font-family: var(--mono); font-size: 11px; color: var(--text2); width: 28px; text-align: right; }
-
-/* Timeline */
-.timeline { display: flex; flex-direction: column; }
-.tl-row {
-  display: flex; align-items: baseline; gap: 10px;
-  padding: 6px 0;
-  border-bottom: 1px solid var(--border);
-  font-size: 12px;
-}
-.tl-row:last-child { border-bottom: none; }
-.tl-status {
-  width: 6px; height: 6px;
-  border-radius: 50%;
-  flex-shrink: 0;
-  margin-top: 3px;
-}
-.tl-ok   { background: var(--green); }
-.tl-fail { background: var(--red); }
-.tl-def  { background: var(--bg4); border: 1px solid var(--border-strong); }
-.tl-agent { font-family: var(--mono); font-size: 11px; color: var(--text3); width: 130px; flex-shrink: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.tl-text  { color: var(--text2); flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.tl-time  { font-family: var(--mono); font-size: 10px; color: var(--text2); white-space: nowrap; flex-shrink: 0; }
-
-/* ── Share ──────────────────────────────────────────────────────────────────── */
-.share-inner { padding: 20px; display: flex; flex-direction: column; gap: 12px; max-width: 520px; }
-.share-card {
-  background: var(--bg1);
-  border: 1px solid var(--border);
-  border-radius: var(--r);
-  padding: 20px;
-}
-.share-title { font-size: 14px; font-weight: 600; margin-bottom: 4px; }
-.share-desc  { font-size: 12px; color: var(--text2); line-height: 1.6; margin-bottom: 16px; }
-.toggle-row  { display: flex; align-items: center; justify-content: space-between; margin-bottom: 16px; }
-.toggle-label-wrap .tl-main { font-size: 13px; font-weight: 500; }
-.toggle-label-wrap .tl-sub  { font-size: 12px; color: var(--text2); margin-top: 1px; }
-
-/* Toggle switch */
-.toggle { position: relative; width: 38px; height: 22px; cursor: pointer; flex-shrink: 0; }
-.toggle input { opacity: 0; width: 0; height: 0; }
-.toggle-track {
-  position: absolute; inset: 0;
-  background: var(--bg3);
-  border: 1px solid var(--border-strong);
-  border-radius: 11px;
-  transition: background .2s, border-color .2s;
-}
-.toggle-track::before {
-  content: '';
-  position: absolute;
-  width: 16px; height: 16px;
-  left: 2px; top: 2px;
-  background: var(--text2);
-  border-radius: 50%;
-  transition: transform .2s, background .2s;
-}
-.toggle input:checked + .toggle-track {
-  background: var(--accent);
-  border-color: var(--accent);
-}
-.toggle input:checked + .toggle-track::before {
-  transform: translateX(16px);
   background: #fff;
 }
+button { font-family: inherit; cursor: pointer; }
 
-.url-block  { background: var(--bg2); border: 1px solid var(--border); border-radius: var(--r); padding: 10px 12px; display: flex; align-items: center; gap: 8px; }
-.url-text   { flex: 1; font-family: var(--mono); font-size: 12px; color: var(--text3); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.icon-btn {
-  padding: 5px 10px;
-  background: var(--bg3);
-  border: 1px solid var(--border);
-  border-radius: var(--r-sm);
-  color: var(--text3);
-  font-size: 12px;
-  cursor: pointer;
-  white-space: nowrap;
-  transition: border-color .12s, color .12s;
-  font-family: var(--font);
+.board {
+  position: relative;
+  width: 100%;
+  height: 100vh;
+  overflow: hidden;
+  display: flex;
+  background: #ffffff;
 }
-.icon-btn:hover { border-color: var(--border-strong); color: var(--text); }
+.board-bg {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  opacity: 0.28;
+  pointer-events: none;
+}
+.board-bg svg { width: 100%; height: 100%; display: block; }
 
-.share-meta { font-size: 11px; color: var(--text2); line-height: 1.7; font-family: var(--mono); }
-.share-meta strong { color: var(--text3); }
+/* ── Sidebar ──────────────────────────────────────────────────────────────── */
+.sidebar {
+  position: relative; z-index: 1;
+  width: 240px; flex-shrink: 0;
+  background: var(--bg-panel);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  border-right: 1px solid var(--border);
+  display: flex; flex-direction: column;
+}
+.proj-switch {
+  display: flex; align-items: center; gap: 8px;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--border);
+  cursor: pointer;
+}
+.proj-switch:hover { background: var(--bg-muted); }
+.proj-switch .star { color: var(--accent); font-size: 16px; }
+.proj-switch .name { font-weight: 600; font-size: 14px; flex: 1; }
+.proj-switch .chev { color: var(--text3); font-size: 11px; }
+
+.nav { padding: 12px 8px; flex: 1; }
+.nav-item {
+  display: flex; align-items: center; gap: 10px;
+  height: 32px; padding: 0 10px;
+  border-radius: 6px;
+  font-size: 13px;
+  color: var(--text);
+  cursor: pointer;
+  position: relative;
+  user-select: none;
+}
+.nav-item:hover { background: var(--bg-muted); }
+.nav-item.active { background: var(--bg-strong); font-weight: 500; }
+.nav-item.active::before {
+  content: "";
+  position: absolute;
+  left: -8px; top: 6px; bottom: 6px;
+  width: 3px;
+  background: var(--accent);
+  border-radius: 0 2px 2px 0;
+}
+.nav-item .icon { width: 16px; height: 16px; color: var(--text2); flex-shrink: 0; }
+.nav-item.active .icon { color: var(--accent); }
+.nav-item .count { margin-left: auto; font-size: 11px; color: var(--text3); font-family: var(--mono); }
+.nav-divider { height: 1px; background: var(--border); margin: 12px 8px; }
+
+.sidebar-footer {
+  padding: 12px 16px;
+  border-top: 1px solid var(--border);
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--text3);
+  letter-spacing: 0.04em;
+  display: flex; align-items: center; gap: 6px;
+}
+.live-dot { width: 6px; height: 6px; border-radius: 50%; background: var(--status-review); }
+.live-dot.error { background: var(--status-blocked); }
+.live-dot.pulse { animation: pulse 2s infinite; }
+@keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.4; } }
+
+/* ── Workspace ────────────────────────────────────────────────────────────── */
+.workspace { flex: 1; min-width: 0; display: flex; flex-direction: column; position: relative; z-index: 1; }
+.topbar {
+  height: 48px;
+  background: var(--bg-panel);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  border-bottom: 1px solid var(--border);
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 0 20px;
+  font-size: 13px;
+}
+.crumbs { display: flex; align-items: center; gap: 8px; color: var(--text2); }
+.crumbs .star { color: var(--accent); }
+.crumbs .sep { color: var(--text3); }
+.crumbs .here { color: var(--text); font-weight: 500; }
+
+.topbar-actions { display: flex; align-items: center; gap: 6px; }
+.tab-row { display: flex; align-items: center; gap: 4px; margin-right: 12px; }
+.tab-btn {
+  background: transparent; border: none;
+  padding: 6px 12px; border-radius: 6px;
+  font-size: 13px; color: var(--text2);
+}
+.tab-btn:hover { background: var(--bg-muted); color: var(--text); }
+.tab-btn.active { background: var(--bg-strong); color: var(--text); font-weight: 500; }
+
+.icon-btn {
+  background: transparent; border: 1px solid transparent;
+  width: 30px; height: 30px;
+  border-radius: 6px;
+  display: inline-flex; align-items: center; justify-content: center;
+  color: var(--text2);
+}
+.icon-btn:hover { background: var(--bg-muted); color: var(--text); }
+
+.btn-new {
+  background: #0f1115; color: #fff; border: none;
+  height: 30px; padding: 0 14px;
+  border-radius: 999px;
+  font-size: 13px; font-weight: 500;
+  display: inline-flex; align-items: center; gap: 6px;
+}
+.btn-new:hover { background: #2a2d33; }
+
+.task-count {
+  font-family: var(--mono); font-size: 11px;
+  color: var(--text3); letter-spacing: 0.04em;
+  margin-right: 6px;
+}
+
+/* ── Panels ───────────────────────────────────────────────────────────────── */
+.panel { flex: 1; overflow: auto; display: none; }
+.panel.active { display: flex; flex-direction: column; }
+
+/* ── Kanban ───────────────────────────────────────────────────────────────── */
+.kanban {
+  flex: 1; overflow: auto;
+  padding: 16px 20px 20px;
+  display: flex; gap: 12px;
+  align-items: flex-start;
+}
+.column {
+  flex: 0 0 264px;
+  background: rgba(255, 255, 255, 0.7);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 10px;
+  display: flex; flex-direction: column; gap: 8px;
+  max-height: 100%;
+}
+.col-head {
+  display: flex; align-items: center; gap: 8px;
+  padding: 4px 6px 8px;
+  font-size: 13px; font-weight: 600;
+}
+.col-dot {
+  width: 10px; height: 10px; border-radius: 50%;
+  border: 2px solid currentColor;
+  background: transparent;
+}
+.col-dot.filled { background: currentColor; }
+.col-dot.half { background: conic-gradient(currentColor 50%, transparent 50%); }
+.col-count {
+  font-family: var(--mono); font-size: 11px;
+  color: var(--text3); margin-left: 2px; font-weight: 500;
+}
+.col-title { color: var(--text); }
+.col-actions { margin-left: auto; display: flex; gap: 2px; color: var(--text3); }
+.col-actions .icon-btn { width: 22px; height: 22px; }
+.col-body { display: flex; flex-direction: column; gap: 6px; }
+
+.card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 12px 14px;
+  cursor: pointer;
+  transition: box-shadow 0.15s, transform 0.15s;
+}
+.card:hover { box-shadow: var(--shadow-card-hover); transform: translateY(-1px); }
+.card.selected { border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-soft); }
+.card .id {
+  font-family: var(--mono); font-size: 11px;
+  letter-spacing: 0.04em; color: var(--text3);
+}
+.card .title {
+  font-weight: 600; font-size: 14px;
+  line-height: 1.35; margin-top: 4px;
+  color: var(--text);
+}
+.card-footer {
+  display: flex; align-items: center; gap: 6px;
+  margin-top: 10px; flex-wrap: wrap;
+}
+.card-time {
+  margin-left: auto;
+  font-family: var(--mono); font-size: 11px;
+  color: var(--text3);
+}
+
+.chip {
+  display: inline-flex; align-items: center; gap: 4px;
+  height: 20px; padding: 0 8px;
+  border-radius: 999px;
+  font-size: 11px; font-weight: 500;
+  background: var(--bg-strong); color: var(--text2);
+}
+.chip-p0 { background: var(--p0-bg); color: var(--p0-fg); }
+.chip-p1 { background: var(--p1-bg); color: var(--p1-fg); }
+.chip-p2 { background: var(--p2-bg); color: var(--p2-fg); }
+.chip-p3 { background: var(--p3-bg); color: var(--p3-fg); }
+.chip-gate { background: rgba(124, 58, 237, 0.12); color: var(--status-gate); }
+.chip-agent {
+  background: var(--accent-soft); color: var(--accent);
+  font-family: var(--mono);
+}
+
+.priority-dot {
+  width: 8px; height: 8px; border-radius: 50%;
+  flex-shrink: 0;
+}
+.priority-dot.p0 { background: var(--p0-fg); }
+.priority-dot.p1 { background: var(--p1-fg); }
+.priority-dot.p2 { background: var(--p2-fg); }
+.priority-dot.p3 { background: var(--p3-fg); }
+
+.card-row1 { display: flex; align-items: center; gap: 8px; }
+
+.empty {
+  padding: 20px 8px;
+  font-size: 12px;
+  color: var(--text3);
+  text-align: center;
+}
+
+/* ── Side panel ───────────────────────────────────────────────────────────── */
+.side {
+  position: absolute;
+  top: 0; right: 0; bottom: 0;
+  width: 480px;
+  background: #fff;
+  border-left: 1px solid var(--border);
+  box-shadow: -12px 0 32px rgba(15, 17, 21, 0.08);
+  z-index: 10;
+  display: flex; flex-direction: column;
+  transform: translateX(100%);
+  transition: transform 0.2s ease;
+}
+.side.open { transform: translateX(0); }
+.side-top {
+  display: flex; align-items: center; gap: 10px;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--border);
+}
+.side-id {
+  font-family: var(--mono); font-size: 11px; font-weight: 500;
+  background: var(--bg-strong); color: var(--text);
+  padding: 4px 8px; border-radius: 4px;
+  letter-spacing: 0.04em;
+}
+.side-close {
+  margin-left: auto; cursor: pointer;
+  width: 28px; height: 28px;
+  display: flex; align-items: center; justify-content: center;
+  border-radius: 6px;
+  color: var(--text3);
+}
+.side-close:hover { background: var(--bg-muted); color: var(--text); }
+.side-body { flex: 1; overflow: auto; padding: 18px; }
+.side-title {
+  font-weight: 600; font-size: 18px;
+  letter-spacing: -0.01em; margin-bottom: 14px;
+}
+.props {
+  display: grid;
+  grid-template-columns: 110px 1fr;
+  gap: 6px 12px;
+  border-top: 1px solid var(--border);
+  padding-top: 14px;
+}
+.prop-key { color: var(--text3); font-size: 12px; padding: 6px 0; font-family: var(--mono); letter-spacing: 0.04em; }
+.prop-val { font-size: 13px; padding: 6px 0; }
+.pill {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 4px 10px; border-radius: 999px;
+  font-size: 12px; font-weight: 500;
+  background: var(--bg-strong); color: var(--text2);
+}
+.pill-gate        { background: rgba(124, 58, 237, 0.12); color: var(--status-gate); }
+.pill-backlog     { background: rgba(148, 163, 184, 0.18); color: var(--status-todo); }
+.pill-in_progress { background: rgba(245, 158, 11, 0.16);  color: var(--status-progress); }
+.pill-done        { background: rgba(37, 99, 235, 0.14);   color: var(--status-done); }
+.pill-blocked     { background: rgba(220, 38, 38, 0.12);   color: var(--status-blocked); }
+.result-box {
+  margin-top: 14px;
+  background: var(--bg-muted);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 12px 14px;
+  font-size: 13px;
+  color: var(--text2);
+  white-space: pre-wrap;
+  line-height: 1.55;
+}
+
+/* ── Metrics page ─────────────────────────────────────────────────────────── */
+.metrics-page { padding: 24px 32px; }
+.mp-section-label {
+  font-family: var(--mono); font-size: 11px;
+  letter-spacing: 0.1em; text-transform: uppercase;
+  color: var(--text3); margin: 0 0 12px;
+}
+.mp-hero {
+  display: grid; grid-template-columns: repeat(3, 1fr);
+  gap: 14px; margin-bottom: 24px;
+}
+.metric-card {
+  background: #fff; border: 1px solid var(--border);
+  border-radius: 12px; padding: 26px 24px;
+  position: relative; overflow: hidden;
+}
+.metric-card::before {
+  content: ""; position: absolute;
+  top: 0; left: 0; right: 0; height: 3px;
+  background: var(--accent);
+}
+.metric-card.green::before { background: var(--status-review); }
+.metric-card.amber::before { background: var(--status-progress); }
+.metric-card.red::before   { background: var(--status-blocked); }
+.metric-card.purple::before { background: #7c3aed; }
+.metric-num {
+  font-family: var(--serif); font-weight: 500;
+  font-size: 52px; line-height: 1;
+  letter-spacing: -0.02em;
+}
+.metric-num small {
+  font-size: 22px; color: var(--text2);
+  margin-left: 4px; font-weight: 400;
+}
+.metric-label {
+  font-family: var(--mono); font-size: 11px;
+  letter-spacing: 0.08em; text-transform: uppercase;
+  color: var(--text2); margin-top: 14px;
+}
+.metric-trend {
+  margin-top: 6px; font-size: 12px; color: var(--text2);
+}
+
+.mp-secondary {
+  display: grid; grid-template-columns: repeat(4, 1fr);
+  gap: 12px; margin-bottom: 28px;
+}
+.mp-secondary .metric-card { padding: 18px; }
+.mp-secondary .metric-num { font-size: 30px; }
+
+.mp-row {
+  display: grid; grid-template-columns: 1fr 1fr; gap: 16px;
+}
+.mp-card {
+  background: #fff; border: 1px solid var(--border);
+  border-radius: 12px; padding: 22px;
+}
+.mp-card h3 {
+  font-family: var(--sans); font-weight: 600;
+  font-size: 15px; margin: 0 0 16px;
+}
+
+.bar-row {
+  display: grid; grid-template-columns: 130px 1fr 50px;
+  align-items: center; gap: 12px;
+  margin-bottom: 10px; font-size: 12.5px;
+}
+.bar-row .name { font-family: var(--mono); color: var(--text); }
+.bar-row .rail {
+  height: 6px; background: var(--bg-strong);
+  border-radius: 999px; overflow: hidden;
+}
+.bar-row .fill {
+  height: 100%; background: var(--accent);
+  border-radius: 999px;
+}
+.bar-row .pct {
+  text-align: right; color: var(--text2);
+  font-family: var(--mono); font-size: 11px;
+}
+
+.feed-row {
+  display: grid;
+  grid-template-columns: 12px 110px 1fr auto;
+  gap: 12px; align-items: baseline;
+  padding: 10px 0;
+  border-top: 1px solid var(--border);
+  font-size: 13px;
+}
+.feed-row:first-child { border-top: none; }
+.feed-dot {
+  width: 8px; height: 8px;
+  border-radius: 50%; margin-top: 4px;
+}
+.feed-dot.ok { background: var(--status-review); }
+.feed-dot.fail { background: var(--status-blocked); }
+.feed-dot.def { background: var(--text3); }
+.feed-row .agent { font-family: var(--mono); color: var(--text2); font-size: 12px; }
+.feed-row .msg { color: var(--text); }
+.feed-row .time { font-family: var(--mono); font-size: 11px; color: var(--text3); }
+
+/* ── Share page ───────────────────────────────────────────────────────────── */
+.share-page {
+  padding: 32px;
+  display: flex; flex-direction: column;
+  align-items: center;
+}
+.share-card {
+  width: 100%; max-width: 640px;
+  background: #fff;
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 32px;
+}
+.share-card h2 {
+  font-family: var(--serif); font-weight: 500;
+  font-size: 28px; letter-spacing: -0.01em;
+  margin: 0 0 6px;
+}
+.share-card .sub { color: var(--text2); margin: 0 0 24px; }
+.share-toggle-row {
+  display: flex; align-items: center; gap: 12px;
+  padding: 16px 18px;
+  background: var(--bg-muted);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  margin-bottom: 16px;
+}
+.share-toggle-row .label-grp { flex: 1; }
+.share-toggle-row .label-grp .l { font-weight: 600; font-size: 14px; }
+.share-toggle-row .label-grp .h { color: var(--text2); font-size: 12px; }
+
+.toggle {
+  width: 38px; height: 22px;
+  background: #cfd5dd;
+  border-radius: 999px;
+  position: relative; cursor: pointer;
+  transition: background 0.15s;
+  flex-shrink: 0;
+}
+.toggle::after {
+  content: "";
+  position: absolute; top: 2px; left: 2px;
+  width: 18px; height: 18px;
+  background: #fff;
+  border-radius: 50%;
+  transition: transform 0.15s;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.15);
+}
+.toggle.on { background: var(--accent); }
+.toggle.on::after { transform: translateX(16px); }
+.toggle input { display: none; }
+
+.url-block {
+  display: flex; align-items: center; gap: 8px;
+  padding: 10px 12px;
+  background: #fff;
+  border: 1px solid var(--border-strong);
+  border-radius: 10px;
+  margin-top: 16px;
+}
+.url-block .url-text {
+  flex: 1; font-family: var(--mono);
+  font-size: 12.5px; color: var(--text);
+  white-space: nowrap; overflow: hidden;
+  text-overflow: ellipsis;
+}
+.btn-black {
+  background: #0f1115; color: #fff; border: none;
+  padding: 8px 14px; border-radius: 999px;
+  font-size: 12px; font-weight: 500;
+}
+.btn-ghost-sm {
+  background: transparent;
+  border: 1px solid var(--border-strong);
+  color: var(--text);
+  padding: 8px 12px; border-radius: 999px;
+  font-size: 12px;
+}
+.share-note {
+  font-size: 13px; color: var(--text2);
+  margin-top: 16px; line-height: 1.55;
+}
+.share-note strong { color: var(--text); }
 
 .loader {
-  display: flex; align-items: center; gap: 8px;
-  font-size: 12px; color: var(--text2);
-  padding: 8px 0;
+  display: flex; align-items: center; gap: 10px;
+  padding: 12px 16px;
+  background: var(--bg-muted);
+  border-radius: 10px;
+  font-size: 13px; color: var(--text2);
+  margin-top: 12px;
 }
 .spinner {
-  width: 13px; height: 13px;
-  border: 2px solid var(--bg4);
+  width: 14px; height: 14px;
+  border: 2px solid var(--border-strong);
   border-top-color: var(--accent);
   border-radius: 50%;
-  animation: spin .7s linear infinite;
-  flex-shrink: 0;
+  animation: spin 0.8s linear infinite;
 }
 @keyframes spin { to { transform: rotate(360deg); } }
 
 .share-badge {
-  display: inline-flex; align-items: center; gap: 5px;
-  font-size: 11px; font-family: var(--mono);
-  padding: 3px 8px;
-  border-radius: 10px;
-}
-.share-badge.on  { background: var(--green-bg); color: #4ade80; }
-.share-badge.off { background: var(--bg3); color: var(--text2); }
-.share-badge-dot { width: 5px; height: 5px; border-radius: 50%; background: currentColor; }
-
-/* ── Side panel ─────────────────────────────────────────────────────────────── */
-.side {
-  position: fixed; top: 0; right: -480px;
-  width: 480px; height: 100vh;
-  background: var(--bg1);
-  border-left: 1px solid var(--border-strong);
-  transition: right .22s cubic-bezier(.4,0,.2,1);
-  z-index: 300;
-  display: flex; flex-direction: column;
-}
-.side.open { right: 0; }
-.side-top {
-  padding: 0 16px;
-  height: 44px;
-  display: flex; align-items: center; justify-content: space-between;
-  border-bottom: 1px solid var(--border);
-  flex-shrink: 0;
-}
-.side-id {
-  font-family: var(--mono); font-size: 11px;
-  color: var(--text2);
-  background: var(--bg3);
-  border: 1px solid var(--border);
-  border-radius: var(--r-sm);
-  padding: 2px 6px;
-}
-.side-close {
-  width: 24px; height: 24px;
-  border-radius: var(--r-sm);
-  display: flex; align-items: center; justify-content: center;
-  color: var(--text2); cursor: pointer; font-size: 14px;
-  transition: background .1s, color .1s;
-}
-.side-close:hover { background: var(--bg3); color: var(--text); }
-.side-body { flex: 1; overflow-y: auto; padding: 20px 20px; }
-.side-title { font-size: 15px; font-weight: 600; line-height: 1.4; margin-bottom: 20px; color: var(--text); }
-
-/* Properties grid */
-.props { display: grid; grid-template-columns: 110px 1fr; row-gap: 0; }
-.prop-key {
-  font-size: 12px; color: var(--text2);
-  padding: 7px 0 7px 0;
-  border-bottom: 1px solid var(--border);
-  display: flex; align-items: center;
-}
-.prop-val {
-  font-size: 12px; color: var(--text3);
-  padding: 7px 0 7px 8px;
-  border-bottom: 1px solid var(--border);
-  display: flex; align-items: center; gap: 5px;
-  word-break: break-word;
-}
-.prop-key:last-of-type,
-.prop-val:last-of-type { border-bottom: none; }
-
-.pill {
   display: inline-flex; align-items: center; gap: 4px;
-  font-size: 11px;
-  padding: 2px 7px;
-  border-radius: 10px;
+  font-size: 10px;
+  padding: 2px 6px; border-radius: 999px;
   font-family: var(--mono);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
 }
-.pill-gate     { background: var(--purple-bg); color: #c4b5fd; }
-.pill-backlog  { background: var(--bg3); color: var(--text2); border: 1px solid var(--border); }
-.pill-in_progress { background: rgba(94,106,210,.15); color: #818cf8; }
-.pill-done     { background: var(--green-bg); color: #4ade80; }
-.pill-blocked  { background: var(--red-bg); color: #f87171; }
-
-.result-box {
-  margin-top: 16px;
-  background: var(--bg0);
-  border: 1px solid var(--border);
-  border-radius: var(--r);
-  padding: 12px;
-  font-size: 12px; font-family: var(--mono);
-  color: var(--text3); line-height: 1.6;
-  white-space: pre-wrap; word-break: break-word;
-  max-height: 300px; overflow-y: auto;
+.share-badge.on  { background: rgba(22, 163, 74, 0.12); color: var(--status-review); }
+.share-badge.off { background: var(--bg-strong); color: var(--text3); }
+.share-badge-dot {
+  width: 5px; height: 5px; border-radius: 50%;
+  background: currentColor;
 }
 
-/* ── Empty state ────────────────────────────────────────────────────────────── */
-.empty { padding: 48px 20px; text-align: center; color: var(--text2); font-size: 12px; }
-
-/* ── Scrollbar ──────────────────────────────────────────────────────────────── */
-::-webkit-scrollbar { width: 5px; height: 5px; }
-::-webkit-scrollbar-track { background: transparent; }
-::-webkit-scrollbar-thumb { background: var(--bg4); border-radius: 3px; }
-::-webkit-scrollbar-thumb:hover { background: var(--border-strong); }
+/* ── Scrollbar ────────────────────────────────────────────────────────────── */
+::-webkit-scrollbar { width: 10px; height: 10px; }
+::-webkit-scrollbar-thumb { background: rgba(15, 17, 21, 0.12); border-radius: 999px; border: 2px solid transparent; background-clip: content-box; }
+::-webkit-scrollbar-thumb:hover { background: rgba(15, 17, 21, 0.22); border: 2px solid transparent; background-clip: content-box; }
 </style>
 </head>
 <body>
-<div class="app">
-
-<!-- Topbar -->
-<header class="topbar">
-  <div class="breadcrumb">
-    <div class="breadcrumb-icon" id="bc-icon">G</div>
-    <span class="breadcrumb-sep">/</span>
-    <span class="breadcrumb-project" id="project-name">—</span>
+<div class="board">
+  <!-- Background landscape -->
+  <div class="board-bg">
+    <svg viewBox="0 0 1600 900" preserveAspectRatio="xMidYMid slice" xmlns="http://www.w3.org/2000/svg">
+      <defs>
+        <linearGradient id="b-sky" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stop-color="#1a2547" />
+          <stop offset="55%" stop-color="#5a4a7a" />
+          <stop offset="85%" stop-color="#f4a87c" />
+          <stop offset="100%" stop-color="#ffd9b8" />
+        </linearGradient>
+        <radialGradient id="b-sun" cx="0.5" cy="0.5" r="0.5">
+          <stop offset="0%" stop-color="#fff4d9" stop-opacity="1" />
+          <stop offset="40%" stop-color="#fff4d9" stop-opacity="0.9" />
+          <stop offset="100%" stop-color="#ffc89b" stop-opacity="0" />
+        </radialGradient>
+        <radialGradient id="b-sunhalo" cx="0.5" cy="0.5" r="0.5">
+          <stop offset="0%" stop-color="#ffc89b" stop-opacity="0.5" />
+          <stop offset="100%" stop-color="#ffc89b" stop-opacity="0" />
+        </radialGradient>
+        <linearGradient id="b-mtnFar" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stop-color="#b8c2d8" />
+          <stop offset="20%" stop-color="#3d4a6b" />
+          <stop offset="100%" stop-color="#3d4a6b" />
+        </linearGradient>
+        <linearGradient id="b-mist" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stop-color="rgba(255,220,200,0)" />
+          <stop offset="100%" stop-color="rgba(255,220,200,0.6)" />
+        </linearGradient>
+        <filter id="b-blur"><feGaussianBlur stdDeviation="8" /></filter>
+      </defs>
+      <rect width="1600" height="900" fill="url(#b-sky)" />
+      <circle cx="1100" cy="540" r="260" fill="url(#b-sunhalo)" />
+      <circle cx="1100" cy="540" r="80" fill="url(#b-sun)" />
+      <g filter="url(#b-blur)" opacity="0.85">
+        <ellipse cx="200" cy="280" rx="180" ry="22" fill="#ffc4a8" />
+        <ellipse cx="600" cy="220" rx="240" ry="18" fill="#f5a890" />
+        <ellipse cx="1280" cy="320" rx="220" ry="24" fill="#ffc4a8" />
+        <ellipse cx="900" cy="380" rx="160" ry="14" fill="#e8b4c4" />
+      </g>
+      <path d="M 0,640 L 80,580 L 140,610 L 220,520 L 300,560 L 380,500 L 460,540 L 540,470 L 620,510 L 700,460 L 780,500 L 860,440 L 940,490 L 1020,450 L 1100,500 L 1180,470 L 1260,520 L 1340,490 L 1420,540 L 1500,510 L 1600,560 L 1600,900 L 0,900 Z" fill="url(#b-mtnFar)" opacity="0.92" />
+      <path d="M 0,720 L 100,680 L 200,700 L 320,640 L 440,680 L 560,620 L 680,670 L 800,610 L 920,660 L 1040,620 L 1160,680 L 1280,640 L 1400,690 L 1520,650 L 1600,700 L 1600,900 L 0,900 Z" fill="#2c3554" opacity="0.95" />
+      <rect x="0" y="700" width="1600" height="80" fill="url(#b-mist)" opacity="0.5" />
+      <path d="M 0,820 L 120,790 L 280,810 L 420,780 L 560,815 L 720,790 L 880,820 L 1040,795 L 1200,815 L 1360,790 L 1520,820 L 1600,800 L 1600,900 L 0,900 Z" fill="#1a2138" />
+    </svg>
   </div>
 
-  <div class="tabs">
-    <div class="tab active" data-tab="kanban" onclick="switchTab('kanban',this)">
-      <svg width="13" height="13" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><rect x="3" y="3" width="5" height="18" rx="1"/><rect x="10" y="3" width="5" height="12" rx="1"/><rect x="17" y="3" width="5" height="15" rx="1"/></svg>
-      Board
+  <!-- Sidebar -->
+  <aside class="sidebar">
+    <div class="proj-switch">
+      <span class="star">✱</span>
+      <span class="name" id="project-name">—</span>
+      <svg class="chev" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg>
     </div>
-    <div class="tab" data-tab="dashboard" onclick="switchTab('dashboard',this)">
-      <svg width="13" height="13" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/></svg>
-      Metrics
+    <nav class="nav">
+      <div class="nav-item active" data-tab="kanban" onclick="switchTab('kanban', this)">
+        <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M9 11l3 3L22 4 M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/></svg>
+        <span>Tasks</span>
+        <span class="count" id="nav-task-count">0</span>
+      </div>
+      <div class="nav-item" data-tab="dashboard" onclick="switchTab('dashboard', this)">
+        <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M3 3v18h18 M7 14l3-3 4 4 5-5"/></svg>
+        <span>Metrics</span>
+      </div>
+      <div class="nav-item" data-tab="share" onclick="switchTab('share', this)">
+        <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z M14 2v6h6 M16 13H8 M16 17H8"/></svg>
+        <span>Share</span>
+        <span id="share-nav-badge" class="share-badge off" style="margin-left:auto;">
+          <span class="share-badge-dot"></span>off
+        </span>
+      </div>
+      <div class="nav-divider"></div>
+      <div class="nav-item">
+        <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2 M22 21v-2a4 4 0 0 0-3-3.87 M16 3.13a4 4 0 0 1 0 7.75 M9 11a4 4 0 1 0 0-8 4 4 0 0 0 0 8z"/></svg>
+        <span>Agents</span>
+        <span class="count" id="nav-agent-count">0</span>
+      </div>
+    </nav>
+    <div class="sidebar-footer">
+      <span class="live-dot pulse" id="live-dot"></span>
+      <span id="live-label">live · synced just now</span>
     </div>
-    <div class="tab" data-tab="share" onclick="switchTab('share',this)">
-      <svg width="13" height="13" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/><line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/></svg>
-      Share
-      <span id="share-nav-badge" class="share-badge off" style="margin-left:2px;">
-        <span class="share-badge-dot"></span>off
-      </span>
-    </div>
-  </div>
+  </aside>
 
-  <div class="topbar-right">
-    <div class="live-indicator">
-      <div class="live-dot pulse" id="live-dot"></div>
-      <span id="live-label" style="font-size:11px;">live</span>
+  <!-- Workspace -->
+  <div class="workspace">
+    <div class="topbar">
+      <div class="crumbs">
+        <span class="star">✱</span>
+        <span id="crumb-project">—</span>
+        <span class="sep">/</span>
+        <span class="here" id="crumb-here">Board</span>
+      </div>
+      <div class="topbar-actions">
+        <div class="tab-row">
+          <button class="tab-btn active" data-tab="kanban" onclick="switchTab('kanban', this)">Board</button>
+          <button class="tab-btn" data-tab="dashboard" onclick="switchTab('dashboard', this)">Metrics</button>
+          <button class="tab-btn" data-tab="share" onclick="switchTab('share', this)">Share</button>
+        </div>
+        <span class="task-count" id="topbar-task-count">0 ISSUES</span>
+        <button class="btn-new">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 5v14 M5 12h14"/></svg>
+          New issue
+        </button>
+      </div>
     </div>
-  </div>
-</header>
 
-<!-- Content -->
-<div class="content">
-
-  <!-- Board -->
-  <div class="panel active" id="panel-kanban">
-    <div class="kanban-wrap">
+    <!-- Kanban -->
+    <div class="panel active" id="panel-kanban">
       <div class="kanban" id="kanban-board"></div>
     </div>
-  </div>
 
-  <!-- Metrics -->
-  <div class="panel" id="panel-dashboard">
-    <div class="dash-inner">
-      <div class="dash-grid" id="stats-grid"></div>
-      <div class="section-hd">Agent utilization</div>
-      <div class="agent-list" id="agent-list"></div>
-      <div class="section-hd">Activity feed</div>
-      <div class="timeline" id="timeline"></div>
-    </div>
-  </div>
-
-  <!-- Share -->
-  <div class="panel" id="panel-share">
-    <div class="share-inner">
-      <div class="share-card">
-        <div class="share-title">Public report</div>
-        <div class="share-desc">Generate a private URL for stakeholders — features shipped, cost savings, security posture, agent activity. No source code.</div>
-
-        <div class="toggle-row">
-          <div class="toggle-label-wrap">
-            <div class="tl-main">Enable shareable link</div>
-            <div class="tl-sub">Unguessable URL · valid 30 days</div>
+    <!-- Metrics -->
+    <div class="panel" id="panel-dashboard">
+      <div class="metrics-page">
+        <div class="mp-section-label">This sprint</div>
+        <div class="mp-hero" id="mp-hero"></div>
+        <div class="mp-secondary" id="mp-secondary"></div>
+        <div class="mp-row">
+          <div class="mp-card">
+            <h3>Agent utilization</h3>
+            <div id="agent-list"></div>
           </div>
-          <label class="toggle">
-            <input type="checkbox" id="share-toggle" onchange="onShareToggle(this.checked)">
-            <div class="toggle-track"></div>
-          </label>
-        </div>
-
-        <div id="share-loading" style="display:none;" class="loader">
-          <div class="spinner"></div> Publishing report…
-        </div>
-
-        <div id="share-url-section" style="display:none;">
-          <div class="url-block">
-            <div class="url-text" id="share-url-text">—</div>
-            <button class="icon-btn" onclick="copyUrl()">Copy</button>
-            <button class="icon-btn" onclick="openUrl()">Open ↗</button>
+          <div class="mp-card">
+            <h3>Activity</h3>
+            <div id="timeline"></div>
           </div>
-        </div>
-
-        <div class="share-meta" style="margin-top:16px;">
-          <strong>Toggle off</strong> → link shows "Report paused". Data preserved — re-enable to restore same URL.
         </div>
       </div>
     </div>
-  </div>
 
-</div><!-- /content -->
-</div><!-- /app -->
+    <!-- Share -->
+    <div class="panel" id="panel-share">
+      <div class="share-page">
+        <div class="share-card">
+          <h2>Share this project</h2>
+          <p class="sub">Generate a public, read-only report. Anyone with the link can see shipped work, metrics, and agent activity.</p>
+          <div class="share-toggle-row">
+            <div class="label-grp">
+              <div class="l">Public report</div>
+              <div class="h" id="share-help">Disabled. Only you can see this project.</div>
+            </div>
+            <div class="toggle" id="share-toggle-visual" onclick="toggleShare()">
+              <input type="checkbox" id="share-toggle">
+            </div>
+          </div>
+          <div id="share-loading" style="display:none;" class="loader">
+            <div class="spinner"></div> Publishing report…
+          </div>
+          <div id="share-url-section" style="display:none;">
+            <div class="url-block">
+              <div class="url-text" id="share-url-text">—</div>
+              <button class="btn-ghost-sm" onclick="openUrl()">Open ↗</button>
+              <button class="btn-black" onclick="copyUrl(event)">Copy</button>
+            </div>
+            <div class="share-note">
+              The report includes shipped tasks, recent activity, agent utilization, and the six headline metrics.
+              Open issues, code, and credentials are <strong>never</strong> exposed.
+            </div>
+          </div>
+          <div id="share-disabled-note" class="share-note">
+            When you turn this on, GreatCTO generates a static URL you can share with investors,
+            customers, or your board. Toggle it off any time to revoke access.
+          </div>
+        </div>
+      </div>
+    </div>
 
-<!-- Side panel -->
-<div class="side" id="side-panel">
-  <div class="side-top">
-    <span class="side-id" id="side-id">—</span>
-    <div class="side-close" onclick="closeSide()">✕</div>
+    <!-- Side panel -->
+    <div class="side" id="side-panel">
+      <div class="side-top">
+        <span class="side-id" id="side-id">—</span>
+        <div style="flex:1"></div>
+        <div class="side-close" onclick="closeSide()">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M18 6L6 18 M6 6l12 12"/></svg>
+        </div>
+      </div>
+      <div class="side-body" id="side-body"></div>
+    </div>
   </div>
-  <div class="side-body" id="side-body"></div>
 </div>
 
 <script>
-/* ── Config ─────────────────────────────────────────────────────────────────── */
 const COLUMNS = [
-  { id: 'gate',        label: 'Gates' },
-  { id: 'backlog',     label: 'Backlog' },
-  { id: 'in_progress', label: 'In Progress' },
-  { id: 'done',        label: 'Done' },
-  { id: 'blocked',     label: 'Blocked' },
+  { id: 'gate',        label: 'Gates',       color: '#7c3aed', dot: 'half' },
+  { id: 'backlog',     label: 'Backlog',     color: '#94a3b8', dot: 'ring' },
+  { id: 'in_progress', label: 'In Progress', color: '#f59e0b', dot: 'half' },
+  { id: 'done',        label: 'Done',        color: '#2563eb', dot: 'filled' },
+  { id: 'blocked',     label: 'Blocked',     color: '#dc2626', dot: 'filled' },
 ];
-const PRIORITY_LABEL = ['P0','P1','P2','P3'];
-const PRIORITY_TIP   = ['Critical','High','Medium','Low'];
+const PRIORITY_LABEL = ['Urgent','High','Medium','Low'];
 
-let allTasks  = [];
-let metrics   = {};
+let allTasks = [];
+let metrics = {};
 let shareState = { enabled: false, url: null };
+let currentTab = 'kanban';
 
-/* ── Bootstrap ──────────────────────────────────────────────────────────────── */
 async function init() {
   const [tasks, met, share] = await Promise.all([
     api('/api/tasks'),
     api('/api/metrics'),
     api('/api/share'),
   ]);
-  allTasks   = tasks  || [];
-  metrics    = met    || {};
-  shareState = share  || { enabled: false, url: null };
+  allTasks = tasks || [];
+  metrics = met || {};
+  shareState = share || { enabled: false, url: null };
 
-  const proj = (allTasks[0]?.id || '').split('-')[0] || null;
-  if (proj) {
-    document.getElementById('project-name').textContent = proj;
-    document.getElementById('bc-icon').textContent = proj[0].toUpperCase();
-    document.title = `${proj} · great_cto`;
-  }
+  const proj = (allTasks[0]?.id || '').split('-')[0] || 'project';
+  document.getElementById('project-name').textContent = proj;
+  document.getElementById('crumb-project').textContent = proj;
+  document.title = `${proj} · great_cto`;
 
   renderKanban(allTasks);
   renderDashboard(metrics);
   renderShareState(shareState);
+  updateNavCounts();
   connectSSE();
 }
 
@@ -674,28 +812,34 @@ function api(url, opts) {
   return fetch(url, opts).then(r => r.json()).catch(() => null);
 }
 
-/* ── SSE ────────────────────────────────────────────────────────────────────── */
 function connectSSE() {
   const es = new EventSource('/api/sse');
   es.addEventListener('tasks', e => {
     allTasks = JSON.parse(e.data);
     renderKanban(allTasks);
+    updateNavCounts();
   });
   es.onopen = () => {
     const d = document.getElementById('live-dot');
     d.className = 'live-dot pulse';
-    document.getElementById('live-label').textContent = 'live';
+    document.getElementById('live-label').textContent = 'live · synced just now';
   };
   es.onerror = () => {
-    const d = document.getElementById('live-dot');
-    d.className = 'live-dot error';
-    document.getElementById('live-label').textContent = 'offline';
+    document.getElementById('live-dot').className = 'live-dot error';
+    document.getElementById('live-label').textContent = 'offline · retrying';
     es.close();
     setTimeout(connectSSE, 5000);
   };
 }
 
-/* ── Kanban ─────────────────────────────────────────────────────────────────── */
+function updateNavCounts() {
+  document.getElementById('nav-task-count').textContent = allTasks.length;
+  document.getElementById('topbar-task-count').textContent = `${allTasks.length} ISSUES`;
+  const agents = metrics.agents || {};
+  document.getElementById('nav-agent-count').textContent = Object.keys(agents).length;
+}
+
+/* ── Kanban ─────────────────────────────────────────────────────────────── */
 function renderKanban(tasks) {
   const board = document.getElementById('kanban-board');
   const byCol = Object.fromEntries(COLUMNS.map(c => [c.id, []]));
@@ -706,15 +850,16 @@ function renderKanban(tasks) {
   board.innerHTML = '';
   for (const col of COLUMNS) {
     const items = byCol[col.id];
+    const dotClass = col.dot === 'filled' ? 'filled' : col.dot === 'half' ? 'half' : '';
     const el = document.createElement('div');
     el.className = `column col-${col.id}`;
     el.innerHTML = `
-      <div class="col-header">
-        <div class="col-indicator"></div>
+      <div class="col-head">
+        <span class="col-dot ${dotClass}" style="color:${col.color}"></span>
         <span class="col-title">${col.label}</span>
         <span class="col-count">${items.length}</span>
       </div>
-      <div class="col-body">${items.length ? items.map(cardHTML).join('') : '<div class="empty" style="padding:20px 8px;font-size:11px;">No tasks</div>'}</div>`;
+      <div class="col-body">${items.length ? items.map(cardHTML).join('') : '<div class="empty">No tasks</div>'}</div>`;
     board.appendChild(el);
     el.querySelectorAll('.card').forEach((cardEl, i) => {
       cardEl.addEventListener('click', () => openSide(items[i]));
@@ -723,93 +868,110 @@ function renderKanban(tasks) {
 }
 
 function cardHTML(t) {
-  const pClass  = `p${t.priority ?? 3}`;
-  const labels  = (t.labels || []).filter(l => l !== 'gate');
-  const isGate  = (t.labels || []).includes('gate');
+  const pIdx = t.priority ?? 3;
+  const pClass = `p${pIdx}`;
+  const pLabel = PRIORITY_LABEL[pIdx];
+  const labels = (t.labels || []).filter(l => l !== 'gate');
+  const isGate = (t.labels || []).includes('gate');
   const elapsed = (t.status === 'in_progress' && t.updated_at)
     ? `<span class="card-time">${relTime(t.updated_at)}</span>` : '';
   return `
     <div class="card">
-      <div class="card-row1">
-        <div class="priority-dot ${pClass}" title="${PRIORITY_TIP[t.priority ?? 3]}"></div>
-        <div class="card-title">${esc(t.title)}</div>
+      <div class="id">${esc(t.id || '')}</div>
+      <div class="card-row1" style="margin-top:4px">
+        <div class="priority-dot ${pClass}" title="${pLabel}"></div>
+        <div class="title">${esc(t.title)}</div>
       </div>
       <div class="card-footer">
-        ${isGate  ? `<span class="chip chip-gate">gate</span>` : ''}
-        ${t.agent ? `<span class="chip chip-agent">${t.agent}</span>` : ''}
-        ${labels.map(l => `<span class="chip chip-label">${l}</span>`).join('')}
+        ${isGate ? `<span class="chip chip-gate">gate</span>` : ''}
+        ${t.agent ? `<span class="chip chip-agent">${esc(t.agent)}</span>` : ''}
+        ${labels.map(l => `<span class="chip">${esc(l)}</span>`).join('')}
+        <span class="chip chip-${pClass}">${pLabel}</span>
         ${elapsed}
       </div>
     </div>`;
 }
 
-/* ── Dashboard ──────────────────────────────────────────────────────────────── */
+/* ── Dashboard ──────────────────────────────────────────────────────────── */
 function renderDashboard(m) {
-  const llmUsd   = m.cost?.llm_usd  ?? 0;
+  const llmUsd = m.cost?.llm_usd ?? 0;
   const humanUsd = m.cost?.human_usd ?? 0;
   const savingsX = m.cost?.savings_x ?? 0;
-  const stats = [
-    { v: m.tasks?.done        ?? '—', label: 'Done',          sub: `+${m.velocity?.this_week ?? 0} this week`,         color: 'var(--green)'  },
-    { v: m.tasks?.in_progress ?? '—', label: 'In progress',   sub: `${m.tasks?.backlog ?? 0} in backlog`,              color: 'var(--accent)' },
-    { v: m.avg_completion_min ? `${m.avg_completion_min}m` : '—', label: 'Avg task time', sub: 'human equiv: hours–days', color: 'var(--yellow)' },
-    { v: llmUsd > 0 ? `$${llmUsd.toFixed(2)}` : '—',         label: 'LLM spend',        sub: savingsX > 0 ? `${savingsX}× cheaper than human` : 'no plans yet',
-      sub2: humanUsd > 0 ? `human equiv: $${humanUsd.toLocaleString()}` : null, color: 'var(--purple)' },
-    { v: m.qa?.pass_rate != null ? `${m.qa.pass_rate}%` : '—', label: 'QA pass rate',   sub: `${m.qa?.passed ?? 0} pass · ${m.qa?.failed ?? 0} fail`, color: 'var(--green)' },
-    { v: m.security?.approved ?? '—', label: 'Security OK',   sub: m.security?.blocked ? `${m.security.blocked} blocked` : 'no blocks',
-      color: m.security?.blocked ? 'var(--red)' : 'var(--green)' },
+  const done = m.tasks?.done ?? 0;
+  const avgMin = m.avg_completion_min ?? 0;
+
+  const hero = [
+    { v: done || '—', sub: 'shipped', label: 'Tasks done', trend: `+${m.velocity?.this_week ?? 0} this week` },
+    { v: llmUsd > 0 ? `$${llmUsd.toFixed(2)}` : '—', sub: '', label: 'LLM spend', trend: humanUsd > 0 ? `vs humans: $${Number(humanUsd).toLocaleString()}` : 'no plans yet', cls: 'amber' },
+    { v: savingsX > 0 ? savingsX : '—', sub: savingsX > 0 ? '×' : '', label: 'Cost savings vs FTE', trend: savingsX > 0 ? `${savingsX}× cheaper than human` : '—', cls: 'green' },
   ];
-  document.getElementById('stats-grid').innerHTML = stats.map(s => `
-    <div class="stat-card" style="--stat-color:${s.color}">
-      <div class="stat-value">${s.v}</div>
-      <div class="stat-label">${s.label}</div>
-      <div class="stat-sub">${s.sub}</div>
-      ${s.sub2 ? `<div class="stat-cost">${s.sub2}</div>` : ''}
+  document.getElementById('mp-hero').innerHTML = hero.map(s => `
+    <div class="metric-card ${s.cls || ''}">
+      <div class="metric-num">${s.v}${s.sub ? `<small>${s.sub}</small>` : ''}</div>
+      <div class="metric-label">${s.label}</div>
+      <div class="metric-trend">${s.trend}</div>
     </div>`).join('');
 
-  const agents  = m.agents || {};
+  const secondary = [
+    { v: avgMin ? `${avgMin}` : '—', sub: avgMin ? 'm' : '', label: 'Avg cycle time' },
+    { v: m.qa?.pass_rate != null ? m.qa.pass_rate : '—', sub: m.qa?.pass_rate != null ? '%' : '', label: 'QA pass rate', cls: 'green' },
+    { v: m.security?.blocked ?? 0, sub: '', label: 'Open security blocks', cls: m.security?.blocked ? 'red' : 'green' },
+    { v: m.tasks?.in_progress ?? 0, sub: '', label: 'In progress', cls: 'amber' },
+  ];
+  document.getElementById('mp-secondary').innerHTML = secondary.map(s => `
+    <div class="metric-card ${s.cls || ''}">
+      <div class="metric-num">${s.v}${s.sub ? `<small>${s.sub}</small>` : ''}</div>
+      <div class="metric-label">${s.label}</div>
+    </div>`).join('');
+
+  const agents = m.agents || {};
   const maxRuns = Math.max(...Object.values(agents), 1);
-  document.getElementById('agent-list').innerHTML =
-    Object.entries(agents).sort((a,b)=>b[1]-a[1]).map(([a,n]) => `
-      <div class="agent-row">
-        <div class="agent-name">${a}</div>
-        <div class="bar-wrap"><div class="bar" style="width:${(n/maxRuns*100).toFixed(0)}%"></div></div>
-        <div class="agent-n">${n}</div>
-      </div>`).join('') || '<div class="empty">No agent runs yet</div>';
+  const colors = ['#2540d4','#7c3aed','#16a34a','#f59e0b','#06b6d4','#2563eb','#64748b','#94a3b8'];
+  const agentKeys = Object.entries(agents).sort((a,b)=>b[1]-a[1]);
+  document.getElementById('agent-list').innerHTML = agentKeys.length ? agentKeys.map(([a, n], i) => `
+    <div class="bar-row">
+      <span class="name">✱ ${esc(a)}</span>
+      <span class="rail"><span class="fill" style="width:${(n/maxRuns*100).toFixed(0)}%; background:${colors[i % colors.length]}"></span></span>
+      <span class="pct">${Math.round(n/maxRuns*100)}%</span>
+    </div>`).join('') : '<div class="empty">No agent runs yet</div>';
 
   const verdicts = (m.verdicts || []).slice();
-  document.getElementById('timeline').innerHTML = verdicts.map(v => {
+  document.getElementById('timeline').innerHTML = verdicts.length ? verdicts.map(v => {
     const vu = (v.verdict || '').toUpperCase();
-    const cls = ['APPROVED','DONE','PASS'].includes(vu) ? 'tl-ok'
-              : ['BLOCKED','FAILED','FAIL'].includes(vu) ? 'tl-fail' : 'tl-def';
-    // Extract readable text: skip timestamp prefix, take up to 80 chars
+    const cls = ['APPROVED','DONE','PASS'].includes(vu) ? 'ok' : ['BLOCKED','FAILED','FAIL'].includes(vu) ? 'fail' : 'def';
     const raw = v.raw || '';
     const afterColon = raw.indexOf(': ') !== -1 ? raw.slice(raw.indexOf(': ') + 2) : raw;
     const text = afterColon.length > 80 ? afterColon.slice(0, 80) + '…' : afterColon;
     return `
-      <div class="tl-row">
-        <div class="tl-status ${cls}"></div>
-        <div class="tl-agent">${v.agent}</div>
-        <div class="tl-text">${esc(text)}</div>
-        <div class="tl-time">${relTime(v.ts)}</div>
+      <div class="feed-row">
+        <span class="feed-dot ${cls}"></span>
+        <span class="agent">✱ ${esc(v.agent)}</span>
+        <span class="msg">${esc(text)}</span>
+        <span class="time">${relTime(v.ts)}</span>
       </div>`;
-  }).join('') || '<div class="empty">No activity yet</div>';
+  }).join('') : '<div class="empty">No activity yet</div>';
 }
 
-/* ── Share ──────────────────────────────────────────────────────────────────── */
+/* ── Share ──────────────────────────────────────────────────────────────── */
 function renderShareState(state) {
   shareState = state;
-  const on  = !!state.enabled;
-  document.getElementById('share-toggle').checked = on;
+  const on = !!state.enabled;
+  const t = document.getElementById('share-toggle');
+  const tv = document.getElementById('share-toggle-visual');
+  t.checked = on;
+  tv.classList.toggle('on', on);
+  document.getElementById('share-help').textContent = on ? 'Anyone with the link can view.' : 'Disabled. Only you can see this project.';
   const badge = document.getElementById('share-nav-badge');
   badge.className = `share-badge ${on ? 'on' : 'off'}`;
   badge.innerHTML = `<span class="share-badge-dot"></span>${on ? 'on' : 'off'}`;
-  const urlSec = document.getElementById('share-url-section');
-  urlSec.style.display = (on && state.url) ? 'block' : 'none';
+  document.getElementById('share-url-section').style.display = (on && state.url) ? 'block' : 'none';
+  document.getElementById('share-disabled-note').style.display = on ? 'none' : 'block';
   document.getElementById('share-url-text').textContent = state.url || '—';
 }
 
-async function onShareToggle(enabled) {
-  document.getElementById('share-loading').style.display  = enabled ? 'flex' : 'none';
+async function toggleShare() {
+  const enabled = !document.getElementById('share-toggle').checked;
+  document.getElementById('share-loading').style.display = enabled ? 'flex' : 'none';
   document.getElementById('share-url-section').style.display = 'none';
   const state = await api('/api/share', {
     method: 'POST',
@@ -819,46 +981,42 @@ async function onShareToggle(enabled) {
   document.getElementById('share-loading').style.display = 'none';
   if (!state || state.error) {
     alert(state?.error || 'Network error');
-    document.getElementById('share-toggle').checked = !enabled;
     return;
   }
   renderShareState(state);
 }
 
-function copyUrl() {
-  const btn = event.currentTarget;
+function copyUrl(e) {
+  const btn = e.currentTarget;
   navigator.clipboard.writeText(shareState.url || '').then(() => {
     btn.textContent = 'Copied!';
     setTimeout(() => btn.textContent = 'Copy', 1500);
   });
 }
-function openUrl() { window.open(shareState.url, '_blank'); }
+function openUrl() { if (shareState.url) window.open(shareState.url, '_blank'); }
 
-/* ── Side panel ─────────────────────────────────────────────────────────────── */
+/* ── Side panel ─────────────────────────────────────────────────────────── */
 function openSide(task) {
   document.getElementById('side-id').textContent = task.id || '—';
-  const pLabel = PRIORITY_LABEL[task.priority ?? 3];
-  const pTip   = PRIORITY_TIP[task.priority ?? 3];
+  const pIdx = task.priority ?? 3;
+  const pLabel = PRIORITY_LABEL[pIdx];
   const dur = task.created_at && task.closed_at
     ? fmtDur(new Date(task.closed_at) - new Date(task.created_at)) : null;
-
   const rows = [
-    ['Status',   `<span class="pill pill-${task.status || 'backlog'}">${(task.status||'backlog').replace('_',' ')}</span>`],
-    ['Priority', `<span class="pill pill-backlog">${pLabel} · ${pTip}</span>`],
-    task.agent    ? ['Agent',   esc(task.agent)] : null,
-    task.labels?.length ? ['Labels', task.labels.map(l=>`<span class="chip">${l}</span>`).join(' ')] : null,
-    ['Created',  fmtDate(task.created_at)],
+    ['Status', `<span class="pill pill-${task.status || 'backlog'}">${(task.status || 'backlog').replace('_', ' ')}</span>`],
+    ['Priority', `<span class="chip chip-p${pIdx}">${pLabel}</span>`],
+    task.agent ? ['Agent', `<span class="chip chip-agent">${esc(task.agent)}</span>`] : null,
+    task.labels?.length ? ['Labels', task.labels.map(l => `<span class="chip">${esc(l)}</span>`).join(' ')] : null,
+    ['Created', fmtDate(task.created_at)],
     task.closed_at ? ['Closed', fmtDate(task.closed_at)] : null,
     dur ? ['Duration', dur] : null,
   ].filter(Boolean);
-
   document.getElementById('side-body').innerHTML = `
     <div class="side-title">${esc(task.title)}</div>
     <div class="props">
-      ${rows.map(([k,v])=>`<div class="prop-key">${k}</div><div class="prop-val">${v}</div>`).join('')}
+      ${rows.map(([k, v]) => `<div class="prop-key">${k}</div><div class="prop-val">${v}</div>`).join('')}
     </div>
     ${task.close_reason ? `<div class="result-box">${esc(task.close_reason)}</div>` : ''}`;
-
   document.getElementById('side-panel').classList.add('open');
 }
 function closeSide() {
@@ -866,33 +1024,39 @@ function closeSide() {
 }
 document.addEventListener('keydown', e => { if (e.key === 'Escape') closeSide(); });
 
-/* ── Tabs ───────────────────────────────────────────────────────────────────── */
+/* ── Tabs ───────────────────────────────────────────────────────────────── */
 function switchTab(id, el) {
-  document.querySelectorAll('.tab').forEach(t => t.classList.remove('active'));
+  currentTab = id;
+  // sidebar nav
+  document.querySelectorAll('.nav-item[data-tab]').forEach(t => t.classList.toggle('active', t.dataset.tab === id));
+  // top tabs
+  document.querySelectorAll('.tab-btn').forEach(t => t.classList.toggle('active', t.dataset.tab === id));
+  // panels
   document.querySelectorAll('.panel').forEach(p => p.classList.remove('active'));
-  el.classList.add('active');
   document.getElementById(`panel-${id}`).classList.add('active');
+  // crumb
+  const labels = { kanban: 'Board', dashboard: 'Metrics', share: 'Share' };
+  document.getElementById('crumb-here').textContent = labels[id] || 'Board';
   if (id === 'dashboard') {
     api('/api/metrics').then(m => { if (m) { metrics = m; renderDashboard(m); } });
   }
 }
 
-/* ── Helpers ────────────────────────────────────────────────────────────────── */
+/* ── Helpers ────────────────────────────────────────────────────────────── */
 function esc(s) {
-  return String(s||'')
-    .replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+  return String(s || '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 }
 function relTime(iso) {
   if (!iso) return '';
   const s = (Date.now() - new Date(iso).getTime()) / 1000;
-  if (s <   60) return `${Math.round(s)}s`;
+  if (s < 60) return `${Math.round(s)}s`;
   if (s < 3600) return `${Math.round(s/60)}m`;
-  if (s < 86400)return `${Math.round(s/3600)}h`;
+  if (s < 86400) return `${Math.round(s/3600)}h`;
   return `${Math.round(s/86400)}d`;
 }
 function fmtDate(iso) { return iso ? new Date(iso).toLocaleString() : '—'; }
 function fmtDur(ms) {
-  const m = Math.round(ms/60000);
+  const m = Math.round(ms / 60000);
   if (m < 60) return `${m}min`;
   return `${Math.floor(m/60)}h ${m%60}m`;
 }

--- a/packages/board/public/share.html
+++ b/packages/board/public/share.html
@@ -9,149 +9,214 @@
 <meta property="og:description" content="AI agents shipped features, saved time and cost. See the breakdown." />
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400..700;1,9..144,400..700&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
 <style>
 :root {
-  --bg0: #0f0f0f;
-  --bg1: #161616;
-  --bg2: #1c1c1c;
-  --bg3: #242424;
-  --border: rgba(255,255,255,0.08);
-  --border-strong: rgba(255,255,255,0.14);
-  --text:  #f1f1f1;
-  --text2: #8b8b8b;
-  --text3: #b0b0b0;
-  --accent: #5e6ad2;
-  --green: #26b066;
-  --green-bg: rgba(38,176,102,.1);
-  --yellow: #f0b429;
-  --yellow-bg: rgba(240,180,41,.1);
-  --red: #e5484d;
-  --mono: 'JetBrains Mono', monospace;
-  --font: 'Inter', system-ui, -apple-system, sans-serif;
+  --bg-card: #ffffff;
+  --bg-muted: #f7f8fa;
+  --bg-strong: #ecedf0;
+  --border: rgba(15, 17, 21, 0.08);
+  --border-strong: rgba(15, 17, 21, 0.14);
+  --text:  #0f1115;
+  --text2: #5b6573;
+  --text3: #828b97;
+  --accent: #2540d4;
+  --accent-soft: #e8edff;
+  --status-review:   #16a34a;
+  --status-progress: #f59e0b;
+  --status-blocked:  #dc2626;
+  --serif: "Fraunces", Georgia, serif;
+  --sans:  "Inter", -apple-system, BlinkMacSystemFont, sans-serif;
+  --mono:  "JetBrains Mono", ui-monospace, "SF Mono", Menlo, monospace;
 }
-*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
-body {
-  background: var(--bg0);
-  color: var(--text);
-  font-family: var(--font);
-  font-size: 14px;
-  line-height: 1.6;
-  min-height: 100vh;
+* { box-sizing: border-box; margin: 0; padding: 0; }
+html, body {
+  width: 100%; min-height: 100%;
+  font-family: var(--sans); color: var(--text);
+  font-size: 14px; line-height: 1.5;
+  background: #f6f5f1;
   -webkit-font-smoothing: antialiased;
 }
+button { font-family: inherit; cursor: pointer; }
 
-/* ── Layout ─────────────────────────────────────────────────────────────────── */
-.wrap { max-width: 780px; margin: 0 auto; padding: 48px 24px 80px; }
+/* Page wrap */
+.report-page {
+  position: relative;
+  width: 100%; min-height: 100vh;
+  display: flex; align-items: flex-start; justify-content: center;
+  padding: 56px 24px;
+  overflow: hidden;
+}
+.report-bg {
+  position: absolute; inset: 0; z-index: 0;
+  pointer-events: none;
+}
+.report-bg svg { width: 100%; height: 100%; display: block; }
 
-/* ── Header ─────────────────────────────────────────────────────────────────── */
-.header-top {
+.report-card {
+  position: relative; z-index: 1;
+  width: 100%; max-width: 720px;
+  background: rgba(255, 255, 255, 0.95);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  border-radius: 20px;
+  box-shadow: 0 24px 64px rgba(15, 17, 21, 0.18), 0 2px 4px rgba(15, 17, 21, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.7);
+  padding: 40px 44px;
+}
+
+.report-head {
+  display: flex; align-items: center; justify-content: space-between;
+  margin-bottom: 32px;
+  padding-bottom: 18px;
+  border-bottom: 1px solid var(--border);
+}
+.report-head .left {
   display: flex; align-items: center; gap: 8px;
-  font-size: 12px; font-family: var(--mono); color: var(--text2);
-  margin-bottom: 28px;
+  font-family: var(--mono); font-size: 12px;
+  color: var(--text2); letter-spacing: 0.04em;
 }
-.header-badge {
-  display: inline-flex; align-items: center; gap: 5px;
-  background: var(--bg2); border: 1px solid var(--border);
-  border-radius: 4px; padding: 3px 8px;
-  font-size: 11px; font-family: var(--mono); color: var(--text3);
+.report-head .left .star { color: var(--accent); font-size: 14px; }
+.report-status {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-size: 11px; font-family: var(--mono);
+  color: var(--status-review);
+  background: rgba(22, 163, 74, 0.08);
+  padding: 4px 10px; border-radius: 999px;
 }
-.header-badge-dot {
-  width: 6px; height: 6px;
-  background: var(--accent); border-radius: 50%;
+.report-status .dot { width: 6px; height: 6px; border-radius: 50%; background: currentColor; }
+
+.report-title { display: flex; gap: 18px; margin-bottom: 36px; }
+.report-title .stripe {
+  width: 4px; background: var(--accent);
+  border-radius: 2px; flex-shrink: 0;
 }
-.header-sep { color: var(--bg3); }
+.report-title h1 {
+  font-family: var(--serif); font-weight: 500;
+  font-size: 44px; line-height: 1.05;
+  letter-spacing: -0.02em; margin: 0;
+}
+.report-title h1 em { font-style: italic; color: var(--accent); font-weight: 400; }
+.report-title .meta {
+  font-family: var(--mono); font-size: 12px;
+  color: var(--text2); margin-top: 12px;
+  letter-spacing: 0.04em;
+}
 
-.h1 { font-size: clamp(22px, 5vw, 36px); font-weight: 700; letter-spacing: -.02em; margin-bottom: 6px; }
-.h1-sub { font-size: 14px; color: var(--text2); }
+.section-label {
+  font-family: var(--mono); font-size: 11px;
+  letter-spacing: 0.1em; text-transform: uppercase;
+  color: var(--text3); margin: 0 0 14px;
+}
 
-/* ── Divider ────────────────────────────────────────────────────────────────── */
-.divider { border: none; border-top: 1px solid var(--border); margin: 32px 0; }
-
-/* ── Stats grid ─────────────────────────────────────────────────────────────── */
-.stats { display: grid; grid-template-columns: repeat(auto-fill, minmax(168px, 1fr)); gap: 8px; margin-bottom: 40px; }
-.stat {
-  background: var(--bg1);
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  padding: 14px 16px;
+.report-stats-hero {
+  display: grid; grid-template-columns: repeat(3, 1fr);
+  gap: 12px; margin-bottom: 12px;
+}
+.report-stat {
+  background: #fff; border: 1px solid var(--border);
+  border-radius: 12px; padding: 22px 20px;
   position: relative; overflow: hidden;
 }
-.stat::before {
-  content: '';
-  position: absolute; top: 0; left: 0; right: 0;
-  height: 2px;
-  background: var(--stat-c, var(--accent));
-  border-radius: 6px 6px 0 0;
+.report-stat::before {
+  content: ""; position: absolute;
+  top: 0; left: 0; right: 0; height: 3px;
+  background: var(--accent);
 }
-.stat-v {
-  font-size: 28px; font-weight: 700;
-  font-family: var(--mono);
-  color: var(--stat-c, var(--text));
-  line-height: 1.1; margin-bottom: 3px;
-  letter-spacing: -.03em;
+.report-stat.green::before  { background: var(--status-review); }
+.report-stat.amber::before  { background: var(--status-progress); }
+.report-stat.red::before    { background: var(--status-blocked); }
+.report-stat.purple::before { background: #7c3aed; }
+.report-stat .num {
+  font-family: var(--serif); font-weight: 500;
+  font-size: 40px; line-height: 1;
+  letter-spacing: -0.02em;
 }
-.stat-l { font-size: 12px; color: var(--text3); font-weight: 500; margin-bottom: 2px; }
-.stat-s { font-size: 11px; color: var(--text2); font-family: var(--mono); }
+.report-stat .num small {
+  font-size: 22px; color: var(--text2);
+  margin-left: 2px; font-weight: 400;
+}
+.report-stat .lbl {
+  font-family: var(--mono); font-size: 11px;
+  letter-spacing: 0.08em; text-transform: uppercase;
+  color: var(--text2); margin-top: 10px;
+}
+.report-stat .sub {
+  margin-top: 6px; font-size: 12px; color: var(--text2);
+}
 
-/* ── Section heading ────────────────────────────────────────────────────────── */
-.sec-hd {
-  font-size: 11px; font-weight: 600;
-  text-transform: uppercase; letter-spacing: .08em;
-  color: var(--text2); margin-bottom: 10px;
+.report-stats-sec {
+  display: grid; grid-template-columns: repeat(3, 1fr);
+  gap: 12px; margin-bottom: 32px;
 }
+.report-stats-sec .report-stat .num { font-size: 26px; font-family: var(--mono); font-weight: 500; }
 
-/* ── Features ───────────────────────────────────────────────────────────────── */
-.features { display: flex; flex-direction: column; gap: 2px; margin-bottom: 40px; }
-.feat {
-  display: flex; align-items: baseline; gap: 10px;
-  padding: 8px 10px;
-  border-radius: 5px;
-  transition: background .1s;
-}
-.feat:hover { background: var(--bg2); }
-.feat-check {
-  width: 16px; height: 16px;
-  background: var(--green-bg);
-  border: 1px solid var(--green);
-  border-radius: 4px;
-  display: flex; align-items: center; justify-content: center;
-  flex-shrink: 0;
-  margin-top: 2px;
-}
-.feat-check svg { color: var(--green); }
-.feat-title { flex: 1; font-size: 13px; color: var(--text); }
-.feat-note  { font-size: 11px; font-family: var(--mono); color: var(--text2); flex-shrink: 0; }
-
-/* ── Footer ─────────────────────────────────────────────────────────────────── */
-.footer {
-  text-align: center;
-  padding-top: 40px;
-  font-size: 12px;
-  color: var(--text2);
+.shipped-row {
+  display: grid;
+  grid-template-columns: 18px 1fr auto;
+  gap: 12px; align-items: baseline;
+  padding: 12px 0;
   border-top: 1px solid var(--border);
+  font-size: 14px;
 }
-.footer a { color: var(--text2); text-decoration: none; }
-.footer a:hover { color: var(--text3); }
+.shipped-row:first-of-type { border-top: none; }
+.shipped-check {
+  width: 16px; height: 16px;
+  border-radius: 50%;
+  background: var(--status-review); color: #fff;
+  display: inline-flex; align-items: center; justify-content: center;
+  font-size: 10px; margin-top: 2px;
+}
+.shipped-row .ttl { color: var(--text); }
+.shipped-row .ttl .sub {
+  color: var(--text3); display: block;
+  font-size: 12px; margin-top: 2px;
+}
+.shipped-row .when {
+  font-family: var(--mono); font-size: 11px; color: var(--text3);
+}
 
-/* ── Paused ─────────────────────────────────────────────────────────────────── */
-.paused-page {
-  min-height: 100vh;
-  display: flex; flex-direction: column;
-  align-items: center; justify-content: center;
-  gap: 10px;
+.report-foot {
+  margin-top: 36px;
+  padding-top: 18px;
+  border-top: 1px solid var(--border);
   text-align: center;
-  padding: 40px 20px;
+  font-family: var(--mono);
+  font-size: 11px; letter-spacing: 0.06em;
+  color: var(--text3);
+}
+.report-foot a { color: var(--accent); text-decoration: none; }
+
+/* Paused */
+.paused-card {
+  text-align: center;
+  padding: 64px 44px;
 }
 .paused-icon {
-  width: 40px; height: 40px;
-  background: var(--bg2); border: 1px solid var(--border);
-  border-radius: 10px;
+  width: 64px; height: 64px;
+  margin: 0 auto 24px;
+  border-radius: 50%;
+  background: var(--bg-muted);
   display: flex; align-items: center; justify-content: center;
-  font-size: 18px; margin-bottom: 8px;
+  color: var(--text2);
 }
-.paused-title { font-size: 18px; font-weight: 600; color: var(--text3); }
-.paused-sub   { font-size: 13px; color: var(--text2); }
+.paused-card h1 {
+  font-family: var(--serif); font-weight: 500;
+  font-size: 32px; letter-spacing: -0.01em;
+  margin: 0 0 10px;
+}
+.paused-card p {
+  color: var(--text2); margin: 0 auto 28px;
+  max-width: 40ch;
+}
+.btn-back {
+  background: #fff; color: var(--accent);
+  border: 1px solid var(--border-strong);
+  padding: 12px 24px; border-radius: 999px;
+  font-weight: 500; font-size: 14px;
+  text-decoration: none; display: inline-block;
+}
+.btn-back:hover { background: var(--bg-muted); }
 </style>
 </head>
 <body>
@@ -164,76 +229,178 @@ const date    = '{{DATE}}';
 const paused  = {{PAUSED}};
 
 function esc(s) {
-  return String(s||'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+  return String(s || '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 }
 
-function checkIcon() {
-  return `<svg width="10" height="10" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24"><polyline points="20 6 9 17 4 12"/></svg>`;
-}
+const LANDSCAPE_SVG = `<svg viewBox="0 0 1600 900" preserveAspectRatio="xMidYMid slice" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="r-sky" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#1a2547" />
+      <stop offset="55%" stop-color="#5a4a7a" />
+      <stop offset="85%" stop-color="#f4a87c" />
+      <stop offset="100%" stop-color="#ffd9b8" />
+    </linearGradient>
+    <radialGradient id="r-sun" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0%" stop-color="#fff4d9" stop-opacity="1" />
+      <stop offset="40%" stop-color="#fff4d9" stop-opacity="0.9" />
+      <stop offset="100%" stop-color="#ffc89b" stop-opacity="0" />
+    </radialGradient>
+    <radialGradient id="r-sunhalo" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0%" stop-color="#ffc89b" stop-opacity="0.5" />
+      <stop offset="100%" stop-color="#ffc89b" stop-opacity="0" />
+    </radialGradient>
+    <linearGradient id="r-mtnFar" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#b8c2d8" />
+      <stop offset="20%" stop-color="#3d4a6b" />
+      <stop offset="100%" stop-color="#3d4a6b" />
+    </linearGradient>
+    <linearGradient id="r-mist" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="rgba(255,220,200,0)" />
+      <stop offset="100%" stop-color="rgba(255,220,200,0.6)" />
+    </linearGradient>
+    <filter id="r-blur"><feGaussianBlur stdDeviation="8" /></filter>
+  </defs>
+  <rect width="1600" height="900" fill="url(#r-sky)" />
+  <circle cx="1100" cy="540" r="260" fill="url(#r-sunhalo)" />
+  <circle cx="1100" cy="540" r="80" fill="url(#r-sun)" />
+  <g filter="url(#r-blur)" opacity="0.85">
+    <ellipse cx="200" cy="280" rx="180" ry="22" fill="#ffc4a8" />
+    <ellipse cx="600" cy="220" rx="240" ry="18" fill="#f5a890" />
+    <ellipse cx="1280" cy="320" rx="220" ry="24" fill="#ffc4a8" />
+    <ellipse cx="900" cy="380" rx="160" ry="14" fill="#e8b4c4" />
+  </g>
+  <path d="M 0,640 L 80,580 L 140,610 L 220,520 L 300,560 L 380,500 L 460,540 L 540,470 L 620,510 L 700,460 L 780,500 L 860,440 L 940,490 L 1020,450 L 1100,500 L 1180,470 L 1260,520 L 1340,490 L 1420,540 L 1500,510 L 1600,560 L 1600,900 L 0,900 Z" fill="url(#r-mtnFar)" opacity="0.92" />
+  <path d="M 0,720 L 100,680 L 200,700 L 320,640 L 440,680 L 560,620 L 680,670 L 800,610 L 920,660 L 1040,620 L 1160,680 L 1280,640 L 1400,690 L 1520,650 L 1600,700 L 1600,900 L 0,900 Z" fill="#2c3554" opacity="0.95" />
+  <rect x="0" y="700" width="1600" height="80" fill="url(#r-mist)" opacity="0.5" />
+  <path d="M 0,820 L 120,790 L 280,810 L 420,780 L 560,815 L 720,790 L 880,820 L 1040,795 L 1200,815 L 1360,790 L 1520,820 L 1600,800 L 1600,900 L 0,900 Z" fill="#1a2138" />
+</svg>`;
 
 if (paused) {
   document.getElementById('root').innerHTML = `
-    <div class="paused-page">
-      <div class="paused-icon">⏸</div>
-      <div class="paused-title">Report paused</div>
-      <div class="paused-sub">The owner has temporarily disabled this link.</div>
-      <div style="margin-top:16px;font-size:12px;color:var(--text2);">
-        Created by <a href="https://greatcto.systems" style="color:var(--text3);font-weight:600;">GreatCTO</a>
+    <div class="report-page">
+      <div class="report-bg">${LANDSCAPE_SVG}</div>
+      <div class="report-card paused-card">
+        <div class="paused-icon">
+          <svg width="28" height="28" viewBox="0 0 24 24" fill="currentColor"><path d="M6 4h4v16H6z M14 4h4v16h-4z"/></svg>
+        </div>
+        <h1>Report paused</h1>
+        <p>The owner has temporarily disabled this link. Reach out to them if you need updated metrics.</p>
+        <a class="btn-back" href="https://greatcto.systems">← Back to greatcto.systems</a>
+        <div class="report-foot" style="margin-top:40px;">
+          CREATED BY <a href="https://greatcto.systems">GREATCTO</a> · GREATCTO.SYSTEMS
+        </div>
       </div>
     </div>`;
 } else {
   const m = metrics || {};
-  const stats = [
-    { v: m.tasks?.done ?? '—',   l: 'Features shipped',    s: `+${m.velocity?.this_week ?? 0} this week`,   c: 'var(--green)'  },
-    { v: m.avg_completion_min ? `${m.avg_completion_min}m` : '—', l: 'Avg completion', s: 'vs human: hours–days', c: 'var(--accent)' },
-    { v: m.cost?.savings_x ? `${m.cost.savings_x}×` : '—', l: 'Cost savings',  s: m.cost?.human_usd ? `$${Number(m.cost.human_usd).toLocaleString()} saved` : 'no plans yet', c: 'var(--yellow)' },
-    { v: m.qa?.pass_rate != null ? `${m.qa.pass_rate}%` : '—', l: 'QA pass rate', s: `${m.qa?.passed??0} pass · ${m.qa?.failed??0} fail`, c: 'var(--green)' },
-    { v: m.security?.approved ?? '—', l: 'Security OK', s: m.security?.blocked ? `${m.security.blocked} blocked` : 'no blocks', c: m.security?.blocked ? 'var(--yellow)' : 'var(--green)' },
-    { v: m.tasks?.in_progress ?? '—', l: 'In progress', s: `${m.tasks?.backlog??0} in backlog`, c: 'var(--accent)' },
+  const done = m.tasks?.done ?? 0;
+  const avgMin = m.avg_completion_min ?? 0;
+  const totalAiMin = done * avgMin;
+  function fmtTime(min) {
+    if (!min) return '—';
+    if (min < 60) return min + 'm';
+    const h = min / 60;
+    if (h < 24) return h.toFixed(h < 10 ? 1 : 0) + 'h';
+    return (h / 8).toFixed(1) + 'd';
+  }
+  const llmUsd = m.cost?.llm_usd ?? 0;
+  const humanUsd = m.cost?.human_usd ?? 0;
+  const savingsX = m.cost?.savings_x ?? 0;
+
+  const hero = [
+    {
+      v: done || '—',
+      sub: done ? 'done' : '',
+      lbl: 'Tasks shipped',
+      extra: `+${m.velocity?.this_week ?? 0} this week`,
+      cls: 'green',
+    },
+    {
+      v: llmUsd > 0 ? '$' + llmUsd.toFixed(2) : '—',
+      sub: '',
+      lbl: 'LLM spend',
+      extra: humanUsd > 0 ? `vs humans: $${Number(humanUsd).toLocaleString()}` : 'no plans yet',
+      cls: 'amber',
+    },
+    {
+      v: savingsX > 0 ? savingsX : '—',
+      sub: savingsX > 0 ? '×' : '',
+      lbl: 'vs FTE cost',
+      extra: savingsX > 0 ? `${savingsX}× cheaper than humans` : '—',
+      cls: 'purple',
+    },
   ];
 
-  const done = tasks.filter(t => t.status === 'done' || t.status === 'closed');
+  const sec = [
+    { v: totalAiMin ? fmtTime(totalAiMin) : '—', lbl: 'AI time', extra: avgMin ? `avg ${avgMin}m / task` : 'no data' },
+    { v: m.qa?.pass_rate != null ? m.qa.pass_rate + '%' : '—', lbl: 'QA pass rate', extra: `${m.qa?.passed ?? 0} pass · ${m.qa?.failed ?? 0} fail`, cls: 'green' },
+    { v: m.tasks?.in_progress ?? 0, lbl: 'In progress', extra: `${m.tasks?.backlog ?? 0} in backlog` },
+  ];
+
+  const doneTasks = (tasks || []).filter(t => t.status === 'done' || t.status === 'closed');
 
   document.getElementById('root').innerHTML = `
-    <div class="wrap">
-      <div class="header-top">
-        <div class="header-badge">
-          <div class="header-badge-dot"></div>
-          great_cto
+    <div class="report-page">
+      <div class="report-bg">${LANDSCAPE_SVG}</div>
+      <div class="report-card">
+        <div class="report-head">
+          <div class="left">
+            <span class="star">✱</span>
+            <span>GREATCTO · ENGINEERING REPORT</span>
+          </div>
+          <span class="report-status">
+            <span class="dot"></span> LIVE
+          </span>
         </div>
-        <span class="header-sep">/</span>
-        <span>AI Engineering Report</span>
-      </div>
 
-      <div class="h1">${esc(project)}</div>
-      <div class="h1-sub">${esc(date)} · Generated by great_cto agents</div>
+        <div class="report-title">
+          <div class="stripe"></div>
+          <div>
+            <h1>${esc(project)}</h1>
+            <div class="meta">${esc(date.toUpperCase())} · GENERATED BY GREAT_CTO AGENTS</div>
+          </div>
+        </div>
 
-      <hr class="divider" />
-
-      <div class="stats">
-        ${stats.map(s => `
-          <div class="stat" style="--stat-c:${s.c}">
-            <div class="stat-v">${s.v}</div>
-            <div class="stat-l">${s.l}</div>
-            ${s.s ? `<div class="stat-s">${s.s}</div>` : ''}
-          </div>`).join('')}
-      </div>
-
-      ${done.length ? `
-        <div class="sec-hd">Recently shipped</div>
-        <div class="features">
-          ${done.map(t => `
-            <div class="feat">
-              <div class="feat-check">${checkIcon()}</div>
-              <div class="feat-title">${esc(t.title)}</div>
-              ${t.close_reason ? `<div class="feat-note">${esc(t.close_reason.substring(0,55))}…</div>` : ''}
+        <div class="section-label">HEADLINE</div>
+        <div class="report-stats-hero">
+          ${hero.map(s => `
+            <div class="report-stat ${s.cls || ''}">
+              <div class="num">${s.v}${s.sub ? `<small>${s.sub}</small>` : ''}</div>
+              <div class="lbl">${s.lbl}</div>
+              ${s.extra ? `<div class="sub">${s.extra}</div>` : ''}
             </div>`).join('')}
-        </div>` : ''}
+        </div>
 
-      <div class="footer">
-        Created by <a href="https://greatcto.systems" target="_blank" style="color:var(--text3);font-weight:600;">GreatCTO</a>
-        &nbsp;·&nbsp; AI engineering infrastructure for dev teams
-        &nbsp;·&nbsp; <a href="https://github.com/avelikiy/great_cto" target="_blank">GitHub</a>
+        <div class="report-stats-sec">
+          ${sec.map(s => `
+            <div class="report-stat ${s.cls || ''}">
+              <div class="num">${s.v}</div>
+              <div class="lbl">${s.lbl}</div>
+              ${s.extra ? `<div class="sub">${s.extra}</div>` : ''}
+            </div>`).join('')}
+        </div>
+
+        ${doneTasks.length ? `
+          <div class="section-label">RECENTLY SHIPPED</div>
+          ${doneTasks.map(t => {
+            const reason = t.close_reason ? esc(t.close_reason.substring(0, 70)) + (t.close_reason.length > 70 ? '…' : '') : '';
+            const when = t.closed_at ? new Date(t.closed_at).toLocaleDateString('en-US', { month: 'short', day: 'numeric' }) : '';
+            return `
+              <div class="shipped-row">
+                <span class="shipped-check">✓</span>
+                <span class="ttl">
+                  ${esc(t.title)}
+                  ${reason ? `<span class="sub">${reason}</span>` : ''}
+                </span>
+                <span class="when">${when}</span>
+              </div>`;
+          }).join('')}` : ''}
+
+        <div class="report-foot">
+          CREATED BY <a href="https://greatcto.systems" target="_blank">GREATCTO</a>
+          &nbsp;·&nbsp; AI engineering infrastructure for dev teams
+          &nbsp;·&nbsp; <a href="https://github.com/avelikiy/great_cto" target="_blank">GITHUB</a>
+        </div>
       </div>
     </div>`;
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "great-cto",
-  "version": "1.0.157",
+  "version": "1.0.158",
   "description": "One command install for the great_cto Claude Code plugin. Auto-detects your stack, picks the right archetype, bootstraps PROJECT.md.",
   "keywords": [
     "claude-code",

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,334 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>GreatCTO — Your next 10 engineers won't be people</title>
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<meta name="description" content="GreatCTO replaces the entire CTO function with specialist agents — architect, security, QA, devops, and more — coordinated through a single board." />
+<meta property="og:title" content="GreatCTO — Your next 10 engineers won't be people" />
+<meta property="og:description" content="17 specialist agents, one board. The AI engineering org for solo founders → 50-eng teams." />
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400..700;1,9..144,400..700&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
+<link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+
+<!-- Hero with landscape -->
+<section class="landing-hero">
+  <div class="landing-bg">
+    <svg viewBox="0 0 1600 900" preserveAspectRatio="xMidYMid slice" xmlns="http://www.w3.org/2000/svg">
+      <defs>
+        <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stop-color="#1a2547" />
+          <stop offset="55%" stop-color="#5a4a7a" />
+          <stop offset="85%" stop-color="#f4a87c" />
+          <stop offset="100%" stop-color="#ffd9b8" />
+        </linearGradient>
+        <radialGradient id="sun" cx="0.5" cy="0.5" r="0.5">
+          <stop offset="0%" stop-color="#fff4d9" stop-opacity="1" />
+          <stop offset="40%" stop-color="#fff4d9" stop-opacity="0.9" />
+          <stop offset="100%" stop-color="#ffc89b" stop-opacity="0" />
+        </radialGradient>
+        <radialGradient id="sunhalo" cx="0.5" cy="0.5" r="0.5">
+          <stop offset="0%" stop-color="#ffc89b" stop-opacity="0.5" />
+          <stop offset="100%" stop-color="#ffc89b" stop-opacity="0" />
+        </radialGradient>
+        <linearGradient id="mtnFar" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stop-color="#b8c2d8" />
+          <stop offset="20%" stop-color="#3d4a6b" />
+          <stop offset="100%" stop-color="#3d4a6b" />
+        </linearGradient>
+        <linearGradient id="mist" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stop-color="rgba(255,220,200,0)" />
+          <stop offset="100%" stop-color="rgba(255,220,200,0.6)" />
+        </linearGradient>
+        <filter id="blur-cloud"><feGaussianBlur stdDeviation="8" /></filter>
+      </defs>
+      <rect width="1600" height="900" fill="url(#sky)" />
+      <circle cx="1100" cy="540" r="260" fill="url(#sunhalo)" />
+      <circle cx="1100" cy="540" r="80" fill="url(#sun)" />
+      <g filter="url(#blur-cloud)" opacity="0.85">
+        <ellipse cx="200" cy="280" rx="180" ry="22" fill="#ffc4a8" />
+        <ellipse cx="600" cy="220" rx="240" ry="18" fill="#f5a890" />
+        <ellipse cx="1280" cy="320" rx="220" ry="24" fill="#ffc4a8" />
+        <ellipse cx="900" cy="380" rx="160" ry="14" fill="#e8b4c4" />
+        <ellipse cx="350" cy="440" rx="280" ry="20" fill="#f5a890" opacity="0.7" />
+        <ellipse cx="1400" cy="480" rx="200" ry="16" fill="#e8b4c4" opacity="0.7" />
+      </g>
+      <g opacity="0.75">
+        <path d="M 100,300 Q 250,280 400,295 T 720,300 Q 800,310 700,318 T 300,322 Q 150,318 100,310 Z" fill="#ffc4a8" opacity="0.55" />
+        <path d="M 980,360 Q 1150,340 1320,355 T 1600,365 L 1600,378 Q 1400,388 1180,382 T 980,380 Z" fill="#f5a890" opacity="0.5" />
+      </g>
+      <g opacity="0.92">
+        <path d="M 0,640 L 80,580 L 140,610 L 220,520 L 300,560 L 380,500 L 460,540 L 540,470 L 620,510 L 700,460 L 780,500 L 860,440 L 940,490 L 1020,450 L 1100,500 L 1180,470 L 1260,520 L 1340,490 L 1420,540 L 1500,510 L 1600,560 L 1600,900 L 0,900 Z" fill="url(#mtnFar)" />
+        <path d="M 220,520 L 240,535 L 260,530 L 280,548 L 300,560 L 280,558 L 260,550 L 240,548 Z" fill="#b8c2d8" opacity="0.5" />
+        <path d="M 540,470 L 560,485 L 580,482 L 600,500 L 620,510 L 600,506 L 580,500 L 560,496 Z" fill="#b8c2d8" opacity="0.6" />
+        <path d="M 860,440 L 880,455 L 900,452 L 920,475 L 940,490 L 920,486 L 900,478 L 880,470 Z" fill="#b8c2d8" opacity="0.55" />
+      </g>
+      <path d="M 0,720 L 100,680 L 200,700 L 320,640 L 440,680 L 560,620 L 680,670 L 800,610 L 920,660 L 1040,620 L 1160,680 L 1280,640 L 1400,690 L 1520,650 L 1600,700 L 1600,900 L 0,900 Z" fill="#2c3554" opacity="0.95" />
+      <rect x="0" y="700" width="1600" height="80" fill="url(#mist)" opacity="0.5" />
+      <path d="M 0,820 L 120,790 L 280,810 L 420,780 L 560,815 L 720,790 L 880,820 L 1040,795 L 1200,815 L 1360,790 L 1520,820 L 1600,800 L 1600,900 L 0,900 Z" fill="#1a2138" />
+      <rect x="0" y="700" width="1600" height="200" fill="rgba(0,0,0,0.05)" />
+    </svg>
+  </div>
+  <div class="landing-content">
+    <nav class="land-nav">
+      <div class="land-nav-logo"><span class="star">✱</span><span>greatcto</span></div>
+      <div class="land-nav-right">
+        <a class="land-nav-link" href="#how">How it works</a>
+        <a class="land-nav-link" href="#agents">Agents</a>
+        <a class="land-nav-link" href="#pricing">Pricing</a>
+        <a class="land-nav-link" href="https://github.com/avelikiy/great_cto">GitHub</a>
+        <a class="land-nav-link solid" href="https://github.com/avelikiy/great_cto">Sign in</a>
+      </div>
+    </nav>
+
+    <header class="land-hero">
+      <span class="land-hero-eyebrow">v0.14 · 17 specialist agents</span>
+      <h1>Your next 10 engineers <em>won't be people.</em></h1>
+      <p>GreatCTO replaces the entire CTO function with specialist agents — architect, security, QA, devops, ops, and twelve more — coordinated through a single board you actually check.</p>
+      <div class="land-cta-row">
+        <a class="btn-primary" href="#cta">Get started →</a>
+        <a class="btn-ghost" href="#how">How it works</a>
+      </div>
+      <div class="land-works-with">WORKS WITH &nbsp; · &nbsp; CLAUDE CODE &nbsp; · &nbsp; CURSOR &nbsp; · &nbsp; AIDER &nbsp; · &nbsp; ZED</div>
+
+      <!-- Dashboard preview -->
+      <div class="land-dash" style="margin-top:32px;text-align:left;">
+        <div class="land-dash-bar">
+          <span class="dot" style="background:#ff5f57"></span>
+          <span class="dot" style="background:#febc2e"></span>
+          <span class="dot" style="background:#28c840"></span>
+          <span class="url-label">board.greatcto.systems</span>
+        </div>
+        <div class="land-dash-body">
+          <div class="land-dash-side">
+            <div class="proj"><span class="star">✱</span> greatcto-core</div>
+            <div class="item">Inbox</div>
+            <div class="item active">Tasks</div>
+            <div class="item">Metrics</div>
+            <div class="item">Reports</div>
+            <div class="item">Agents</div>
+          </div>
+          <div class="land-dash-main">
+            <div class="land-dash-col">
+              <div class="land-dash-col-head" style="color:#94a3b8">
+                <span class="col-dot"></span>
+                <span style="color:var(--text)">Backlog</span>
+                <span class="count">4</span>
+              </div>
+              <div class="land-dash-card">
+                <div class="id">GCT-32</div>
+                <div class="ttl">Investigate Postgres lock contention</div>
+                <div><span class="chip chip-p1">High</span></div>
+              </div>
+              <div class="land-dash-card">
+                <div class="id">GCT-31</div>
+                <div class="ttl">Spec out webhook retry policy</div>
+                <div><span class="chip chip-p2">Medium</span></div>
+              </div>
+            </div>
+            <div class="land-dash-col">
+              <div class="land-dash-col-head" style="color:#64748b">
+                <span class="col-dot"></span>
+                <span style="color:var(--text)">Todo</span>
+                <span class="count">5</span>
+              </div>
+              <div class="land-dash-card">
+                <div class="id">GCT-28</div>
+                <div class="ttl">Wire up SSO via Auth0</div>
+                <div><span class="chip chip-p1">High</span></div>
+              </div>
+              <div class="land-dash-card">
+                <div class="id">GCT-27</div>
+                <div class="ttl">Add idempotency keys to /charge</div>
+                <div><span class="chip chip-p0">Urgent</span></div>
+              </div>
+            </div>
+            <div class="land-dash-col">
+              <div class="land-dash-col-head" style="color:#f59e0b">
+                <span class="col-dot filled"></span>
+                <span style="color:var(--text)">In Progress</span>
+                <span class="count">3</span>
+              </div>
+              <div class="land-dash-card">
+                <div class="id">GCT-23</div>
+                <div class="ttl">Implement OAuth2 token refresh</div>
+                <div><span class="chip chip-p0">Urgent</span></div>
+              </div>
+              <div class="land-dash-card">
+                <div class="id">GCT-22</div>
+                <div class="ttl">Database connection pool tuning</div>
+                <div><span class="chip chip-p1">High</span></div>
+              </div>
+            </div>
+            <div class="land-dash-col">
+              <div class="land-dash-col-head" style="color:#16a34a">
+                <span class="col-dot filled"></span>
+                <span style="color:var(--text)">In Review</span>
+                <span class="count">2</span>
+              </div>
+              <div class="land-dash-card">
+                <div class="id">GCT-20</div>
+                <div class="ttl">Security audit — auth surface</div>
+                <div><span class="chip chip-p1">High</span></div>
+              </div>
+              <div class="land-dash-card">
+                <div class="id">GCT-19</div>
+                <div class="ttl">Image upload pipeline</div>
+                <div><span class="chip chip-p2">Medium</span></div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </header>
+  </div>
+</section>
+
+<!-- How it works -->
+<section class="land-section" id="how">
+  <div class="land-section-narrow">
+    <h2>How it <em>works</em></h2>
+    <p class="sub">Three commands. The board does the rest.</p>
+    <div class="how-grid">
+      <div class="how-card">
+        <div class="how-num">01</div>
+        <h3>Initialize a project</h3>
+        <p>Drop into any repo and get a board, a backlog, and seventeen ready agents.</p>
+        <pre>$ npx great-cto init</pre>
+      </div>
+      <div class="how-card">
+        <div class="how-num">02</div>
+        <h3>Agents pick up work</h3>
+        <p>Architect drafts, frontend builds, QA tests, security audits, devops ships. Status updates in realtime.</p>
+        <pre>$ npx great-cto start</pre>
+      </div>
+      <div class="how-card">
+        <div class="how-num">03</div>
+        <h3>Ship</h3>
+        <p>You review the diff, merge the PR, hand off the share link to your investors.</p>
+        <pre>$ npx great-cto ship</pre>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- Six metrics -->
+<section class="land-section alt">
+  <div class="land-section-narrow">
+    <h2>Six metrics that <em>matter</em></h2>
+    <p class="sub">Less vanity. More signal. The board surfaces what would actually be in your CTO update.</p>
+    <div class="metrics-grid">
+      <div class="metric-card">
+        <div class="metric-num">42<small>shipped</small></div>
+        <div class="metric-label">Tasks done · last 30d</div>
+        <div class="metric-trend"><span class="up">▲ 18%</span> vs prior period</div>
+      </div>
+      <div class="metric-card amber">
+        <div class="metric-num">$47<small>/day</small></div>
+        <div class="metric-label">LLM spend</div>
+        <div class="metric-trend"><span class="down">▼ 4%</span> after caching</div>
+      </div>
+      <div class="metric-card green">
+        <div class="metric-num">12<small>×</small></div>
+        <div class="metric-label">Throughput vs solo</div>
+        <div class="metric-trend"><span class="up">▲ stable</span></div>
+      </div>
+      <div class="metric-card">
+        <div class="metric-num">78<small>min</small></div>
+        <div class="metric-label">Avg cycle time</div>
+        <div class="metric-trend"><span class="up">▲ 9% faster</span></div>
+      </div>
+      <div class="metric-card green">
+        <div class="metric-num">94<small>%</small></div>
+        <div class="metric-label">QA pass rate</div>
+        <div class="metric-trend">across 412 tests</div>
+      </div>
+      <div class="metric-card red">
+        <div class="metric-num">0<small>highs</small></div>
+        <div class="metric-label">Open security findings</div>
+        <div class="metric-trend">last audit Apr 26</div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- Quotes -->
+<section class="land-section">
+  <div class="land-section-narrow">
+    <h2>Built for solo founders <em>→</em> 50-eng teams</h2>
+    <p class="sub">Same board, same agents, scales with you.</p>
+    <div class="quotes-grid">
+      <div class="quote-card">
+        <p>"It's the first time I've felt like I had a real CTO without having to hire one. The architect agent has caught three things my last contractor missed."</p>
+        <div class="quote-attr"><span class="quote-avatar"></span> Solo founder · seed-stage SaaS</div>
+      </div>
+      <div class="quote-card">
+        <p>"We're a team of nine and we run GreatCTO alongside our humans. The QA and security agents do the work nobody wants to do — and they don't forget."</p>
+        <div class="quote-attr"><span class="quote-avatar" style="background:linear-gradient(135deg,#ffd9b8,#ffc4a8)"></span> VP Eng · series A</div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- Agents table -->
+<section class="land-section alt" id="agents">
+  <div class="land-section-narrow">
+    <h2>What's <em>inside</em></h2>
+    <p class="sub">Seventeen agents. Each does one thing well. Together they cover the whole CTO function.</p>
+    <table class="agents-table">
+      <thead>
+        <tr><th>Agent</th><th>Discipline</th><th>What they do</th></tr>
+      </thead>
+      <tbody>
+        <tr><td class="name">✱ architect</td><td class="role">Systems design</td><td class="desc">Plans services, data flow, RFCs. Writes ADRs.</td></tr>
+        <tr><td class="name">✱ security</td><td class="role">Threat & audit</td><td class="desc">Pen-test cadence, dep CVE triage, secret scanning.</td></tr>
+        <tr><td class="name">✱ qa</td><td class="role">Test discipline</td><td class="desc">Coverage gates, flake hunter, visual regression.</td></tr>
+        <tr><td class="name">✱ devops</td><td class="role">Build & deploy</td><td class="desc">CI/CD, k8s, infra-as-code, rollback drills.</td></tr>
+        <tr><td class="name">✱ ops</td><td class="role">Incident & on-call</td><td class="desc">Runbooks, paging policy, post-mortems.</td></tr>
+        <tr><td class="name">✱ frontend</td><td class="role">UI engineering</td><td class="desc">Component library, a11y, design tokens.</td></tr>
+        <tr><td class="name">✱ backend</td><td class="role">API & data</td><td class="desc">Schema, query plans, idempotency, queues.</td></tr>
+        <tr><td class="name">✱ docs</td><td class="role">Reference & changelog</td><td class="desc">Auto-regenerates on every release.</td></tr>
+        <tr><td class="name">✱ release</td><td class="role">Versioning</td><td class="desc">Semver, changelogs, release notes.</td></tr>
+        <tr><td class="name">✱ data</td><td class="role">Analytics & ETL</td><td class="desc">Pipelines, schema drift, dashboards.</td></tr>
+        <tr><td class="name">✱ growth</td><td class="role">A/B & funnels</td><td class="desc">Experiment design, statistical significance.</td></tr>
+        <tr><td class="name">✱ billing</td><td class="role">Revenue ops</td><td class="desc">Stripe, dunning, refund flows.</td></tr>
+        <tr><td class="name">✱ support</td><td class="role">Customer ops</td><td class="desc">Ticket triage, FAQ generation.</td></tr>
+        <tr><td class="name">✱ legal</td><td class="role">Policy & compliance</td><td class="desc">ToS, DPA, SOC2 evidence collection.</td></tr>
+        <tr><td class="name">✱ pm</td><td class="role">Roadmap</td><td class="desc">Quarterly OKRs, status reports.</td></tr>
+        <tr><td class="name">✱ recruiter</td><td class="role">Hiring (when needed)</td><td class="desc">JDs, screening, scorecards.</td></tr>
+        <tr><td class="name">✱ finance</td><td class="role">Burn & runway</td><td class="desc">Forecasts, vendor consolidation.</td></tr>
+      </tbody>
+    </table>
+  </div>
+</section>
+
+<!-- CTA -->
+<section class="land-section" id="cta">
+  <div class="land-section-narrow">
+    <div class="cta-block">
+      <h2>Start in <em>30 seconds</em></h2>
+      <p>Free to try. Pay only for the LLM tokens your agents use.</p>
+      <div class="terminal">
+        <span class="dollar">$</span>
+        <span>npx great-cto init</span>
+        <button class="copy" onclick="copyCmd(this)">COPY</button>
+      </div>
+      <div class="footnote">CREATED BY GREATCTO · GREATCTO.SYSTEMS</div>
+    </div>
+  </div>
+</section>
+
+<script>
+function copyCmd(btn) {
+  navigator.clipboard.writeText('npx great-cto init').then(() => {
+    btn.textContent = 'COPIED';
+    setTimeout(() => btn.textContent = 'COPY', 1500);
+  });
+}
+</script>
+
+</body>
+</html>

--- a/site/styles.css
+++ b/site/styles.css
@@ -1,0 +1,349 @@
+/* GreatCTO Light Theme — Design Tokens */
+:root {
+  --bg-page: transparent;
+  --bg-panel: rgba(255, 255, 255, 0.92);
+  --bg-card: #ffffff;
+  --bg-muted: #f7f8fa;
+  --bg-strong: #ecedf0;
+
+  --border: rgba(15, 17, 21, 0.08);
+  --border-strong: rgba(15, 17, 21, 0.14);
+
+  --text: #0f1115;
+  --text2: #5b6573;
+  --text3: #828b97;
+
+  --accent: #2540d4;
+  --accent-2: #6b81ff;
+  --accent-soft: #e8edff;
+
+  --status-review: #16a34a;
+  --status-progress: #f59e0b;
+  --status-blocked: #dc2626;
+
+  --p0-bg: #fee2e2; --p0-fg: #b91c1c;
+  --p1-bg: #ffedd5; --p1-fg: #c2410c;
+  --p2-bg: #fef3c7; --p2-fg: #92400e;
+  --p3-bg: #f1f5f9; --p3-fg: #475569;
+
+  --serif: "Fraunces", Georgia, serif;
+  --sans: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --mono: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, monospace;
+
+  --shadow-card: 0 1px 2px rgba(15, 17, 21, 0.04);
+  --shadow-card-hover: 0 1px 2px rgba(15, 17, 21, 0.06), 0 8px 24px rgba(15, 17, 21, 0.08);
+}
+* { box-sizing: border-box; }
+html, body {
+  margin: 0;
+  padding: 0;
+  font-family: var(--sans);
+  color: var(--text);
+  font-size: 14px;
+  line-height: 1.5;
+  background: #fff;
+  -webkit-font-smoothing: antialiased;
+}
+button { font-family: inherit; cursor: pointer; }
+
+/* ── Landing hero ──────────────────────────────────────────────────────────── */
+.landing-hero { position: relative; min-height: 720px; overflow: hidden; }
+.landing-bg { position: absolute; inset: 0; z-index: 0; }
+.landing-bg svg { width: 100%; height: 100%; display: block; }
+.landing-content { position: relative; z-index: 1; }
+
+.land-nav {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 22px 56px; color: #fff;
+}
+.land-nav-logo {
+  display: flex; align-items: center; gap: 8px;
+  font-family: var(--serif);
+  font-weight: 600; font-size: 20px;
+  letter-spacing: -0.01em; color: #fff;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.25);
+}
+.land-nav-logo .star { color: #ffd9b8; font-size: 22px; }
+.land-nav-right { display: flex; align-items: center; gap: 8px; font-size: 13px; }
+.land-nav-link {
+  color: #fff; text-decoration: none;
+  padding: 8px 14px; border-radius: 999px;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.25);
+  transition: background 0.15s;
+}
+.land-nav-link:hover { background: rgba(255, 255, 255, 0.12); }
+.land-nav-link.solid {
+  background: rgba(255, 255, 255, 0.95); color: var(--text);
+  text-shadow: none; font-weight: 500;
+}
+
+.land-hero { text-align: center; padding: 60px 32px 0; color: #fff; }
+.land-hero-eyebrow {
+  display: inline-block;
+  font-family: var(--mono); font-size: 11px;
+  letter-spacing: 0.12em; text-transform: uppercase;
+  padding: 6px 14px; border-radius: 999px;
+  background: rgba(255, 255, 255, 0.16);
+  border: 1px solid rgba(255, 255, 255, 0.28);
+  color: #fff; text-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+  backdrop-filter: blur(8px);
+}
+.land-hero h1 {
+  font-family: var(--serif);
+  font-weight: 600;
+  font-size: clamp(48px, 6.4vw, 84px);
+  line-height: 1.04; letter-spacing: -0.025em;
+  margin: 22px auto 18px; max-width: 14ch;
+  text-wrap: balance;
+  text-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
+}
+.land-hero h1 em { font-style: italic; font-weight: 400; color: #ffe4c8; }
+.land-hero p {
+  max-width: 56ch; margin: 0 auto 30px;
+  font-size: 17px; line-height: 1.55;
+  color: rgba(255, 255, 255, 0.92);
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.25);
+}
+.land-cta-row { display: flex; gap: 10px; justify-content: center; margin-bottom: 28px; flex-wrap: wrap; }
+.btn-primary {
+  background: #fff; color: var(--accent);
+  border: none; padding: 14px 26px;
+  border-radius: 999px; font-weight: 600; font-size: 14px;
+  box-shadow: 0 1px 0 rgba(0,0,0,.04), 0 8px 24px rgba(15,17,21,.18), inset 0 -1px 0 rgba(15,17,21,.06);
+  text-decoration: none; display: inline-block;
+}
+.btn-primary:hover { background: #f4f6ff; }
+.btn-ghost {
+  background: transparent; color: #fff;
+  border: 1px solid rgba(255,255,255,.4);
+  padding: 14px 24px; border-radius: 999px;
+  font-weight: 500; font-size: 14px;
+  text-shadow: 0 1px 2px rgba(0,0,0,.2);
+  backdrop-filter: blur(8px);
+  text-decoration: none; display: inline-block;
+}
+.btn-ghost:hover { background: rgba(255,255,255,.12); }
+
+.land-works-with {
+  font-size: 12px; font-family: var(--mono);
+  color: rgba(255,255,255,.85); letter-spacing: 0.08em;
+  text-shadow: 0 1px 2px rgba(0,0,0,.2);
+  margin-bottom: 60px; text-align: center;
+}
+
+/* Floating dashboard preview */
+.land-dash {
+  margin: 0 auto; max-width: 1080px;
+  border-radius: 16px;
+  background: var(--bg-card);
+  box-shadow: 0 24px 64px rgba(15,17,21,.22), 0 2px 4px rgba(15,17,21,.08);
+  border: 1px solid var(--border);
+  overflow: hidden;
+}
+.land-dash-bar {
+  height: 38px; display: flex; align-items: center;
+  padding: 0 16px; border-bottom: 1px solid var(--border);
+  gap: 8px; background: #fafafa;
+}
+.land-dash-bar .dot { width: 10px; height: 10px; border-radius: 50%; }
+.land-dash-bar .url-label { margin-left: 16px; font-family: var(--mono); font-size: 11px; color: var(--text3); }
+.land-dash-body { display: grid; grid-template-columns: 200px 1fr; min-height: 380px; }
+.land-dash-side {
+  border-right: 1px solid var(--border);
+  padding: 12px; background: #fbfbfd;
+}
+.land-dash-side .proj {
+  display: flex; align-items: center; gap: 8px;
+  padding: 6px 8px; margin-bottom: 12px;
+  font-weight: 600; font-size: 13px;
+}
+.land-dash-side .proj .star { color: var(--accent); }
+.land-dash-side .item {
+  padding: 6px 10px; border-radius: 6px;
+  font-size: 12.5px; color: var(--text2);
+  margin-bottom: 2px;
+}
+.land-dash-side .item.active {
+  color: var(--text); background: var(--bg-strong); font-weight: 500;
+}
+.land-dash-main {
+  padding: 14px; display: flex; gap: 10px; overflow: hidden;
+}
+.land-dash-col {
+  flex: 1; min-width: 0;
+  background: rgba(247, 248, 250, 0.6);
+  border: 1px solid var(--border);
+  border-radius: 8px; padding: 8px;
+}
+.land-dash-col-head {
+  display: flex; align-items: center; gap: 6px;
+  font-size: 12px; font-weight: 600;
+  padding: 2px 4px 8px;
+}
+.land-dash-col-head .col-dot {
+  width: 8px; height: 8px; border-radius: 50%;
+  border: 1.5px solid currentColor;
+}
+.land-dash-col-head .col-dot.filled { background: currentColor; }
+.land-dash-col-head .count {
+  font-family: var(--mono); font-size: 10px;
+  color: var(--text3); font-weight: 500;
+}
+.land-dash-card {
+  background: #fff; border: 1px solid var(--border);
+  border-radius: 6px; padding: 8px; margin-bottom: 6px;
+}
+.land-dash-card .id { font-family: var(--mono); font-size: 9px; color: var(--text3); }
+.land-dash-card .ttl { font-weight: 600; font-size: 11px; margin-top: 2px; line-height: 1.3; color: var(--text); }
+.land-dash-card .pri {
+  display: inline-flex; height: 16px; padding: 0 6px;
+  margin-top: 6px; border-radius: 999px;
+  font-size: 9px; font-weight: 500; align-items: center;
+}
+
+/* Sections below */
+.land-section { background: #fff; padding: 96px 56px; position: relative; z-index: 1; }
+.land-section.alt { background: var(--bg-muted); }
+.land-section-narrow { max-width: 1080px; margin: 0 auto; }
+.land-section h2 {
+  font-family: var(--serif); font-weight: 600;
+  font-size: clamp(32px, 4vw, 48px);
+  letter-spacing: -0.02em; line-height: 1.1;
+  margin: 0 0 12px;
+}
+.land-section h2 em { font-style: italic; font-weight: 400; color: var(--accent); }
+.land-section .sub {
+  color: var(--text2); font-size: 17px;
+  max-width: 56ch; margin: 0 0 56px;
+}
+
+.how-grid { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 32px; }
+.how-card { border-top: 1px solid var(--border-strong); padding-top: 24px; }
+.how-num {
+  font-family: var(--serif); font-style: italic; font-weight: 400;
+  font-size: 56px; line-height: 1;
+  color: var(--accent); margin-bottom: 18px;
+}
+.how-card h3 { font-family: var(--sans); font-weight: 600; font-size: 18px; margin: 0 0 8px; }
+.how-card p { color: var(--text2); margin: 0; line-height: 1.55; }
+.how-card pre {
+  margin-top: 14px; background: #0f1115; color: #e6e8ec;
+  padding: 12px 14px; border-radius: 8px;
+  font-family: var(--mono); font-size: 12px; overflow: auto;
+}
+
+.metrics-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; }
+.metric-card {
+  background: #fff; border: 1px solid var(--border);
+  border-radius: 12px; padding: 24px;
+  position: relative; overflow: hidden;
+}
+.metric-card::before {
+  content: ""; position: absolute;
+  top: 0; left: 0; right: 0; height: 3px;
+  background: var(--accent);
+}
+.metric-card.green::before { background: var(--status-review); }
+.metric-card.amber::before { background: var(--status-progress); }
+.metric-card.red::before { background: var(--status-blocked); }
+.metric-num {
+  font-family: var(--serif); font-weight: 500; font-size: 44px;
+  letter-spacing: -0.02em; line-height: 1;
+}
+.metric-num small { font-size: 22px; color: var(--text2); margin-left: 4px; font-weight: 400; }
+.metric-label {
+  font-family: var(--mono); font-size: 11px;
+  letter-spacing: 0.08em; text-transform: uppercase;
+  color: var(--text2); margin-top: 14px;
+}
+.metric-trend { margin-top: 6px; font-size: 12px; color: var(--text2); }
+.metric-trend .up { color: var(--status-review); }
+.metric-trend .down { color: var(--status-blocked); }
+
+.quotes-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+.quote-card {
+  background: #fff; border: 1px solid var(--border);
+  border-radius: 12px; padding: 28px;
+}
+.quote-card p {
+  font-family: var(--serif); font-size: 22px;
+  line-height: 1.35; margin: 0 0 18px;
+  letter-spacing: -0.01em;
+}
+.quote-attr { display: flex; align-items: center; gap: 10px; font-size: 13px; color: var(--text2); }
+.quote-avatar {
+  width: 32px; height: 32px; border-radius: 50%;
+  background: linear-gradient(135deg, #c9d6ff, #f0c9ff);
+}
+
+.agents-table { width: 100%; border-collapse: collapse; }
+.agents-table th, .agents-table td {
+  text-align: left; padding: 14px 12px;
+  border-bottom: 1px solid var(--border);
+  font-size: 14px; vertical-align: top;
+}
+.agents-table th {
+  font-family: var(--mono); font-size: 11px;
+  letter-spacing: 0.08em; text-transform: uppercase;
+  color: var(--text3); font-weight: 500;
+  border-bottom: 1px solid var(--border-strong);
+}
+.agents-table td.name {
+  font-family: var(--mono); font-size: 13px;
+  color: var(--accent); font-weight: 500; width: 180px;
+}
+.agents-table td.role { color: var(--text); width: 220px; }
+.agents-table td.desc { color: var(--text2); }
+.agents-table tr:hover { background: var(--bg-muted); }
+
+.cta-block {
+  background: #0f1115; border-radius: 16px;
+  padding: 64px 48px; text-align: center;
+  color: #fff; margin-top: 32px;
+}
+.cta-block h2 {
+  font-family: var(--serif); font-size: 48px;
+  font-weight: 500; letter-spacing: -0.02em;
+  margin: 0 0 16px; color: #fff;
+}
+.cta-block h2 em { font-style: italic; color: #ffd9b8; }
+.cta-block p { color: rgba(255, 255, 255, 0.72); margin: 0 0 8px; font-size: 16px; }
+.cta-block .terminal {
+  display: inline-flex; align-items: center; gap: 12px;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  padding: 14px 18px; border-radius: 10px;
+  font-family: var(--mono); font-size: 14px;
+  margin-top: 12px;
+}
+.cta-block .terminal .dollar { color: rgba(255, 255, 255, 0.4); }
+.cta-block .terminal .copy {
+  background: rgba(255, 255, 255, 0.1);
+  border: none; color: #fff;
+  padding: 4px 10px; font-size: 11px;
+  border-radius: 4px; font-family: var(--mono);
+}
+.cta-block .footnote {
+  margin-top: 32px; font-size: 12px;
+  color: rgba(255, 255, 255, 0.5);
+  font-family: var(--mono); letter-spacing: 0.06em;
+}
+
+.chip {
+  display: inline-flex; align-items: center;
+  height: 16px; padding: 0 6px;
+  border-radius: 999px;
+  font-size: 9px; font-weight: 500;
+}
+.chip-p0 { background: var(--p0-bg); color: var(--p0-fg); }
+.chip-p1 { background: var(--p1-bg); color: var(--p1-fg); }
+.chip-p2 { background: var(--p2-bg); color: var(--p2-fg); }
+.chip-p3 { background: var(--p3-bg); color: var(--p3-fg); }
+
+@media (max-width: 800px) {
+  .land-nav { padding: 18px 20px; flex-wrap: wrap; }
+  .land-section { padding: 64px 24px; }
+  .how-grid, .metrics-grid, .quotes-grid { grid-template-columns: 1fr; }
+  .land-dash-body { grid-template-columns: 1fr; }
+  .land-dash-side { display: none; }
+}


### PR DESCRIPTION
## Summary

Implements the GreatCTO Design handoff (light Ghibli theme) across all 3 surfaces and adds a public landing page.

- **`site/`** — new public landing (auto-deploys to GitHub Pages on merge to main via existing [`pages.yml`](.github/workflows/pages.yml)). Hero + landscape SVG, dashboard preview, How it works, six metrics, quotes, 17-agent table, CTA. Pure static, zero deps.
- **`packages/board/public/index.html`** — board admin rewritten in light theme. Sidebar nav (Tasks/Metrics/Share/Agents), Fraunces serif, kanban with ring/half/filled status dots, redesigned Metrics (3 hero + 4 secondary + utilization + activity feed), Share toggle. All `/api/tasks`, `/api/metrics`, `/api/share`, `/api/sse` wiring preserved.
- **`packages/board/public/share.html`** — public report rewritten. Glass card on landscape bg, 3 hero stats (Tasks shipped / LLM spend / vs FTE) + 3 secondary (AI time / QA / In progress), recently shipped, paused state. Template placeholders unchanged — server.mjs and Cloudflare worker unaffected.

Version bumped to **v1.0.158** in `package.json`, `plugin.json`, README badge.

## Test plan

- [ ] Merge to `main` → confirm `pages.yml` runs and landing publishes to GitHub Pages
- [ ] `npx great-cto board` locally → verify Kanban renders, SSE updates work, side panel opens, Metrics tab loads, Share toggle works
- [ ] Open `/api/share` URL in incognito → verify public report card renders with landscape bg
- [ ] Toggle share off → verify Cloudflare worker substitutes `{{PAUSED}}=true` and paused state shows