### PR TITLE
fix(board): metrics & report — 30d windows, suppress tautological savings, drop global-verdict fallback

### DIFF
--- a/packages/board/public/index.html
+++ b/packages/board/public/index.html
@@ -3085,33 +3085,43 @@ async function updateTaskPriority(id, priority) {
 function renderDashboard(m) {
   const llmUsd = m.cost?.llm_usd ?? 0;
   const humanUsd = m.cost?.human_usd ?? 0;
-  const savingsX = m.cost?.savings_x ?? 0;
+  const savingsX = m.cost?.savings_x;
+  const rateRatio = m.cost?.rate_ratio;
   const done = m.tasks?.done ?? 0;
   const avgMin = m.avg_completion_min ?? 0;
+  const cycleStat = m.cycle_time_stat === 'median_30d' ? 'Median cycle (30d)' : 'Avg cycle time';
 
   const fromTasks = m.cost?.source === 'tasks';
+  const windowDays = m.cost?.window_days;
+  const llmTrend = humanUsd > 0
+    ? `vs humans: $${fmtMoney(humanUsd)}${fromTasks ? ` (est. from tasks · ${windowDays ?? 30}d)` : ''}`
+    : 'no plans or tasks yet';
   const hero = [
     { v: done || '—', sub: 'shipped', label: 'Tasks done', trend: `+${m.velocity?.this_week ?? 0} this week` },
     {
       v: llmUsd > 0 ? `$${llmUsd.toFixed(2)}` : '—',
       sub: '',
       label: 'LLM spend',
-      trend: humanUsd > 0
-        ? `vs humans: $${fmtMoney(humanUsd)}${fromTasks ? ' (est. from tasks)' : ''}`
-        : 'no plans or tasks yet',
+      trend: llmTrend,
       cls: 'amber',
     },
-    {
-      v: savingsX > 0 ? savingsX : '—',
-      sub: savingsX > 0 ? '×' : '',
-      label: 'Cost savings vs FTE',
-      trend: savingsX > 0
-        ? (fromTasks
-            ? `${savingsX}× faster, est. at $0.30/AI-hr · $150/human-hr`
-            : `${savingsX}× cheaper (from PLAN-*.md figures)`)
-        : 'add docs/plans/PLAN-*.md for precise figures',
-      cls: 'green',
-    },
+    (savingsX != null && savingsX > 0)
+      ? {
+          v: savingsX,
+          sub: '×',
+          label: 'Cost savings vs FTE',
+          trend: `${savingsX}× cheaper (from PLAN-*.md figures)`,
+          cls: 'green',
+        }
+      : {
+          v: '—',
+          sub: '',
+          label: 'Cost savings vs FTE',
+          trend: fromTasks && rateRatio
+            ? `rate ratio ${rateRatio}× (no measured savings — add docs/plans/PLAN-*.md)`
+            : 'add docs/plans/PLAN-*.md for precise figures',
+          cls: '',
+        },
   ];
   document.getElementById('mp-hero').innerHTML = hero.map(s => `
     <div class="metric-card ${s.cls || ''}">
@@ -3121,7 +3131,7 @@ function renderDashboard(m) {
     </div>`).join('');
 
   const secondary = [
-    { v: avgMin ? `${avgMin}` : '—', sub: avgMin ? 'm' : '', label: 'Avg cycle time' },
+    { v: avgMin ? `${avgMin}` : '—', sub: avgMin ? 'm' : '', label: cycleStat },
     { v: m.qa?.pass_rate != null ? m.qa.pass_rate : '—', sub: m.qa?.pass_rate != null ? '%' : '', label: m.qa?.pass_rate != null ? 'QA pass rate' : 'QA — run /qa', cls: 'green' },
     { v: m.security?.blocked ?? 0, sub: '', label: 'Open security blocks', cls: m.security?.blocked ? 'red' : 'green' },
     { v: m.tasks?.in_progress ?? 0, sub: '', label: 'In progress', cls: 'amber' },

--- a/packages/board/public/share.html
+++ b/packages/board/public/share.html
@@ -589,7 +589,12 @@ if (paused) {
   // Use whichever cost source has data
   const effectiveLlmUsd   = llmUsd   > 0 ? llmUsd   : totalLlmFromAgents;
   const effectiveHumanUsd = humanUsd > 0 ? humanUsd : totalHumanFromAgents;
-  const effectiveSavings  = effectiveLlmUsd > 0 && effectiveHumanUsd > 0
+  // Skip the savings ratio when source='tasks': both legs share the same
+  // task-minute base, so the ratio is just HUMAN_RATE/LLM_RATE (e.g. 500×) —
+  // a rate-config readout, not measured savings. Only show for plans/verdicts
+  // where human cost is an independent number.
+  const savingsTrustworthy = m.cost?.source && m.cost.source !== 'tasks';
+  const effectiveSavings  = savingsTrustworthy && effectiveLlmUsd > 0 && effectiveHumanUsd > 0
     ? (effectiveHumanUsd / effectiveLlmUsd).toFixed(0) + '×' : null;
   const effectiveAiH = totalAiMin > 0 ? totalAiMin / 60 : totalTimeMin / 60;
 
@@ -829,18 +834,6 @@ if (paused) {
               <span class="agent-human">$${agentsCost.reduce((s,a)=>s+a.human_usd,0).toFixed(0)}</span>
               <span class="agent-tasks">${agentsCost.reduce((s,a)=>s+a.tasks_done,0)}/${agentsCost.reduce((s,a)=>s+a.tasks_total,0)}</span>
             </div>
-          </div>` : agentList.length ? `
-          <div class="section-label">Who did the work</div>
-          <div class="agent-list">
-            ${agentList.map(([name, count]) => {
-              const pct = totalAgentRuns > 0 ? (count / totalAgentRuns) * 100 : 0;
-              return `
-                <div class="agent-row">
-                  <span class="agent-name">✱ ${esc(name)}</span>
-                  <span class="agent-rail"><span class="agent-fill" style="width:${pct.toFixed(0)}%"></span></span>
-                  <span class="agent-count">${count} verdict${count === 1 ? '' : 's'}</span>
-                </div>`;
-            }).join('')}
           </div>` : ''}
 
         <div class="trust-foot">

--- a/packages/board/server.mjs
+++ b/packages/board/server.mjs
@@ -740,12 +740,19 @@ function getMetrics(cwd = process.cwd()) {
   const doneThisWeek = done.filter(t => t.closed_at && (now - new Date(t.closed_at).getTime()) < week);
   const doneThisMonth = done.filter(t => t.closed_at && (now - new Date(t.closed_at).getTime()) < 30 * 24 * 60 * 60 * 1000);
 
-  // Avg completion time (ms)
+  // Cycle time (median, last 30 days, cap individual cycles at 30 days).
+  // Previously: arithmetic mean over ALL tasks ever, no cap — stuck tasks
+  // (created months earlier, finally closed) pulled the average into the
+  // tens of thousands of minutes. Median + 30d cap matches how the cost
+  // tile bounds cycles ([server.mjs:816](server.mjs:816)).
+  const cycleCap = 30 * 86400_000;
   const completionTimes = done
-    .filter(t => t.created_at && t.closed_at)
-    .map(t => new Date(t.closed_at).getTime() - new Date(t.created_at).getTime());
-  const avgCompletionMs = completionTimes.length
-    ? completionTimes.reduce((a, b) => a + b, 0) / completionTimes.length
+    .filter(t => t.created_at && t.closed_at && (now - new Date(t.closed_at).getTime()) < cycleCap)
+    .map(t => new Date(t.closed_at).getTime() - new Date(t.created_at).getTime())
+    .filter(ms => ms > 0 && ms < cycleCap)
+    .sort((a, b) => a - b);
+  const medianCompletionMs = completionTimes.length
+    ? completionTimes[Math.floor(completionTimes.length / 2)]
     : 0;
 
   // Verdicts (global verdicts log lives in ~/.great_cto/verdicts/)
@@ -807,13 +814,19 @@ function getMetrics(cwd = process.cwd()) {
   const HUMAN_RATE_PER_HR = parseFloat(process.env.GREATCTO_HUMAN_RATE_PER_HR || '150');
   const LLM_RATE_PER_HR   = parseFloat(process.env.GREATCTO_LLM_RATE_PER_HR || '0.30');
   const DEFAULT_TASK_MIN  = 30;  // fallback when no timing data
+  // Window: count only tasks closed in the last 30 days (or still in progress).
+  // Previously: lifetime — produced LLM-spend tile ($1749) wildly out of step
+  // with the "Last 30 days" panel ($6.42) shown directly below it. Now both
+  // sit on the same 30-day window so the dashboard numbers reconcile.
+  const costWindowMs = 30 * 86400_000;
   const agentCostMap = {};
   for (const t of tasks) {
     if (!t.agent) continue;
+    if (t.closed_at && (now - new Date(t.closed_at).getTime()) > costWindowMs) continue;
     let mins = 0;
     if (t.created_at && t.closed_at) {
       const ms = new Date(t.closed_at).getTime() - new Date(t.created_at).getTime();
-      if (ms > 0 && ms < 30 * 86400_000) mins = ms / 60000;
+      if (ms > 0 && ms < costWindowMs) mins = ms / 60000;
     }
     if (!mins) mins = t.estimated_minutes || DEFAULT_TASK_MIN;
     const llmCost   = mins / 60 * LLM_RATE_PER_HR;
@@ -873,10 +886,17 @@ function getMetrics(cwd = process.cwd()) {
   if (costData.llm_usd > 0 || costData.human_usd > 0) {
     cost = { ...costData, real_llm_usd: verdictLlmTotal > 0 ? Math.round(verdictLlmTotal * 10000) / 10000 : null };
   } else if (taskLlmTotal > 0) {
+    // savings_x intentionally NULL for source='tasks': it would always equal
+    // HUMAN_RATE_PER_HR / LLM_RATE_PER_HR (e.g. 500) because both legs share
+    // the same task-minute base. That's the rate ratio, not measured savings —
+    // putting it on a dashboard tile misleads. Only plans/verdicts have an
+    // independent human number worth comparing.
     cost = {
       llm_usd:   Math.round(taskLlmTotal   * 100) / 100,
       human_usd: Math.round(taskHumanTotal),
-      savings_x: Math.round(taskHumanTotal / taskLlmTotal),
+      savings_x: null,
+      rate_ratio: Math.round(HUMAN_RATE_PER_HR / LLM_RATE_PER_HR),
+      window_days: 30,
       count:     0,
       source:    'tasks',
       real_llm_usd: verdictLlmTotal > 0 ? Math.round(verdictLlmTotal * 10000) / 10000 : null,
@@ -901,7 +921,8 @@ function getMetrics(cwd = process.cwd()) {
   return {
     tasks: { total: tasks.length, done: done.length, in_progress: inProgress.length, backlog: backlog.length },
     velocity: { this_week: doneThisWeek.length, this_month: doneThisMonth.length },
-    avg_completion_min: Math.round(avgCompletionMs / 60000),
+    avg_completion_min: Math.round(medianCompletionMs / 60000),
+    cycle_time_stat: 'median_30d',
     cost,
     qa: qaStats,
     security: secStats,


### PR DESCRIPTION
## Summary
Statistics on the dashboard and in the public report showed inconsistent numbers. Three classes of bugs:

- **Windows didn't reconcile.** The "LLM spend" hero tile was computed over all tasks ever ($1749.25), but the "Last 30 days" panel directly below it covered 30 days ($6.42). They sat side by side and didn't match.
- **Tautological 500×.** Under task-based estimate: `savings_x = humanCost / llmCost = (mins × $150) / (mins × $0.30) = 500` — that's the configured rate ratio, not measured savings.
- **Avg cycle time 5965m (~99h).** Arithmetic mean over all tasks with no cap — stuck-then-resolved tasks pulled the average up.
- **Public report attributed other projects' work.** "Who did the work" used global verdict counts from `~/.great_cto/verdicts/` (shared across all projects), while tasks/cost were project-scoped → empty projects rendered phantom agent bars.

## Changes
**Dashboard** ([packages/board/server.mjs](packages/board/server.mjs), [public/index.html](packages/board/public/index.html)):
- LLM spend / vs-humans bounded to last 30 days; UI label "30d".
- `savings_x = null` when source=`tasks`; tile shows "—" + `rate ratio Nx (no measured savings)`.
- Cycle time: median + 30d window + 30d cap; label "Median cycle (30d)".

**Public report** ([public/share.html](packages/board/public/share.html)):
- Removed the "Who did the work" fallback that rendered global verdict counts.
- compare-card hides "Nx cheaper" when source=`tasks`.

## Test plan
- [x] Verified locally on :3142 — hero shows $1625.15 (30d), "—" for savings, 374m median cycle
- [x] Verified report rendering — no phantom agent bars when `tasks.total=0`; "Nx cheaper" suppressed when source=tasks
- [ ] Smoke test post-merge — open admin board on a real project, verify numbers reconcile
- [ ] If a shareable report is already published — regenerate it (toggle share off→on)