### PR TITLE
fix(board): edge-case clamps + legacy agent bucket; feat: Sprint 2 cross-provider harness

### DIFF
--- a/docs/testing/SPRINT-2-CROSS-PROVIDER.md
+++ b/docs/testing/SPRINT-2-CROSS-PROVIDER.md
@@ -1,0 +1,123 @@
+# Sprint 2 — Cross-provider testing (run instructions)
+
+Status: 🟡 **Harness ready, awaiting OpenRouter credits**
+
+## What it does
+
+Runs the same 5 representative archetypes through 4 different LLM
+providers to surface prompt assumptions that depend on Anthropic
+specifics. Produces a `✅/⚠️/❌` matrix per (archetype × model).
+
+## Why
+
+Today, all great_cto agents are tested against Sonnet 4 only. We don't
+know which agents:
+- Work equally well on Haiku 4.5 (4× cheaper)
+- Depend on Anthropic prompting style (would fail on GPT-5 / Gemini)
+- Need explicit phrasing to work cross-provider
+
+Cross-provider matrix gives data-driven answers — informs model selection
+per agent in production (e.g. "use Haiku for cli-reviewer, Sonnet for
+oracle-reviewer").
+
+## Coverage
+
+5 archetypes × 4 stages × 4 models = **80 LLM calls per full run**.
+
+**Archetypes** (selected to maximize reviewer diversity):
+- `fintech` (pci-reviewer — high regulatory specificity)
+- `healthcare` (healthcare-reviewer — newest agent)
+- `web3` (oracle-reviewer — Solidity-specific)
+- `enterprise-saas` (enterprise-saas-reviewer — multi-tenant complexity)
+- `cli-tool` (cli-reviewer — simplest baseline)
+
+**Models** (via OpenRouter):
+- `anthropic/claude-sonnet-4` — current baseline ($3/$15 per M)
+- `anthropic/claude-haiku-4.5` — 4× cheaper ($0.80/$4 per M)
+- `openai/gpt-5` — non-Anthropic ($10/$30 estimated)
+- `google/gemini-2.5-pro` — alternative ($1.25/$5)
+
+## Cost estimate
+
+| Model | Per-call cost | × 20 calls | Sub-total |
+|---|---|---|---|
+| Sonnet 4 | ~$0.15 | 20 | $3.00 |
+| Haiku 4.5 | ~$0.03 | 20 | $0.60 |
+| GPT-5 | ~$0.25 | 20 | $5.00 |
+| Gemini 2.5 Pro | ~$0.06 | 20 | $1.20 |
+| **Total** | | 80 calls | **~$9.80** |
+
+## Run instructions
+
+### Full run
+
+```bash
+export OPENROUTER_API_KEY=sk-or-v1-...
+node tests/openrouter-cross-provider.mjs
+```
+
+Output:
+1. Live console matrix with per-cell verdict + cost
+2. `docs/testing/CROSS-PROVIDER-MATRIX.md` written with full details
+
+### Subset runs (cheaper exploration)
+
+```bash
+# One model across all archetypes (~$3 for sonnet, $0.60 for haiku)
+node tests/openrouter-cross-provider.mjs --model sonnet
+
+# One archetype across all models (~$1.60 for fintech)
+node tests/openrouter-cross-provider.mjs --archetype fintech
+
+# Anthropic-only comparison (sonnet vs haiku, ~$3.60)
+node tests/openrouter-cross-provider.mjs --model sonnet,haiku
+```
+
+## Expected output
+
+Matrix like:
+
+```
+                  Sonnet 4   Haiku 4.5   GPT-5      Gemini 2.5
+fintech           ✅ PASS    ✅ PASS     ⚠️ PARTIAL  ✅ PASS
+healthcare        ✅ PASS    ⚠️ PARTIAL  ✅ PASS     ⚠️ PARTIAL
+web3              ✅ PASS    ❌ FAIL    ✅ PASS     ✅ PASS
+enterprise-saas   ✅ PASS    ✅ PASS    ✅ PASS     ✅ PASS
+cli-tool          ✅ PASS    ✅ PASS    ✅ PASS     ✅ PASS
+```
+
+What we'd learn:
+- "Haiku works for cli-tool / enterprise-saas / fintech but misses oracle subtleties → use Haiku for those, Sonnet for web3"
+- "GPT-5 partial on fintech → PCI prompt depends on Anthropic specifics"
+- "Gemini misses healthcare nuance → need HIPAA cues that don't rely on Claude-style implicit reasoning"
+
+## Cell-verdict semantics
+
+| Symbol | Meaning |
+|---|---|
+| ✅ **PASS** | Reviewer BLOCKED the planted-vuln stub + flagged ≥1 expected domain keyword |
+| ⚠️ **PARTIAL** | Reviewer BLOCKED but missed expected keywords (shallow review) |
+| ❌ **FAIL** | Reviewer APPROVED a clearly-deficient stub (bad outcome) |
+| 💥 **ERROR** | API call failed (rate limit, auth, etc.) |
+
+PASS is the only acceptable outcome. ⚠️ PARTIAL means the prompt
+works on that model but loses domain-specific rigor.
+
+## When to run
+
+- **Before changing an agent prompt that's been validated on Sonnet**
+- **When considering switching default model** (e.g. cost-optimisation
+  from Sonnet to Haiku)
+- **Quarterly** to detect drift as model providers update
+
+## What blocks this from running today
+
+OpenRouter credit balance. Each full run is ~$10. Top up at
+https://openrouter.ai/settings/credits, then run as above.
+
+## Files involved
+
+- `tests/openrouter-cross-provider.mjs` — runner (this Sprint)
+- `docs/testing/CROSS-PROVIDER-MATRIX.md` — output (created on each run,
+  overwrites previous)
+- `agents/<reviewer>.md` — prompts under test (unchanged)

--- a/packages/board/server.mjs
+++ b/packages/board/server.mjs
@@ -714,14 +714,28 @@ function getMetrics(cwd = process.cwd()) {
   // Agent utilization from verdicts.
   // Filter against canonical list of installed agents (~/.claude/agents/great_cto-*.md)
   // so a typo in a verdict line does not produce a phantom agent in the dashboard.
-  // Unknown agent names are bucketed under `unknown` (visible but flagged).
+  //
+  // Previously: non-canonical agents bucketed into `unknown` — which became
+  // the TOP agent in production dashboards because legacy verdict log files
+  // (backend.log, frontend.log, docs.log, ops.log, qa.log, security.log,
+  // test-agent.log) from older great_cto versions were all aggregated there.
+  // That hid real agent activity under a misleading label.
+  //
+  // Now: non-canonical agents are tracked separately (legacy_agent_runs)
+  // and surfaced as a single summary count, NOT individually polluting the
+  // agent-runs map. Users see honest specialist metrics + a cleanup hint.
   const canonicalAgents = getCanonicalAgents();
   const agentRuns = {};
+  const legacyAgentRuns = {};
   for (const v of verdicts) {
     if (!v.agent) continue;
-    const key = canonicalAgents.has(v.agent) ? v.agent : 'unknown';
-    agentRuns[key] = (agentRuns[key] || 0) + 1;
+    if (canonicalAgents.has(v.agent)) {
+      agentRuns[v.agent] = (agentRuns[v.agent] || 0) + 1;
+    } else {
+      legacyAgentRuns[v.agent] = (legacyAgentRuns[v.agent] || 0) + 1;
+    }
   }
+  const legacyAgentCount = Object.values(legacyAgentRuns).reduce((a, b) => a + b, 0);
 
   // Agent cost + time breakdown.
   //
@@ -846,6 +860,8 @@ function getMetrics(cwd = process.cwd()) {
     security: secStats,
     agents: agentRuns,
     agents_cost: agentsCost,
+    legacy_agent_runs: legacyAgentRuns,
+    legacy_agent_count: legacyAgentCount,
     verdicts: verdicts.slice(-20),
     recent_done: done.slice(-10).reverse(),
   };
@@ -1403,7 +1419,13 @@ const server = http.createServer(async (req, res) => {
 
   // Decisions log — global ADR-style log across all projects
   if (pathname === '/api/decisions') {
-    const limit = parseInt(url.searchParams.get('limit') || '20', 10);
+    // Clamp `limit` to [1, 200]. Same defensive pattern as /api/cost?days
+    // — handle ?limit=abc / ?limit=0 / ?limit=-5 / ?limit=999 deterministically.
+    const rawLimit = url.searchParams.get('limit');
+    const parsed = rawLimit != null ? parseInt(rawLimit, 10) : 20;
+    const limit = Number.isFinite(parsed) && parsed > 0
+      ? Math.min(parsed, 200)
+      : 20;
     res.writeHead(200, { 'Content-Type': 'application/json' });
     res.end(JSON.stringify(readDecisionsLog(limit)));
     return;
@@ -1423,9 +1445,20 @@ const server = http.createServer(async (req, res) => {
     return;
   }
 
-  // Cost history — daily LLM burn over N days
+  // Cost history — daily LLM burn over N days.
+  // Clamp `days` to [1, 365] to defend against:
+  //   ?days=abc       → NaN → default 30 (parseInt fallback to 30)
+  //   ?days=999       → 1000-bucket response (memory + payload bloat)
+  //   ?days=-5        → empty series, daily_avg = null in UI
+  //   ?days=0         → division-by-zero in daily_avg calc
+  // 365 is enough for "last year" views; anything bigger should use
+  // a different endpoint / batch query path.
   if (pathname === '/api/cost') {
-    const days = parseInt(url.searchParams.get('days') || '30', 10);
+    const rawDays = url.searchParams.get('days');
+    const parsed = rawDays != null ? parseInt(rawDays, 10) : 30;
+    const days = Number.isFinite(parsed) && parsed > 0
+      ? Math.min(parsed, 365)
+      : 30;
     res.writeHead(200, { 'Content-Type': 'application/json' });
     res.end(JSON.stringify(getCostHistory(cwd, days)));
     return;

--- a/tests/openrouter-cross-provider.mjs
+++ b/tests/openrouter-cross-provider.mjs
@@ -1,0 +1,361 @@
+// Cross-provider real-pipeline test via OpenRouter (Sprint 2).
+//
+// Runs the same 5 representative archetypes through 4 different LLM
+// providers (Sonnet 4 baseline + Haiku 4.5 + GPT-5 + Gemini 2.5 Pro)
+// to surface prompt assumptions that depend on Anthropic specifics.
+//
+// Output: docs/testing/CROSS-PROVIDER-MATRIX.md with a ✅/⚠️/❌ matrix
+// per (archetype × model). Plus per-cell cost + verdict.
+//
+// Usage:
+//   export OPENROUTER_API_KEY=sk-or-v1-...
+//   node tests/openrouter-cross-provider.mjs                       # all 5×4
+//   node tests/openrouter-cross-provider.mjs --model sonnet,haiku  # subset
+//   node tests/openrouter-cross-provider.mjs --archetype fintech   # single archetype
+//
+// Cost: ~$10 per full run (5 archetypes × 4 models × 4 stages = 80 calls).
+//   Sonnet 4    ~$3.00  (20 calls × $0.15)
+//   Haiku 4.5   ~$0.60  (20 calls × $0.03)
+//   GPT-5       ~$5.00  (20 calls × $0.25, estimate)
+//   Gemini 2.5  ~$1.20  (20 calls × $0.06)
+// DO NOT add to CI.
+
+import { writeFileSync, readFileSync, existsSync, mkdirSync, mkdtempSync, rmSync, appendFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { tmpdir } from 'node:os';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(__dirname, '..');
+const AGENTS_DIR = join(REPO_ROOT, 'agents');
+
+const API_KEY = process.env.OPENROUTER_API_KEY;
+if (!API_KEY) {
+  console.error('FATAL: OPENROUTER_API_KEY env var not set.');
+  process.exit(1);
+}
+
+// ── model registry ─────────────────────────────────────────────────────────
+
+const MODELS = {
+  sonnet:  { slug: 'anthropic/claude-sonnet-4',     priceIn: 3.0,  priceOut: 15.0, label: 'Sonnet 4'      },
+  haiku:   { slug: 'anthropic/claude-haiku-4.5',    priceIn: 0.8,  priceOut: 4.0,  label: 'Haiku 4.5'     },
+  gpt5:    { slug: 'openai/gpt-5',                  priceIn: 10.0, priceOut: 30.0, label: 'GPT-5'         },
+  gemini:  { slug: 'google/gemini-2.5-pro',         priceIn: 1.25, priceOut: 5.0,  label: 'Gemini 2.5 Pro'},
+};
+
+// ── 5 representative archetypes (covers full reviewer diversity) ──────────
+
+const ARCHETYPES = {
+  'fintech': {
+    feature: 'stripe-webhook-hmac',
+    task: 'Build /webhook endpoint that receives Stripe events, verifies HMAC signature via stripe-signature header, handles idempotency for replay protection.',
+    reviewer: 'pci-reviewer',
+    expectedBlocked: ['signature', 'idempot', 'pci', 'replay'],
+  },
+  'healthcare': {
+    feature: 'phi-export-endpoint',
+    task: 'GET /patient/:id/export returns FHIR JSON bundle. Requires JWT scope phi:export. All access logged to immutable audit table with reason field.',
+    reviewer: 'healthcare-reviewer',
+    expectedBlocked: ['audit', 'jwt', 'scope', 'phi', 'break-glass', 'baa'],
+  },
+  'web3': {
+    feature: 'chainlink-price-oracle',
+    task: 'Solidity 0.8 contract reading ETH/USD from Chainlink AggregatorV3Interface. Add staleness check (revert if updatedAt > 1h ago), decimals normalization, negative-price revert.',
+    reviewer: 'oracle-reviewer',
+    expectedBlocked: ['stale', 'decimal', 'negative', 'mev'],
+  },
+  'enterprise-saas': {
+    feature: 'tenant-onboarding',
+    task: 'POST /tenants — creates a new tenant with isolated DB schema, SCIM-provisioned admin, Stripe Customer. Multi-tenant Postgres RLS.',
+    reviewer: 'enterprise-saas-reviewer',
+    expectedBlocked: ['rls', 'isolation', 'tenant', 'scim', 'audit'],
+  },
+  'cli-tool': {
+    feature: 'env-vars-loader',
+    task: 'Node CLI reading .env file from disk, prints parsed vars as JSON. Support --help, --version, --json, NO_COLOR. Exit 0 success / 2 file-not-found.',
+    reviewer: 'cli-reviewer',
+    expectedBlocked: ['help', 'version', 'confirm', 'destructive', 'argv'],
+  },
+};
+
+// ── helpers ────────────────────────────────────────────────────────────────
+
+function loadAgentPrompt(name) {
+  const file = join(AGENTS_DIR, `${name}.md`);
+  if (!existsSync(file)) throw new Error(`agent prompt not found: ${file}`);
+  const raw = readFileSync(file, 'utf8');
+  const m = raw.match(/^---\n[\s\S]*?\n---\n([\s\S]*)$/);
+  return m ? m[1].trim() : raw;
+}
+
+async function callOR({ system, user, model, label }) {
+  const t0 = Date.now();
+  const r = await fetch('https://openrouter.ai/api/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${API_KEY}`,
+      'Content-Type': 'application/json',
+      'HTTP-Referer': 'https://github.com/avelikiy/great_cto',
+      'X-Title': 'great_cto cross-provider matrix',
+    },
+    body: JSON.stringify({
+      model: model.slug,
+      max_tokens: 1500,
+      messages: [{ role: 'system', content: system }, { role: 'user', content: user }],
+    }),
+  });
+  if (!r.ok) {
+    const errBody = await r.text();
+    throw new Error(`${model.slug} ${r.status}: ${errBody.slice(0, 250)}`);
+  }
+  const data = await r.json();
+  const u = data.usage || {};
+  // Per-million-token pricing → per-call cost
+  const cost = ((u.prompt_tokens || 0) / 1_000_000) * model.priceIn
+             + ((u.completion_tokens || 0) / 1_000_000) * model.priceOut;
+  return {
+    content: data.choices?.[0]?.message?.content || '',
+    cost,
+    promptTokens: u.prompt_tokens || 0,
+    completionTokens: u.completion_tokens || 0,
+    elapsed: ((Date.now() - t0) / 1000).toFixed(1),
+  };
+}
+
+function parseVerdict(text) {
+  const strict = text.match(/VERDICT:\s*(\w+)\s+reason="([^"]+)"/i);
+  if (strict) return { verdict: strict[1].toUpperCase(), reason: strict[2] };
+  const loose = text.match(/\*?\*?Verdict\*?\*?:?\s*\*?\*?\s*(APPROVED|BLOCKED|PASS|FAIL|DONE)\b/i);
+  return { verdict: loose?.[1]?.toUpperCase() || 'UNKNOWN', reason: '' };
+}
+
+function parseFiles(text) {
+  const out = [];
+  const re = /<file path="([^"]+)">([\s\S]*?)<\/file>/g;
+  let m;
+  while ((m = re.exec(text))) out.push({ path: m[1].trim(), content: m[2].trim() });
+  return out;
+}
+
+const ORCH_WRAPPER = `
+
+---
+AUTOMATED CROSS-PROVIDER TEST — IMPORTANT:
+- Emit files as XML blocks: <file path="docs/foo.md">CONTENT</file>
+- End with: VERDICT: <APPROVED|BLOCKED|DONE|PASS> reason="<short>"
+- Output under 1200 tokens. Be CONCISE.
+---
+`;
+
+// ── runner ─────────────────────────────────────────────────────────────────
+
+async function runCell({ archetypeKey, modelKey }) {
+  const cfg = ARCHETYPES[archetypeKey];
+  const model = MODELS[modelKey];
+  if (!cfg || !model) throw new Error(`bad combo: ${archetypeKey} × ${modelKey}`);
+
+  let totalCost = 0;
+  let promptTokens = 0;
+  let completionTokens = 0;
+  const stages = [];
+  let lastImpl = '';
+
+  // Stage 1: architect
+  const arch = await callOR({
+    system: loadAgentPrompt('architect') + ORCH_WRAPPER,
+    user: `Archetype: ${archetypeKey}\nFeature: "${cfg.feature}"\n\n${cfg.task}\n\nProduce SHORT ARCH doc + ADR.`,
+    model, label: 'architect',
+  });
+  totalCost += arch.cost; promptTokens += arch.promptTokens; completionTokens += arch.completionTokens;
+  stages.push({ stage: 'architect', verdict: parseVerdict(arch.content).verdict, cost: arch.cost });
+
+  // Stage 2: pm
+  const archDoc = parseFiles(arch.content).find(f => f.path.includes('ARCH'))?.content || '';
+  const pm = await callOR({
+    system: loadAgentPrompt('pm') + ORCH_WRAPPER,
+    user: `Archetype: ${archetypeKey}\nFeature: "${cfg.feature}"\n\nARCH:\n${archDoc.slice(0, 1000)}\n\nProduce 3-task PLAN doc.`,
+    model, label: 'pm',
+  });
+  totalCost += pm.cost; promptTokens += pm.promptTokens; completionTokens += pm.completionTokens;
+  stages.push({ stage: 'pm', verdict: parseVerdict(pm.content).verdict, cost: pm.cost });
+
+  // Stage 3: senior-dev
+  const planDoc = parseFiles(pm.content).find(f => f.path.includes('PLAN'))?.content || '';
+  const dev = await callOR({
+    system: loadAgentPrompt('senior-dev') + ORCH_WRAPPER,
+    user: `Archetype: ${archetypeKey}\nFeature: "${cfg.feature}"\n\nPLAN:\n${planDoc.slice(0, 1000)}\n\nImplement task #1 as a single file in src/. ~30 lines + 1 test.`,
+    model, label: 'senior-dev',
+  });
+  totalCost += dev.cost; promptTokens += dev.promptTokens; completionTokens += dev.completionTokens;
+  stages.push({ stage: 'senior-dev', verdict: parseVerdict(dev.content).verdict, cost: dev.cost });
+  lastImpl = parseFiles(dev.content).find(f => f.path.startsWith('src/'))?.content || '(no impl)';
+
+  // Stage 4: archetype reviewer
+  const review = await callOR({
+    system: loadAgentPrompt(cfg.reviewer) + ORCH_WRAPPER,
+    user: `Archetype: ${archetypeKey}\nFeature: "${cfg.feature}"\n\nReview this implementation:\n\`\`\`\n${lastImpl.slice(0, 1500)}\n\`\`\`\n\nFocus on YOUR domain. Emit VERDICT.`,
+    model, label: cfg.reviewer,
+  });
+  totalCost += review.cost; promptTokens += review.promptTokens; completionTokens += review.completionTokens;
+  const { verdict: reviewerVerdict } = parseVerdict(review.content);
+  stages.push({ stage: cfg.reviewer, verdict: reviewerVerdict, cost: review.cost });
+
+  // Did reviewer flag expected concerns?
+  const lower = review.content.toLowerCase();
+  const flagged = cfg.expectedBlocked.filter(kw => lower.includes(kw));
+
+  // Cell verdict:
+  //   ✅ PASS  — reviewer BLOCKED + flagged ≥1 expected keyword
+  //   ⚠️ partial — reviewer BLOCKED but missed keywords (shallow review)
+  //   ❌ FAIL — reviewer APPROVED a clearly-deficient stub
+  let cellVerdict;
+  if (reviewerVerdict === 'BLOCKED' && flagged.length > 0) cellVerdict = 'PASS';
+  else if (reviewerVerdict === 'BLOCKED') cellVerdict = 'PARTIAL';
+  else cellVerdict = 'FAIL';
+
+  return {
+    archetype: archetypeKey, model: modelKey, modelLabel: model.label,
+    cellVerdict, reviewerVerdict, flagged, stages,
+    totalCost, promptTokens, completionTokens,
+  };
+}
+
+// ── main ───────────────────────────────────────────────────────────────────
+
+function parseArgs() {
+  const argv = process.argv.slice(2);
+  let models = Object.keys(MODELS);
+  let archetypes = Object.keys(ARCHETYPES);
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--model' && argv[i + 1]) {
+      models = argv[++i].split(',').map(s => s.trim()).filter(m => MODELS[m]);
+    } else if (argv[i] === '--archetype' && argv[i + 1]) {
+      archetypes = argv[++i].split(',').map(s => s.trim()).filter(a => ARCHETYPES[a]);
+    }
+  }
+  return { models, archetypes };
+}
+
+async function main() {
+  const { models, archetypes } = parseArgs();
+
+  console.log('═══════════════════════════════════════════════════════════════');
+  console.log(' Cross-provider matrix — real-LLM E2E');
+  console.log(`   models:     ${models.map(m => MODELS[m].label).join(', ')}`);
+  console.log(`   archetypes: ${archetypes.join(', ')}`);
+  console.log(`   total cells: ${models.length * archetypes.length}`);
+  console.log('═══════════════════════════════════════════════════════════════\n');
+
+  const results = [];
+  let totalCost = 0;
+
+  for (const archetype of archetypes) {
+    for (const model of models) {
+      process.stdout.write(`▸ [${archetype}/${MODELS[model].label.padEnd(15)}] running ${4} stages... `);
+      try {
+        const r = await runCell({ archetypeKey: archetype, modelKey: model });
+        totalCost += r.totalCost;
+        const symbol = r.cellVerdict === 'PASS' ? '✅'
+                     : r.cellVerdict === 'PARTIAL' ? '⚠️'
+                     : '❌';
+        console.log(`${symbol} verdict=${r.reviewerVerdict.padEnd(8)} flagged=[${r.flagged.join(',')}]  $${r.totalCost.toFixed(4)}`);
+        results.push(r);
+      } catch (e) {
+        console.log(`💥 ${e.message.slice(0, 100)}`);
+        results.push({ archetype, model, modelLabel: MODELS[model].label, error: e.message, cellVerdict: 'ERROR', totalCost: 0 });
+      }
+    }
+  }
+
+  console.log('\n═══════════════════════════════════════════════════════════════');
+  console.log(' Matrix');
+  console.log('═══════════════════════════════════════════════════════════════\n');
+
+  // Header
+  const hdr = '  archetype'.padEnd(20) + models.map(m => MODELS[m].label.padEnd(16)).join('');
+  console.log(hdr);
+  console.log('  ' + '─'.repeat(20 + models.length * 16));
+  for (const archetype of archetypes) {
+    let row = '  ' + archetype.padEnd(18);
+    for (const model of models) {
+      const cell = results.find(r => r.archetype === archetype && r.model === model);
+      if (!cell || cell.error) { row += '💥 ERROR'.padEnd(16); continue; }
+      const sym = cell.cellVerdict === 'PASS' ? '✅'
+                : cell.cellVerdict === 'PARTIAL' ? '⚠️'
+                : '❌';
+      row += `${sym} ${cell.cellVerdict.padEnd(7)} `.padEnd(16);
+    }
+    console.log(row);
+  }
+
+  // Per-model summary
+  console.log('\nPer-model:');
+  for (const model of models) {
+    const cells = results.filter(r => r.model === model);
+    const pass = cells.filter(c => c.cellVerdict === 'PASS').length;
+    const partial = cells.filter(c => c.cellVerdict === 'PARTIAL').length;
+    const fail = cells.filter(c => c.cellVerdict === 'FAIL').length;
+    const cost = cells.reduce((a, c) => a + (c.totalCost || 0), 0);
+    console.log(`  ${MODELS[model].label.padEnd(15)} ${pass}/${cells.length} pass · ${partial} partial · ${fail} fail · $${cost.toFixed(4)}`);
+  }
+
+  console.log(`\nGrand total cost: $${totalCost.toFixed(4)}`);
+
+  // Write matrix doc
+  const matrixDoc = generateMatrixDoc(results, models, archetypes, totalCost);
+  const outPath = join(REPO_ROOT, 'docs', 'testing', 'CROSS-PROVIDER-MATRIX.md');
+  mkdirSync(dirname(outPath), { recursive: true });
+  writeFileSync(outPath, matrixDoc);
+  console.log(`\nMatrix doc: ${outPath}`);
+}
+
+function generateMatrixDoc(results, models, archetypes, totalCost) {
+  const now = new Date().toISOString();
+  let out = `# Cross-provider matrix — ${now.slice(0, 10)}\n\n`;
+  out += `Generated by \`tests/openrouter-cross-provider.mjs\`.\n\n`;
+  out += `**Total cost:** $${totalCost.toFixed(4)}\n\n`;
+  out += `## Matrix\n\n`;
+  out += `| Archetype | ${models.map(m => MODELS[m].label).join(' | ')} |\n`;
+  out += `|---|${models.map(() => '---').join('|')}|\n`;
+  for (const archetype of archetypes) {
+    let row = `| ${archetype} `;
+    for (const model of models) {
+      const cell = results.find(r => r.archetype === archetype && r.model === model);
+      if (!cell || cell.error) { row += `| 💥 `; continue; }
+      const sym = cell.cellVerdict === 'PASS' ? '✅' : cell.cellVerdict === 'PARTIAL' ? '⚠️' : '❌';
+      row += `| ${sym} ${cell.cellVerdict} `;
+    }
+    out += row + '|\n';
+  }
+  out += `\n**Legend:**\n- ✅ PASS — reviewer BLOCKED + flagged ≥1 expected keyword\n`;
+  out += `- ⚠️ PARTIAL — reviewer BLOCKED but missed expected keywords (shallow review)\n`;
+  out += `- ❌ FAIL — reviewer APPROVED a clearly-deficient stub\n\n`;
+  out += `## Per-model summary\n\n`;
+  out += `| Model | Pass | Partial | Fail | Cost |\n|---|---|---|---|---|\n`;
+  for (const model of models) {
+    const cells = results.filter(r => r.model === model);
+    const pass = cells.filter(c => c.cellVerdict === 'PASS').length;
+    const partial = cells.filter(c => c.cellVerdict === 'PARTIAL').length;
+    const fail = cells.filter(c => c.cellVerdict === 'FAIL').length;
+    const cost = cells.reduce((a, c) => a + (c.totalCost || 0), 0);
+    out += `| ${MODELS[model].label} | ${pass}/${cells.length} | ${partial} | ${fail} | $${cost.toFixed(4)} |\n`;
+  }
+  out += `\n## Per-cell detail\n\n`;
+  for (const r of results) {
+    if (r.error) { out += `### ${r.archetype} × ${r.modelLabel}\n\n💥 ERROR: ${r.error}\n\n`; continue; }
+    out += `### ${r.archetype} × ${r.modelLabel}\n\n`;
+    out += `- Cell verdict: **${r.cellVerdict}**\n`;
+    out += `- Reviewer verdict: ${r.reviewerVerdict}\n`;
+    out += `- Flagged keywords: ${r.flagged.length > 0 ? r.flagged.map(k => `\`${k}\``).join(', ') : '_(none)_'}\n`;
+    out += `- Cost: $${r.totalCost.toFixed(4)} (${r.promptTokens}p / ${r.completionTokens}c tokens)\n`;
+    out += `- Stages: ${r.stages.map(s => `${s.stage}:${s.verdict}`).join(' → ')}\n\n`;
+  }
+  return out;
+}
+
+main().catch(e => {
+  console.error('\nFATAL:', e.message);
+  process.exit(1);
+});

--- a/tests/pipeline-contracts.test.mjs
+++ b/tests/pipeline-contracts.test.mjs
@@ -359,6 +359,142 @@ test('BH-2: savings_x is null (not 0) when human estimate is missing', async () 
   }
 });
 
+// ── BH-3: legacy agent bucket separation ────────────────────────────────────
+
+test('BH-3: non-canonical agents go to legacy_agent_runs, not the main agent map', async () => {
+  // Previously: non-canonical verdict files (backend.log, frontend.log,
+  // docs.log, ops.log, qa.log, security.log) were bucketed under
+  // agents['unknown']. That became the TOP entry in /api/metrics.agents,
+  // hiding real specialist activity. Now they go into a separate
+  // legacy_agent_runs field, surfaced honestly.
+
+  const home = mkdtempSync(join(tmpdir(), 'bh3-home-'));
+  const project = mkdtempSync(join(tmpdir(), 'bh3-proj-'));
+  try {
+    mkdirSync(join(home, '.great_cto', 'verdicts'), { recursive: true });
+    mkdirSync(join(project, '.great_cto'), { recursive: true });
+    writeFileSync(join(project, '.great_cto', 'PROJECT.md'), 'archetype: web-service\n');
+
+    const today = new Date().toISOString().slice(0, 10);
+    // 1 canonical agent verdict
+    writeFileSync(join(home, '.great_cto', 'verdicts', 'architect.log'),
+      `${today}T10:00:00Z APPROVED feature=test cost=$0.42\n`);
+    // 2 NON-canonical (legacy) verdicts
+    writeFileSync(join(home, '.great_cto', 'verdicts', 'backend.log'),
+      `${today}T10:00:00Z DONE feature=test cost=$0.10\n`);
+    writeFileSync(join(home, '.great_cto', 'verdicts', 'frontend.log'),
+      `${today}T11:00:00Z DONE feature=test cost=$0.10\n`);
+
+    const port = 34300 + Math.floor(Math.random() * 100);
+    const board = spawn('node', [
+      join(__dirname, '..', 'packages', 'cli', 'index.mjs'),
+      'board', '--port', String(port), '--no-open',
+    ], {
+      cwd: project, env: { ...process.env, HOME: home },
+      stdio: ['ignore', 'pipe', 'pipe'], detached: true,
+    });
+
+    try {
+      // Wait for board ready
+      const deadline = Date.now() + 8000;
+      while (Date.now() < deadline) {
+        try {
+          const r = await fetch(`http://127.0.0.1:${port}/api/projects`);
+          if (r.ok || r.status === 404) break;
+        } catch {}
+        await new Promise(r => setTimeout(r, 150));
+      }
+
+      const r = await fetch(`http://127.0.0.1:${port}/api/metrics`);
+      const data = await r.json();
+      const agents = data.agents || {};
+      const legacy = data.legacy_agent_runs || {};
+
+      // Architect should appear in canonical agents
+      // (only if architect is in ~/.claude/agents/great_cto-* — may not be
+      // in test home, so this is conditional)
+      // The KEY contract: 'unknown' should NOT appear as an entry in agents
+      assert.ok(!('unknown' in agents),
+        `'unknown' key should NOT appear in canonical agents map. ` +
+        `Got keys: ${Object.keys(agents).join(', ')}`);
+
+      // legacy_agent_count must be defined (even if 0)
+      assert.equal(typeof data.legacy_agent_count, 'number',
+        'legacy_agent_count must be a number');
+    } finally {
+      try { process.kill(-board.pid, 'SIGKILL'); } catch {}
+      try { board.kill('SIGKILL'); } catch {}
+    }
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+    rmSync(project, { recursive: true, force: true });
+  }
+});
+
+// ── BH-4: query-param clamping (days, limit) ───────────────────────────────
+
+test('BH-4: /api/cost?days clamps malformed input to safe defaults', async () => {
+  // Pre-fix: ?days=999 returned 1000 buckets (memory bloat);
+  //          ?days=abc returned 0 buckets + daily_avg=null;
+  //          ?days=-5 returned 0 buckets silently.
+  // Post-fix: clamp to [1, 365]; non-numeric → default 30.
+
+  const home = mkdtempSync(join(tmpdir(), 'bh4a-home-'));
+  const project = mkdtempSync(join(tmpdir(), 'bh4a-proj-'));
+  try {
+    mkdirSync(join(home, '.great_cto', 'verdicts'), { recursive: true });
+    mkdirSync(join(project, '.great_cto'), { recursive: true });
+    writeFileSync(join(project, '.great_cto', 'PROJECT.md'), 'archetype: web-service\n');
+
+    const port = 34400 + Math.floor(Math.random() * 100);
+    const board = spawn('node', [
+      join(__dirname, '..', 'packages', 'cli', 'index.mjs'),
+      'board', '--port', String(port), '--no-open',
+    ], {
+      cwd: project, env: { ...process.env, HOME: home },
+      stdio: ['ignore', 'pipe', 'pipe'], detached: true,
+    });
+
+    try {
+      const deadline = Date.now() + 8000;
+      while (Date.now() < deadline) {
+        try {
+          const r = await fetch(`http://127.0.0.1:${port}/api/projects`);
+          if (r.ok || r.status === 404) break;
+        } catch {}
+        await new Promise(r => setTimeout(r, 150));
+      }
+
+      // ?days=999 → clamped to 365 (366 buckets = 365 + today)
+      const big = await (await fetch(`http://127.0.0.1:${port}/api/cost?days=999`)).json();
+      assert.ok(big.series.length <= 366,
+        `?days=999 should clamp series to ≤366, got ${big.series.length}`);
+
+      // ?days=abc → fallback to default 30 → 31 buckets
+      const bad = await (await fetch(`http://127.0.0.1:${port}/api/cost?days=abc`)).json();
+      assert.equal(bad.series.length, 31,
+        `?days=abc should fallback to 30 → 31 buckets, got ${bad.series.length}`);
+
+      // ?days=-5 → fallback to default 30 → 31 buckets
+      const neg = await (await fetch(`http://127.0.0.1:${port}/api/cost?days=-5`)).json();
+      assert.equal(neg.series.length, 31,
+        `?days=-5 should fallback to 30 → 31 buckets, got ${neg.series.length}`);
+
+      // daily_avg should always be a finite number (no null/NaN)
+      for (const data of [big, bad, neg]) {
+        assert.ok(Number.isFinite(data.daily_avg),
+          `daily_avg must be a finite number, got ${data.daily_avg}`);
+      }
+    } finally {
+      try { process.kill(-board.pid, 'SIGKILL'); } catch {}
+      try { board.kill('SIGKILL'); } catch {}
+    }
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+    rmSync(project, { recursive: true, force: true });
+  }
+});
+
 test('X1 TDD: senior-dev RED → GREEN cycle works on a tiny stub', async () => {
   // We don't drive a real LLM here (that's X6/multi-archetype). Instead,
   // verify the TDD-cycle scaffolding works: scenario where impl is missing


### PR DESCRIPTION
## Bugs fixed (via bug-hunt in production board)

### BH-3: `unknown` agent dominated `/api/metrics`
- **Before:** non-canonical verdict files (backend, frontend, docs, ops, qa, security, test-agent) all bucketed as `unknown: 15` — TOP entry in metrics, hiding real specialists.
- **After:** separate `legacy_agent_runs` map + `legacy_agent_count`. Canonical agents shown honestly (architect=8, senior-dev=6, ...).

### BH-4: query-param clamping
`/api/cost?days=999` returned 1000 buckets · `?days=abc` returned `daily_avg: null` · `?days=-5` silently returned 0 buckets.
- **After:** clamp to `[1, 365]`, fallback to 30 for malformed. Same pattern applied to `/api/decisions?limit` (clamp to `[1, 200]`, fallback 20).

## Regression tests (+4 cases)

In `tests/pipeline-contracts.test.mjs`:
- BH-3: 'unknown' not in metrics.agents
- BH-4: 3 sub-cases for days clamping

**Total automated: 49 cases (was 45). All pass.**

## Sprint 2 prep: `tests/openrouter-cross-provider.mjs`

Cross-provider matrix harness — 5 archetypes × 4 models (Sonnet 4 + Haiku 4.5 + GPT-5 + Gemini 2.5 Pro) = 80 LLM calls. Generates `docs/testing/CROSS-PROVIDER-MATRIX.md` with ✅/⚠️/❌ per cell.

**Cost:** ~$9.80 full run. Subset runs supported via `--model` / `--archetype` flags.

**Status:** harness ready, waiting on OpenRouter credit top-up.

## Verification

- All 49 automated tests pass
- Board running locally: http://localhost:3141/
- No breaking API changes (clamping is internal; new fields are optional)