### PR TITLE
fix(board): POST /api/tasks input validation (BH-6/7/8)

### DIFF
--- a/packages/board/server.mjs
+++ b/packages/board/server.mjs
@@ -1469,11 +1469,48 @@ const server = http.createServer(async (req, res) => {
     let body = '';
     req.on('data', c => body += c);
     req.on('end', () => {
+      // Validation hardening (2026-05-15): bug-hunt found 3 ways to crash this
+      // endpoint or silently drop bad input:
+      //   - invalid JSON body → 500 (parser exception in catch → 500)
+      //   - 10K-char title → 500 (bd argv too long)
+      //   - priority=99 → 200 (silently ignored, user thinks it worked)
+      // Each is now an explicit 400 with structured error.
+      let parsed;
       try {
-        const { title, description, priority, agent, labels } = JSON.parse(body || '{}');
-        if (!title || !title.trim()) {
+        parsed = JSON.parse(body || '{}');
+      } catch (e) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'invalid_json', message: String(e.message || e) }));
+        return;
+      }
+      try {
+        const { title, description, priority, agent, labels } = parsed;
+        if (!title || typeof title !== 'string' || !title.trim()) {
           res.writeHead(400, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ error: 'title required' }));
+          return;
+        }
+        // Title length bound: bd issue titles practically cap around 200 chars;
+        // 500 is a safe ceiling that catches obvious junk while allowing
+        // long-form summaries when warranted.
+        if (title.length > 500) {
+          res.writeHead(400, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({
+            error: 'title_too_long',
+            message: `Title is ${title.length} chars; max 500 allowed.`,
+            length: title.length,
+          }));
+          return;
+        }
+        // Priority must be in P0–P3 if specified. Silent ignore was hiding
+        // typos like priority=11 (probably meant P1).
+        if (priority != null && (typeof priority !== 'number' || priority < 0 || priority > 3)) {
+          res.writeHead(400, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({
+            error: 'invalid_priority',
+            message: 'priority must be an integer in [0, 3] (P0–P3).',
+            received: priority,
+          }));
           return;
         }
         const beadsErr = checkBeadsAvailable(cwd);

--- a/tests/pipeline-contracts.test.mjs
+++ b/tests/pipeline-contracts.test.mjs
@@ -495,6 +495,95 @@ test('BH-4: /api/cost?days clamps malformed input to safe defaults', async () =>
   }
 });
 
+// ── BH-6 / BH-7 / BH-8: POST /api/tasks input validation ──────────────────
+
+test('BH-6/7/8: POST /api/tasks rejects malformed input with 400 (not 500)', async () => {
+  // Bug-hunt 2026-05-15 found 3 ways to crash POST /api/tasks:
+  //   BH-6: invalid JSON body → 500 (parser exception bubbled up)
+  //   BH-7: 10K-char title → 500 (bd argv too long; needed cap)
+  //   BH-8: priority=99 → 200 silently ignored (typo "11" meant "P1"
+  //          dropped on the floor — user thinks it worked)
+  // Each is now an explicit 400 with a structured error.
+
+  // Build a real bd-initialised project so /api/tasks can reach the handler
+  const home = mkdtempSync(join(tmpdir(), 'bh-tasks-home-'));
+  const project = mkdtempSync(join(tmpdir(), 'bh-tasks-proj-'));
+  try {
+    mkdirSync(join(home, '.great_cto', 'verdicts'), { recursive: true });
+    mkdirSync(join(project, '.great_cto'), { recursive: true });
+    writeFileSync(join(project, '.great_cto', 'PROJECT.md'), 'archetype: web-service\n');
+    const init = spawnSync('bd', ['init'], { cwd: project, encoding: 'utf8' });
+    if (init.status !== 0) {
+      console.log('  skipped: bd not available');
+      return;
+    }
+
+    const port = 34500 + Math.floor(Math.random() * 100);
+    const board = spawn('node', [
+      join(__dirname, '..', 'packages', 'cli', 'index.mjs'),
+      'board', '--port', String(port), '--no-open',
+    ], {
+      cwd: project, env: { ...process.env, HOME: home },
+      stdio: ['ignore', 'pipe', 'pipe'], detached: true,
+    });
+
+    try {
+      // Wait for board ready
+      const deadline = Date.now() + 8000;
+      while (Date.now() < deadline) {
+        try {
+          const r = await fetch(`http://127.0.0.1:${port}/api/projects`);
+          if (r.ok || r.status === 404) break;
+        } catch {}
+        await new Promise(r => setTimeout(r, 150));
+      }
+
+      const post = async (body) =>
+        fetch(`http://127.0.0.1:${port}/api/tasks`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body,
+        });
+
+      // BH-6: invalid JSON → 400
+      const r1 = await post('not-valid-json{');
+      assert.equal(r1.status, 400,
+        `BH-6: invalid JSON should yield HTTP 400, got ${r1.status}`);
+      const e1 = await r1.json();
+      assert.equal(e1.error, 'invalid_json',
+        `BH-6: error code should be 'invalid_json', got '${e1.error}'`);
+
+      // BH-7: too-long title → 400
+      const longTitle = 'a'.repeat(600);
+      const r2 = await post(JSON.stringify({ title: longTitle }));
+      assert.equal(r2.status, 400,
+        `BH-7: 600-char title should yield HTTP 400, got ${r2.status}`);
+      const e2 = await r2.json();
+      assert.equal(e2.error, 'title_too_long',
+        `BH-7: error code should be 'title_too_long', got '${e2.error}'`);
+
+      // BH-8: priority=99 → 400
+      const r3 = await post(JSON.stringify({ title: 'ok', priority: 99 }));
+      assert.equal(r3.status, 400,
+        `BH-8: priority=99 should yield HTTP 400, got ${r3.status}`);
+      const e3 = await r3.json();
+      assert.equal(e3.error, 'invalid_priority',
+        `BH-8: error code should be 'invalid_priority', got '${e3.error}'`);
+
+      // Sanity: valid input still works (priority=2 OK, normal title OK)
+      const r4 = await post(JSON.stringify({ title: 'a valid task', priority: 2 }));
+      assert.equal(r4.status, 200,
+        `Valid input should still succeed, got HTTP ${r4.status}`);
+    } finally {
+      try { process.kill(-board.pid, 'SIGKILL'); } catch {}
+      try { board.kill('SIGKILL'); } catch {}
+    }
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+    rmSync(project, { recursive: true, force: true });
+  }
+});
+
 test('X1 TDD: senior-dev RED → GREEN cycle works on a tiny stub', async () => {
   // We don't drive a real LLM here (that's X6/multi-archetype). Instead,
   // verify the TDD-cycle scaffolding works: scenario where impl is missing


### PR DESCRIPTION
Three bugs found while bug-hunting the production board.

## Bugs fixed

| # | Symptom | Before | After |
|---|---|---|---|
| **BH-6** | Invalid JSON body | HTTP 500 | **HTTP 400** `error: invalid_json` |
| **BH-7** | 10K-char title | HTTP 500 (bd argv crash) | **HTTP 400** `error: title_too_long` |
| **BH-8** | `priority=99` | HTTP 200 silently ignored | **HTTP 400** `error: invalid_priority` |

BH-8 is the sneakiest — user types `priority: 11` (typo, meant P1) and gets back `{ok: true, id: ...}`. Task created with default priority. They think it worked. Silent data loss.

## Regression test

`tests/pipeline-contracts.test.mjs` +1 case (`BH-6/7/8`) — 4 assertions covering all 3 bug paths + a valid-input sanity check.

## Verification

- 48 automated tests pass (was 45 — added 3 via BH-3/BH-4/BH-6 earlier)
- 36 archetype fixtures
- 456 pack assertions

## Files

```
packages/board/server.mjs            ~30 lines validation added
tests/pipeline-contracts.test.mjs   ~80 lines test added
```

No breaking API changes — clients sending valid input see no difference; bad-input clients now get explicit 400s instead of opaque 500s.