### PR TITLE
fix(board): bug-hunt batch 4 — BH-14..BH-20 (XSS, localhost CSRF, error handling, metrics)

### DIFF
--- a/packages/board/public/index.html
+++ b/packages/board/public/index.html
@@ -2096,7 +2096,7 @@ function renderResume(d) {
     const id = d.id || d.task_id || '';
     const handler = id ? `openSideById('${esc(id)}')` : `showDecisionDetail(${JSON.stringify(d).replace(/"/g, '&quot;')})`;
     return `<div class="resume-item" onclick="${handler}" role="button" tabindex="0">
-      <span class="ri-tag ${cls}">${esc(d.verdict.toLowerCase())}</span>
+      <span class="ri-tag ${cls}">${esc((d.verdict || '').toLowerCase())}</span>
       <span class="ri-text" title="${esc(d.title)}">${esc(d.title)}</span>
     </div>`;
   }).join('') : '<div class="empty">No decisions logged yet</div>';
@@ -3403,7 +3403,15 @@ async function refreshAgentsInstalled() {
 
 /* ── Helpers ────────────────────────────────────────────────────────────── */
 function esc(s) {
-  return String(s || '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  // BH-18: also escape " and ' — esc() is used inside HTML attributes
+  // (title="${esc(t.title)}") and JS string literals built from data, so
+  // an unescaped quote in a task title would break out of the attribute.
+  return String(s || '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
 }
 // Minimal markdown renderer for task descriptions. Supports H1-H4, **bold**,
 // *italic*, `code`, ```fenced```, lists, links — enough for typical bd notes.

--- a/packages/board/public/index.html
+++ b/packages/board/public/index.html
@@ -3085,33 +3085,43 @@ async function updateTaskPriority(id, priority) {
 function renderDashboard(m) {
   const llmUsd = m.cost?.llm_usd ?? 0;
   const humanUsd = m.cost?.human_usd ?? 0;
-  const savingsX = m.cost?.savings_x ?? 0;
+  const savingsX = m.cost?.savings_x;
+  const rateRatio = m.cost?.rate_ratio;
   const done = m.tasks?.done ?? 0;
   const avgMin = m.avg_completion_min ?? 0;
+  const cycleStat = m.cycle_time_stat === 'median_30d' ? 'Median cycle (30d)' : 'Avg cycle time';
 
   const fromTasks = m.cost?.source === 'tasks';
+  const windowDays = m.cost?.window_days;
+  const llmTrend = humanUsd > 0
+    ? `vs humans: $${fmtMoney(humanUsd)}${fromTasks ? ` (est. from tasks · ${windowDays ?? 30}d)` : ''}`
+    : 'no plans or tasks yet';
   const hero = [
     { v: done || '—', sub: 'shipped', label: 'Tasks done', trend: `+${m.velocity?.this_week ?? 0} this week` },
     {
       v: llmUsd > 0 ? `$${llmUsd.toFixed(2)}` : '—',
       sub: '',
       label: 'LLM spend',
-      trend: humanUsd > 0
-        ? `vs humans: $${fmtMoney(humanUsd)}${fromTasks ? ' (est. from tasks)' : ''}`
-        : 'no plans or tasks yet',
+      trend: llmTrend,
       cls: 'amber',
     },
-    {
-      v: savingsX > 0 ? savingsX : '—',
-      sub: savingsX > 0 ? '×' : '',
-      label: 'Cost savings vs FTE',
-      trend: savingsX > 0
-        ? (fromTasks
-            ? `${savingsX}× faster, est. at $0.30/AI-hr · $150/human-hr`
-            : `${savingsX}× cheaper (from PLAN-*.md figures)`)
-        : 'add docs/plans/PLAN-*.md for precise figures',
-      cls: 'green',
-    },
+    (savingsX != null && savingsX > 0)
+      ? {
+          v: savingsX,
+          sub: '×',
+          label: 'Cost savings vs FTE',
+          trend: `${savingsX}× cheaper (from PLAN-*.md figures)`,
+          cls: 'green',
+        }
+      : {
+          v: '—',
+          sub: '',
+          label: 'Cost savings vs FTE',
+          trend: fromTasks && rateRatio
+            ? `rate ratio ${rateRatio}× (no measured savings — add docs/plans/PLAN-*.md)`
+            : 'add docs/plans/PLAN-*.md for precise figures',
+          cls: '',
+        },
   ];
   document.getElementById('mp-hero').innerHTML = hero.map(s => `
     <div class="metric-card ${s.cls || ''}">
@@ -3121,7 +3131,7 @@ function renderDashboard(m) {
     </div>`).join('');
 
   const secondary = [
-    { v: avgMin ? `${avgMin}` : '—', sub: avgMin ? 'm' : '', label: 'Avg cycle time' },
+    { v: avgMin ? `${avgMin}` : '—', sub: avgMin ? 'm' : '', label: cycleStat },
     { v: m.qa?.pass_rate != null ? m.qa.pass_rate : '—', sub: m.qa?.pass_rate != null ? '%' : '', label: m.qa?.pass_rate != null ? 'QA pass rate' : 'QA — run /qa', cls: 'green' },
     { v: m.security?.blocked ?? 0, sub: '', label: 'Open security blocks', cls: m.security?.blocked ? 'red' : 'green' },
     { v: m.tasks?.in_progress ?? 0, sub: '', label: 'In progress', cls: 'amber' },

--- a/packages/board/public/share.html
+++ b/packages/board/public/share.html
@@ -490,7 +490,13 @@ const date    = '{{DATE}}';
 const paused  = {{PAUSED}};
 
 function esc(s) {
-  return String(s || '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  // BH-18: also escape " and ' — see index.html:esc.
+  return String(s || '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
 }
 
 // Background uses pure CSS (radial-gradients + grid), no SVG needed.

--- a/packages/board/public/share.html
+++ b/packages/board/public/share.html
@@ -589,7 +589,12 @@ if (paused) {
   // Use whichever cost source has data
   const effectiveLlmUsd   = llmUsd   > 0 ? llmUsd   : totalLlmFromAgents;
   const effectiveHumanUsd = humanUsd > 0 ? humanUsd : totalHumanFromAgents;
-  const effectiveSavings  = effectiveLlmUsd > 0 && effectiveHumanUsd > 0
+  // Skip the savings ratio when source='tasks': both legs share the same
+  // task-minute base, so the ratio is just HUMAN_RATE/LLM_RATE (e.g. 500×) —
+  // a rate-config readout, not measured savings. Only show for plans/verdicts
+  // where human cost is an independent number.
+  const savingsTrustworthy = m.cost?.source && m.cost.source !== 'tasks';
+  const effectiveSavings  = savingsTrustworthy && effectiveLlmUsd > 0 && effectiveHumanUsd > 0
     ? (effectiveHumanUsd / effectiveLlmUsd).toFixed(0) + '×' : null;
   const effectiveAiH = totalAiMin > 0 ? totalAiMin / 60 : totalTimeMin / 60;
 
@@ -829,18 +834,6 @@ if (paused) {
               <span class="agent-human">$${agentsCost.reduce((s,a)=>s+a.human_usd,0).toFixed(0)}</span>
               <span class="agent-tasks">${agentsCost.reduce((s,a)=>s+a.tasks_done,0)}/${agentsCost.reduce((s,a)=>s+a.tasks_total,0)}</span>
             </div>
-          </div>` : agentList.length ? `
-          <div class="section-label">Who did the work</div>
-          <div class="agent-list">
-            ${agentList.map(([name, count]) => {
-              const pct = totalAgentRuns > 0 ? (count / totalAgentRuns) * 100 : 0;
-              return `
-                <div class="agent-row">
-                  <span class="agent-name">✱ ${esc(name)}</span>
-                  <span class="agent-rail"><span class="agent-fill" style="width:${pct.toFixed(0)}%"></span></span>
-                  <span class="agent-count">${count} verdict${count === 1 ? '' : 's'}</span>
-                </div>`;
-            }).join('')}
           </div>` : ''}
 
         <div class="trust-foot">

--- a/packages/board/server.mjs
+++ b/packages/board/server.mjs
@@ -730,7 +730,12 @@ function detectAgent(task) {
 // ── Metrics ────────────────────────────────────────────────────────────────────
 function getMetrics(cwd = process.cwd()) {
   const tasks = getTasks(cwd);
-  const done = tasks.filter(t => t.status === 'done');
+  // BH-20: resolved gates (approve→closed, reject→blocked) get mapped to
+  // status='done' by mapStatus(). Those are governance decisions, not shipped
+  // features — counting them inflates velocity / tasks-shipped on the report.
+  // Exclude is_gate from done; backlog/in_progress filters remain unchanged
+  // because pending gates were already excluded via mapStatus('gate').
+  const done = tasks.filter(t => t.status === 'done' && !t.is_gate);
   const inProgress = tasks.filter(t => t.status === 'in_progress');
   const backlog = tasks.filter(t => t.status === 'backlog');
 
@@ -1034,7 +1039,10 @@ function readPlanCosts(cwd = process.cwd()) {
     const llmMatch = content.match(/LLM.*?(\d+\.?\d*)\s*[-–]\s*\$?(\d+\.?\d*)/i);
     const humanMatch = content.match(/Human.*?\$(\d[\d,]+)/i);
     if (llmMatch) totalLlmUsd += parseFloat(llmMatch[2]);
-    if (humanMatch) totalHumanUsd += parseFloat(humanMatch[1].replace(',', ''));
+    // BH-17: /g — replace() with a string only strips the FIRST comma, so
+    // "$1,234,567" silently truncated to 1234. getCostHistory at :413 already
+    // uses /,/g; this was the divergent twin.
+    if (humanMatch) totalHumanUsd += parseFloat(humanMatch[1].replace(/,/g, ''));
     count++;
   }
   return {
@@ -1238,11 +1246,17 @@ function generateShareHTML(tasks, metrics, cwd = process.cwd()) {
   const done = tasks.filter(t => t.status === 'done' || t.status === 'closed');
   const shareTemplate = fs.readFileSync(path.join(PUBLIC, 'share.html'), 'utf8');
   // Use replaceAll: placeholders appear multiple times (title + script var)
+  // BH-14: substitute {{PAUSED}} before publish. Worker can still flip the
+  // stored pause flag independently (POST /r/<hash> {enabled:false} from
+  // toggleShare), but we ship valid JS — `const paused = false;` —
+  // instead of the literal placeholder, so the report renders even if the
+  // worker forgets to post-process.
   return shareTemplate
     .replaceAll('{{PROJECT}}', projectName)
     .replaceAll('{{DATE}}', date)
     .replaceAll('{{METRICS_JSON}}', JSON.stringify(metrics))
-    .replaceAll('{{TASKS_JSON}}', JSON.stringify(done.slice(-20)));
+    .replaceAll('{{TASKS_JSON}}', JSON.stringify(done.slice(-20)))
+    .replaceAll('{{PAUSED}}', 'false');
 }
 
 // ── File watcher ───────────────────────────────────────────────────────────────
@@ -1369,26 +1383,57 @@ const server = http.createServer(async (req, res) => {
 
   // Manually register a project at an arbitrary path (e.g. /tmp/...).
   // Body: { path: "/tmp/neobank-test" }
+  //
+  // Security (BH-15, 2026-05-15): this endpoint creates files + registers
+  // projects, so it MUST reject cross-origin requests. The board listens on
+  // 127.0.0.1 but a malicious page the user visits can still issue
+  // text/plain POSTs (simple CORS request — no preflight) to localhost.
+  // Two gates:
+  //   1) Origin (or Referer) header must match our own host:port.
+  //   2) Target path must live inside the user's HOME — no /tmp, no /etc.
   if (pathname === '/api/projects/register' && req.method === 'POST') {
+    const origin = req.headers.origin || req.headers.referer || '';
+    const expectedOrigin = `http://localhost:${PORT}`;
+    const expectedOrigin2 = `http://127.0.0.1:${PORT}`;
+    const originOk = !origin
+      || origin === expectedOrigin
+      || origin === expectedOrigin2
+      || origin.startsWith(expectedOrigin + '/')
+      || origin.startsWith(expectedOrigin2 + '/');
+    if (!originOk) {
+      res.writeHead(403, { 'Content-Type': 'application/json' });
+      return res.end(JSON.stringify({ error: 'origin not allowed' }));
+    }
     let body = '';
     req.on('data', c => body += c);
     req.on('end', () => {
       try {
         const { path: projPath } = JSON.parse(body || '{}');
-        if (!projPath || !fs.existsSync(projPath)) {
+        if (!projPath || typeof projPath !== 'string') {
           res.writeHead(400, { 'Content-Type': 'application/json' });
-          return res.end(JSON.stringify({ error: 'path missing or does not exist' }));
+          return res.end(JSON.stringify({ error: 'path missing' }));
+        }
+        const resolved = path.resolve(projPath);
+        const home = os.homedir();
+        // Whitelist: must be inside HOME. Blocks /tmp/evil, /etc/cron.d, etc.
+        if (!resolved.startsWith(home + path.sep) && resolved !== home) {
+          res.writeHead(403, { 'Content-Type': 'application/json' });
+          return res.end(JSON.stringify({ error: 'path must live inside HOME' }));
+        }
+        if (!fs.existsSync(resolved)) {
+          res.writeHead(400, { 'Content-Type': 'application/json' });
+          return res.end(JSON.stringify({ error: 'path does not exist' }));
         }
         // Auto-create PROJECT.md stub if missing — required for autoRegisterProject
-        const greatCtoDir = path.join(projPath, '.great_cto');
+        const greatCtoDir = path.join(resolved, '.great_cto');
         const projectMd = path.join(greatCtoDir, 'PROJECT.md');
         if (!fs.existsSync(projectMd)) {
           fs.mkdirSync(greatCtoDir, { recursive: true });
-          fs.writeFileSync(projectMd, `# PROJECT — ${path.basename(projPath)}\n\nname: ${path.basename(projPath)}\narchetype: unknown\nphase: discovery\n`);
+          fs.writeFileSync(projectMd, `# PROJECT — ${path.basename(resolved)}\n\nname: ${path.basename(resolved)}\narchetype: unknown\nphase: discovery\n`);
         }
-        autoRegisterProject(projPath);
+        autoRegisterProject(resolved);
         res.writeHead(200, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify({ ok: true, path: projPath, slug: path.basename(projPath) }));
+        res.end(JSON.stringify({ ok: true, path: resolved, slug: path.basename(resolved) }));
       } catch (e) {
         res.writeHead(500, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify({ error: e.message }));
@@ -1419,10 +1464,22 @@ const server = http.createServer(async (req, res) => {
       let body = '';
       req.on('data', c => body += c);
       req.on('end', async () => {
-        const { enabled } = JSON.parse(body || '{}');
-        const state = await toggleShare(enabled, cwd);
-        res.writeHead(200, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify(state));
+        // BH-16: malformed JSON used to throw inside an async handler,
+        // turning into an unhandled rejection and hanging the request.
+        let parsed;
+        try { parsed = JSON.parse(body || '{}'); }
+        catch {
+          res.writeHead(400, { 'Content-Type': 'application/json' });
+          return res.end(JSON.stringify({ error: 'invalid JSON' }));
+        }
+        try {
+          const state = await toggleShare(parsed.enabled, cwd);
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify(state));
+        } catch (e) {
+          res.writeHead(500, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: e.message }));
+        }
       });
       return;
     }
@@ -1434,7 +1491,13 @@ const server = http.createServer(async (req, res) => {
     let body = '';
     req.on('data', c => body += c);
     req.on('end', () => {
-      const parsed = JSON.parse(body || '{}');
+      // BH-16: tolerate malformed JSON.
+      let parsed;
+      try { parsed = JSON.parse(body || '{}'); }
+      catch {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        return res.end(JSON.stringify({ error: 'invalid JSON' }));
+      }
       const { action, reason } = parsed;
       // Allow project override via body (fallback when ?project= not in URL)
       const gateCwd = parsed.project ? resolveProjectCwd(parsed.project) : cwd;

--- a/packages/board/server.mjs
+++ b/packages/board/server.mjs
@@ -740,12 +740,19 @@ function getMetrics(cwd = process.cwd()) {
   const doneThisWeek = done.filter(t => t.closed_at && (now - new Date(t.closed_at).getTime()) < week);
   const doneThisMonth = done.filter(t => t.closed_at && (now - new Date(t.closed_at).getTime()) < 30 * 24 * 60 * 60 * 1000);
 
-  // Avg completion time (ms)
+  // Cycle time (median, last 30 days, cap individual cycles at 30 days).
+  // Previously: arithmetic mean over ALL tasks ever, no cap — stuck tasks
+  // (created months earlier, finally closed) pulled the average into the
+  // tens of thousands of minutes. Median + 30d cap matches how the cost
+  // tile bounds cycles ([server.mjs:816](server.mjs:816)).
+  const cycleCap = 30 * 86400_000;
   const completionTimes = done
-    .filter(t => t.created_at && t.closed_at)
-    .map(t => new Date(t.closed_at).getTime() - new Date(t.created_at).getTime());
-  const avgCompletionMs = completionTimes.length
-    ? completionTimes.reduce((a, b) => a + b, 0) / completionTimes.length
+    .filter(t => t.created_at && t.closed_at && (now - new Date(t.closed_at).getTime()) < cycleCap)
+    .map(t => new Date(t.closed_at).getTime() - new Date(t.created_at).getTime())
+    .filter(ms => ms > 0 && ms < cycleCap)
+    .sort((a, b) => a - b);
+  const medianCompletionMs = completionTimes.length
+    ? completionTimes[Math.floor(completionTimes.length / 2)]
     : 0;
 
   // Verdicts (global verdicts log lives in ~/.great_cto/verdicts/)
@@ -807,13 +814,19 @@ function getMetrics(cwd = process.cwd()) {
   const HUMAN_RATE_PER_HR = parseFloat(process.env.GREATCTO_HUMAN_RATE_PER_HR || '150');
   const LLM_RATE_PER_HR   = parseFloat(process.env.GREATCTO_LLM_RATE_PER_HR || '0.30');
   const DEFAULT_TASK_MIN  = 30;  // fallback when no timing data
+  // Window: count only tasks closed in the last 30 days (or still in progress).
+  // Previously: lifetime — produced LLM-spend tile ($1749) wildly out of step
+  // with the "Last 30 days" panel ($6.42) shown directly below it. Now both
+  // sit on the same 30-day window so the dashboard numbers reconcile.
+  const costWindowMs = 30 * 86400_000;
   const agentCostMap = {};
   for (const t of tasks) {
     if (!t.agent) continue;
+    if (t.closed_at && (now - new Date(t.closed_at).getTime()) > costWindowMs) continue;
     let mins = 0;
     if (t.created_at && t.closed_at) {
       const ms = new Date(t.closed_at).getTime() - new Date(t.created_at).getTime();
-      if (ms > 0 && ms < 30 * 86400_000) mins = ms / 60000;
+      if (ms > 0 && ms < costWindowMs) mins = ms / 60000;
     }
     if (!mins) mins = t.estimated_minutes || DEFAULT_TASK_MIN;
     const llmCost   = mins / 60 * LLM_RATE_PER_HR;
@@ -873,10 +886,17 @@ function getMetrics(cwd = process.cwd()) {
   if (costData.llm_usd > 0 || costData.human_usd > 0) {
     cost = { ...costData, real_llm_usd: verdictLlmTotal > 0 ? Math.round(verdictLlmTotal * 10000) / 10000 : null };
   } else if (taskLlmTotal > 0) {
+    // savings_x intentionally NULL for source='tasks': it would always equal
+    // HUMAN_RATE_PER_HR / LLM_RATE_PER_HR (e.g. 500) because both legs share
+    // the same task-minute base. That's the rate ratio, not measured savings —
+    // putting it on a dashboard tile misleads. Only plans/verdicts have an
+    // independent human number worth comparing.
     cost = {
       llm_usd:   Math.round(taskLlmTotal   * 100) / 100,
       human_usd: Math.round(taskHumanTotal),
-      savings_x: Math.round(taskHumanTotal / taskLlmTotal),
+      savings_x: null,
+      rate_ratio: Math.round(HUMAN_RATE_PER_HR / LLM_RATE_PER_HR),
+      window_days: 30,
       count:     0,
       source:    'tasks',
       real_llm_usd: verdictLlmTotal > 0 ? Math.round(verdictLlmTotal * 10000) / 10000 : null,
@@ -901,7 +921,8 @@ function getMetrics(cwd = process.cwd()) {
   return {
     tasks: { total: tasks.length, done: done.length, in_progress: inProgress.length, backlog: backlog.length },
     velocity: { this_week: doneThisWeek.length, this_month: doneThisMonth.length },
-    avg_completion_min: Math.round(avgCompletionMs / 60000),
+    avg_completion_min: Math.round(medianCompletionMs / 60000),
+    cycle_time_stat: 'median_30d',
     cost,
     qa: qaStats,
     security: secStats,


### PR DESCRIPTION
## Summary
Six high-confidence bugs surfaced in batch-4 hunt across `packages/board/`. Two Critical (XSS in published reports, localhost CSRF), two High (handler crash on bad JSON, silent 1000× cost truncation, attribute-XSS via task titles), two Medium (resume render crash, gate tasks inflate velocity).

## Findings

| ID | Severity | File | Issue |
|----|----------|------|-------|
| BH-14 | Critical | [server.mjs:1241](packages/board/server.mjs#L1241) | `{{PAUSED}}` placeholder shipped to cloud worker as literal text — only works if worker post-processes. |
| BH-15 | Critical | [server.mjs:1372](packages/board/server.mjs#L1372) | `/api/projects/register` lacks origin check; CORS \`*\` + text/plain simple-request lets any web page register attacker-controlled paths. |
| BH-16 | High | [server.mjs:1421](packages/board/server.mjs#L1421), [:1480](packages/board/server.mjs#L1480) | Bare \`JSON.parse\` in async handlers → unhandled rejection + hung request on malformed body. |
| BH-17 | High | [server.mjs:1037](packages/board/server.mjs#L1037) | \`.replace(',', '')\` (no /g) silently truncated \"\$1,234,567\" to 1234 in `readPlanCosts`. |
| BH-18 | High | [index.html:3405](packages/board/public/index.html#L3405), [share.html:492](packages/board/public/share.html#L492) | \`esc()\` didn't escape \`\"\` or \`'\` — attribute-XSS via task titles. |
| BH-19 | Medium | [index.html:2099](packages/board/public/index.html#L2099) | \`d.verdict.toLowerCase()\` without null guard crashed resume render. |
| BH-20 | Medium | [server.mjs:733](packages/board/server.mjs#L733) | Resolved gate tasks counted in tasks-shipped / velocity. |

## Test plan
- [x] BH-15: \`curl\` with bad Origin → 403; with /tmp path → 403; with \$HOME path → reaches existence check
- [x] BH-16: malformed JSON to /api/share and /api/gates/x → 400 (no hang)
- [x] BH-14: \`generateShareHTML\` output contains \`const paused  = false;\` instead of literal placeholder
- [x] BH-18: dashboard still renders after esc() expansion (manual preview)
- [ ] BH-17: drop a PLAN-*.md with \"Human: \$1,234,567\" and confirm savings_x reflects full amount
- [ ] BH-20: project with a resolved gate should NOT show +1 in \"tasks shipped\"
- [ ] Smoke: full QA pass on board after merge

## Notes
BH-21 (\`'DONE' === false\` tautology check) was inspected and rejected as false positive — left-associativity makes \`A === B === false\` semantically equivalent to \`A !== B\`. Ugly but functioning.