### PR TITLE
release: v2.8.2 — /board slash command + clickable resume UI

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "great_cto",
   "id": "great_cto",
   "description": "Engineering process for solo founders and teams up to 50 engineers. Agents do architecture, code review, QA, and security. You make two decisions per feature.",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "author": {
     "name": "Great CTO",
     "url": "https://github.com/avelikiy/great_cto"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,43 @@ All notable changes to great_cto are documented here.
 
 ---
 
+## v2.8.2 — 2026-05-14
+
+### Board UX + new `/board` slash command
+
+**New: `/board` slash command** (PR #33)
+
+Closes a UX gap: previously the only way to open the admin dashboard
+was running `great-cto board` in a terminal. Now `/board` from Claude
+Code:
+- Detects if board already running (0.1s curl check)
+- Starts it via `nohup ... & disown` if not (survives command exit)
+- Opens browser via `open` (macOS) / `xdg-open` (Linux)
+- Logs to `~/.great_cto/board.log`
+- Flags: `--port N` `--no-open` `--restart`
+
+**Board UI: clickable "Pick up where you left off" rows** (PR #34)
+
+Recent Verdicts + Decisions columns are now interactive. Click a row →
+opens a detail modal with:
+- Agent · verdict · timestamp header
+- Raw verdict line (monospace, preserved)
+- Parsed metadata chips (feature, task, cost)
+- Artefact buttons (`arch=`, `plan=`, `tm=`, `qa=`, etc.) → click opens
+  the path via `vscode://file/` URL scheme (works for VS Code, Cursor,
+  Windsurf, Claude Code)
+
+Decisions rows route to the linked bd task side-panel when known.
+
+Esc or backdrop click closes the modal.
+
+**Notes:**
+- No breaking changes
+- All 45 automated tests + 36 archetype fixtures + 456 pack assertions
+  still pass (537 verified contracts)
+
+---
+
 ## v2.8.1 — 2026-05-14
 
 ### Bug fixes + test pyramid expansion

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "great-cto",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "description": "One command install for the great_cto Claude Code plugin. Auto-detects your stack, picks the right archetype, bootstraps PROJECT.md.",
   "keywords": [
     "claude-code",


### PR DESCRIPTION
Patch release after v2.8.1. Two UX wins, no breaking changes.

## What's new

### 1. `/board` slash command (PR #33 already merged)
Auto-starts admin dashboard from Claude Code without opening a terminal.

### 2. Clickable 'Pick up where you left off' rows (PR #34 already merged)
Recent Verdicts + Decisions are now interactive — click → modal with parsed metadata + artefact open-in-editor links.

## Verification

- 45 automated tests
- 36 archetype detection fixtures
- 456 pack assertions
- **537 verified contracts**

ALL PASS.

## Diff

```
packages/cli/package.json     2.8.1 → 2.8.2
.claude-plugin/plugin.json    2.8.1 → 2.8.2
CHANGELOG.md                  + v2.8.2 entry
```

Tarball: `great-cto-2.8.2.tgz` (84.8 KB)