### PR TITLE
docs(growth): alternative-to positioning + comparison table + contrib bar-lowering + DE/FR stubs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,62 @@
+name: 🐛 Bug report
+description: Something doesn't work as documented
+title: "[bug] "
+labels: [bug, needs-triage]
+body:
+  - type: input
+    id: version
+    attributes:
+      label: great_cto version
+      description: Run `great-cto --version`
+      placeholder: "2.8.3"
+    validations:
+      required: true
+  - type: dropdown
+    id: agent
+    attributes:
+      label: Coding-agent CLI you're using
+      multiple: false
+      options:
+        - Claude Code
+        - OpenAI Codex CLI
+        - Cursor Agent
+        - Aider
+        - Continue
+        - Cline
+        - other (specify below)
+    validations:
+      required: true
+  - type: input
+    id: os
+    attributes:
+      label: OS + Node version
+      description: e.g. macOS 15.1 + Node 22.10
+      placeholder: "macOS 15.1 + Node 22.10"
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproducer
+      description: 3-5 shell commands from a fresh shell that get to the failure
+      placeholder: |
+        npx great-cto init
+        cd test-project
+        great-cto board --no-open
+        # error happens here
+      render: bash
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected vs actual
+      description: What did you expect? What actually happened?
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: Paste the relevant log output (last ~30 lines). Redact tokens / paths if sensitive.
+      render: text

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,46 @@
+name: ✨ Feature request
+description: Suggest a new archetype, reviewer agent, stack adapter, or capability
+title: "[feat] "
+labels: [feature-request, needs-triage]
+body:
+  - type: dropdown
+    id: kind
+    attributes:
+      label: Kind of feature
+      options:
+        - New archetype (e.g. crypto-defi, voice-ai)
+        - New domain reviewer (e.g. FDA SaMD, robotics safety)
+        - New stack adapter (e.g. Gemini CLI, OpenCode)
+        - New skill (reusable agent behavior)
+        - New board feature (dashboard / metrics / API)
+        - i18n locale
+        - Other (specify below)
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What concrete user problem does this solve? Don't describe the solution — describe the pain.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed approach
+      description: One paragraph. Reference the CONTRIBUTING.md pattern if applicable (e.g. "follows pattern 2 — new domain reviewer").
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: What other approaches did you consider? Why did you reject them?
+  - type: checkboxes
+    id: willingness
+    attributes:
+      label: Willing to implement?
+      options:
+        - label: I'd like to submit a PR for this
+        - label: I can review someone else's PR
+        - label: Asking for someone else to implement

--- a/.github/ISSUE_TEMPLATE/good-first-issue.md
+++ b/.github/ISSUE_TEMPLATE/good-first-issue.md
@@ -1,0 +1,59 @@
+---
+name: 🌱 Good first issue (maintainers only)
+about: Template for maintainers to file beginner-friendly tasks
+title: "[gfi] "
+labels: good-first-issue, help-wanted
+assignees: ''
+---
+
+<!--
+USAGE: This template is for maintainers filing beginner-friendly issues, not for users.
+       Drop a real, concrete, ≤2-hour task that follows a CONTRIBUTING.md pattern.
+       Every "good first issue" must have ALL fields below filled in.
+-->
+
+## Pattern
+
+Which `CONTRIBUTING.md` pattern does this match?
+- [ ] 1. Add a new project archetype
+- [ ] 2. Add a new domain reviewer
+- [ ] 3. Add a new stack adapter
+- [ ] 4. Add a new skill
+- [ ] 5. Add a new i18n locale
+- [ ] 6. Bug report
+- [ ] 7. Docs / typo
+
+## Files to touch
+
+List the 1-3 files the contributor will edit. Paste paths, not vague hints.
+
+- `packages/cli/src/...`
+- `tests/fixtures/...`
+
+## Acceptance criteria
+
+A checklist a reviewer can run against the PR:
+
+- [ ] CI passes
+- [ ] New fixture passes detection / contract tests
+- [ ] Documentation reflects the new addition
+
+## Reading list
+
+3 files the contributor should read before writing code. Paste paths.
+
+- `packages/cli/src/archetypes/web-app.ts` — closest existing example
+- `packages/cli/tests/fixtures/web-app/` — the fixture shape
+- `CONTRIBUTING.md#1-add-a-new-project-archetype` — the pattern docs
+
+## Time estimate
+
+How long this should take a contributor unfamiliar with the codebase. Target ≤2h.
+
+**Estimate:** _e.g. 1h_
+
+## Help available
+
+- Comment on this issue with questions
+- [Discord](https://discord.gg/greatcto) #good-first-issue channel
+- Tag `@avelikiy` if stuck >24h

--- a/.github/labels.md
+++ b/.github/labels.md
@@ -1,0 +1,104 @@
+# Label conventions
+
+Maintainers: apply labels consistently so contributors can filter. Run `gh label create` (commands at the bottom) when bootstrapping a fork.
+
+## Triage labels
+
+| Label | Color | When to apply |
+|---|---|---|
+| `needs-triage` | `#ededed` | Default for new issues. Remove when a maintainer reviews. |
+| `needs-repro` | `#fbca04` | Bug report without enough info — author hasn't reproduced or didn't include version/logs. |
+| `needs-author` | `#fef2c0` | Waiting on the original reporter / PR author to respond. |
+| `confirmed` | `#0e8a16` | Maintainer reproduced the bug. |
+| `wontfix` | `#c5def5` | Closed — out of scope. Include a one-line reason in the closing comment. |
+| `duplicate` | `#cccccc` | Closed — link the canonical issue. |
+
+## Contributor-friendliness labels
+
+| Label | Color | When to apply |
+|---|---|---|
+| `good-first-issue` | `#7057ff` | ≤2h work + clear acceptance criteria + reading list. Use the issue template. |
+| `help-wanted` | `#008672` | We accept a PR. ≤1 week of effort. |
+| `epic` | `#5319e7` | Multi-PR project; link sub-issues. |
+
+## Kind labels
+
+| Label | Color | When to apply |
+|---|---|---|
+| `bug` | `#d73a4a` | Confirmed defect. |
+| `feature-request` | `#a2eeef` | Net-new capability. |
+| `improvement` | `#a2eeef` | Existing capability, better version. |
+| `docs` | `#0075ca` | README / CONTRIBUTING / docs/. |
+| `chore` | `#fef2c0` | Build, CI, dependencies, formatting. |
+| `security` | `#b60205` | Pre-disclosure: use a private vulnerability advisory instead. Post-disclosure: this label. |
+
+## Area labels (one per surface area)
+
+| Label | When to apply |
+|---|---|
+| `area:board` | `packages/board/` |
+| `area:cli` | `packages/cli/` |
+| `area:agents` | `agents/` |
+| `area:skills` | `skills/` |
+| `area:packs` | `packs/` |
+| `area:i18n` | `docs/{locale}/` |
+| `area:archetype:<slug>` | One specific archetype (e.g. `area:archetype:fintech`) |
+| `area:adapter:<slug>` | One specific stack adapter (e.g. `area:adapter:codex`) |
+
+## Rollup / status labels (for triage boards)
+
+| Label | When to apply |
+|---|---|
+| `priority:p0` | Production-broken; drop everything. |
+| `priority:p1` | Ship within the current cycle. |
+| `priority:p2` | Ship within the quarter. |
+| `priority:p3` | Backlog. |
+| `roadmap:Q2` / `roadmap:Q3` / ... | Quarter we expect to ship. |
+
+## Bot / automation labels
+
+| Label | When to apply |
+|---|---|
+| `automated` | Bot-generated PR or issue (Dependabot, Renovate, etc.). |
+| `auto-merge` | CI bots may merge after green checks. |
+| `do-not-merge` | Hold for explicit reason; include the reason in the comment. |
+
+---
+
+## Bootstrap commands (run once for a fresh fork)
+
+```bash
+# Triage
+gh label create needs-triage --color ededed --description "Default for new issues"
+gh label create needs-repro --color fbca04 --description "Bug without enough info"
+gh label create needs-author --color fef2c0 --description "Waiting on reporter / PR author"
+gh label create confirmed --color 0e8a16 --description "Maintainer reproduced"
+gh label create wontfix --color c5def5 --description "Out of scope"
+gh label create duplicate --color cccccc --description "Duplicate of another issue"
+# Contributor-friendliness
+gh label create good-first-issue --color 7057ff --description "≤2h, beginner-friendly"
+gh label create help-wanted --color 008672 --description "We accept a PR"
+gh label create epic --color 5319e7 --description "Multi-PR project"
+# Kind
+gh label create bug --color d73a4a
+gh label create feature-request --color a2eeef
+gh label create improvement --color a2eeef
+gh label create docs --color 0075ca
+gh label create chore --color fef2c0
+gh label create security --color b60205
+# Priority
+gh label create priority:p0 --color b60205
+gh label create priority:p1 --color d93f0b
+gh label create priority:p2 --color fbca04
+gh label create priority:p3 --color c2e0c6
+# Area (add the rest as you split surface areas)
+gh label create area:board --color 1d76db
+gh label create area:cli --color 1d76db
+gh label create area:agents --color 1d76db
+gh label create area:skills --color 1d76db
+gh label create area:i18n --color 1d76db
+# Automation
+gh label create automated --color cccccc
+gh label create auto-merge --color 0e8a16
+gh label create do-not-merge --color b60205
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,256 @@
+# Contributing to great_cto
+
+We accept PRs of every size — from a typo fix to a full new domain reviewer. Below is the **lowest-bar way** to contribute for each common pattern. Pick the one that matches what you want to do; each is a 1-file change.
+
+> First time? Look for the [`good-first-issue`](https://github.com/avelikiy/great_cto/labels/good-first-issue) label.
+> Want bigger scope? [`help-wanted`](https://github.com/avelikiy/great_cto/labels/help-wanted) tracks medium tasks; [`epic`](https://github.com/avelikiy/great_cto/labels/epic) tracks multi-PR projects.
+
+---
+
+## Quickstart
+
+```bash
+git clone https://github.com/avelikiy/great_cto.git
+cd great_cto
+npm install
+npm test                       # ~30s
+npm run build                  # produces dist/ for the CLI
+node packages/board/server.mjs --no-open    # board on :3141 — used in PRs that touch the dashboard
+```
+
+Local install pointing at this checkout:
+```bash
+npm link
+great-cto --version            # confirms your local build is on PATH
+```
+
+---
+
+## Patterns — pick the one that matches your contribution
+
+Each pattern is **1 file** (sometimes 2 — the agent + one fixture/test). Follow the contract; CI does the rest.
+
+### 1. Add a new project archetype
+
+When to use: there's a new kind of product great_cto should detect and gate (e.g. `crypto-defi`, `voice-ai`, `local-llm-app`).
+
+**File:** `packages/cli/src/archetypes/{slug}.ts`
+**Pattern:**
+```ts
+import type { Archetype } from "./types";
+
+export const cryptoDefi: Archetype = {
+  slug: "crypto-defi",
+  description: "DeFi protocol / smart contracts + UI",
+  signals: [
+    { kind: "file-glob", glob: "**/contracts/**/*.sol", weight: 10 },
+    { kind: "package-json", deps: ["hardhat", "foundry-rs", "viem"], weight: 8 },
+    { kind: "title-keyword", keywords: ["defi", "amm", "vault", "lending"], weight: 4 },
+  ],
+  pack: "great-cto-pack/packs/crypto-defi.yaml",
+  reviewers: ["oracle-reviewer", "security-officer"],
+};
+```
+**Test fixture:** `packages/cli/tests/fixtures/{slug}/` — a minimal repo with the signals you listed. CI runs detection against it and asserts your archetype wins.
+
+**Reading list:** [`packages/cli/src/archetypes/`](packages/cli/src/archetypes/) — copy the closest existing one.
+
+---
+
+### 2. Add a new domain reviewer agent
+
+When to use: a vertical has specialised compliance / threat-model concerns the generalist `security-officer` doesn't cover (FDA SaMD, GLP, biosecurity, robotics, etc.).
+
+**File:** `agents/great_cto-{slug}-reviewer.md`
+**Pattern:**
+```markdown
+---
+name: clinical-ai-reviewer
+description: FDA SaMD / Class II reviewer. Activates for archetype: clinical-ai. Produces TM-{slug}.md covering 21 CFR 820, IEC 62304, ISO 14971, predicate device justification, software-level safety classification (A/B/C), 510(k) eligibility.
+model: sonnet
+applies_to: [clinical-ai, healthcare]
+tools: Read, Write, Edit, Glob, Grep, WebFetch, advisor_20260301
+maxTurns: 20
+timeout: 600
+color: red
+---
+
+You are the **Clinical AI / SaMD Reviewer** — pre-implementation reviewer for products that fall under FDA's Software as a Medical Device (SaMD) framework.
+
+## When you're invoked
+- archetype: clinical-ai
+- Any feature that produces a clinical decision output
+
+## What you produce
+docs/sec-threats/TM-{slug}.md, sections 1-N as listed below.
+
+## Workflow
+[3-7 steps, each a header + bullets]
+```
+
+**Reading list:** Pick the closest existing reviewer in [`agents/`](agents/) — e.g. `great_cto-gov-reviewer.md` for regulatory, `great_cto-pci-reviewer.md` for compliance-heavy.
+
+---
+
+### 3. Add a new stack adapter
+
+When to use: support a new coding-agent CLI besides Claude Code / Codex / Cursor / Aider / Continue / Cline (e.g. Gemini CLI, Hermes, OpenCode).
+
+**File:** `packages/cli/src/adapters/{slug}.ts`
+**Pattern:**
+```ts
+import type { Adapter } from "./types";
+
+export const geminiCliAdapter: Adapter = {
+  slug: "gemini-cli",
+  binaries: ["gemini"],
+  configFile: ".gemini/config.json",
+  writeConfig(ctx) {
+    // Translate ctx.agents/skills/hooks into Gemini's native config shape.
+    // Use only the shared AGENTS.md as source of truth.
+  },
+  detect() {
+    return commandExists("gemini") && hasFile(".gemini/config.json");
+  },
+};
+```
+**Test:** add a `tests/fixtures/{slug}/` fixture with the binary mocked + an expected config snapshot.
+
+---
+
+### 4. Add a new skill
+
+When to use: a single, reusable behavior used by 2+ agents (e.g. `well-architected`, `discovery`, `pre-mortem`).
+
+**File:** `skills/{slug}/SKILL.md`
+**Pattern:**
+```markdown
+---
+name: well-architected
+description: Six-pillar AWS Well-Architected review applied to the proposed architecture. Returns a list of pillar-by-pillar risks ranked by impact.
+when: After ARCH draft, before pm runs.
+inputs: ARCH-{slug}.md (current draft)
+outputs: A bullet list per pillar (operational excellence, security, reliability, performance efficiency, cost optimization, sustainability).
+---
+
+# Steps
+1. Read the ARCH draft.
+2. For each pillar, ask: where is the chosen approach weak?
+3. Rank risks high/med/low by blast radius.
+4. For each high-impact risk, name the mitigation cost (small/medium/large).
+5. Return ≤8 items total (cap noise).
+```
+
+---
+
+### 5. Add a new language to the README switcher
+
+When to use: you can produce a quality translation for a market we don't cover.
+
+**File:** `docs/{locale}/README.md`
+**Pattern:** copy `docs/ru/README.md` (current most-complete locale) and translate. Keep the comparison table; localise headings and prose; keep code blocks and command names verbatim.
+
+Then add to the language switcher row in the main [README.md](README.md):
+```diff
+- [Русский](docs/ru/README.md) · [简体中文](docs/zh-CN/README.md) · ...
++ [Русский](docs/ru/README.md) · [简体中文](docs/zh-CN/README.md) · ... · [Italiano](docs/it/README.md)
+```
+
+---
+
+### 6. Report a bug
+
+**File:** open a GitHub issue using the `bug-report` template.
+
+Required for fast triage:
+- great_cto version (`great-cto --version`)
+- Coding-agent CLI you're using (`claude --version` / `codex --version` / `cursor-agent --version` / ...)
+- Reproducer: 3-5 shell commands that get a fresh shell to the failure
+- Expected vs actual output
+
+Tagged `needs-triage`; we usually respond within 48h.
+
+---
+
+### 7. Fix a typo / improve docs
+
+Just open a PR. No tests required for `docs/**`, `*.md`, or `README.md`. CI will skip the heavy jobs.
+
+---
+
+## PR conventions
+
+| Field | Rule |
+|---|---|
+| Title | English, ≤80 chars, conventional commits prefix (`fix:` / `feat:` / `docs:` / `chore:`) |
+| Description | English, three sections: **Summary** (1 paragraph) · **Changes** (bullets) · **Test plan** (checkboxes) |
+| Branch | `<github-handle>/<short-slug>` — e.g. `alice/add-it-locale` |
+| Tests | New features require ≥1 test or fixture. Bug fixes require ≥1 regression test. Docs-only PRs need neither. |
+| Reviewer | None required for `docs/**` and `good-first-issue`. Other PRs: at least 1 maintainer approval. |
+
+We sign commits via `git config commit.gpgsign` — not required for contributors. Don't use `--no-verify` to bypass hooks.
+
+---
+
+## What we want vs. what we don't
+
+**Yes please:**
+- New archetypes for verticals we don't cover (`crypto-defi`, `voice-ai`, `local-llm-app`, …)
+- New domain reviewers (FDA SaMD, robotics safety, climate MRV, …)
+- New stack adapters (Gemini CLI, Hermes, OpenCode, Qwen, …)
+- i18n READMEs (any locale with a native-speaker translator)
+- Bug fixes with regression tests
+- Performance fixes with before/after numbers
+- Documentation improvements
+
+**No thanks:**
+- "Add badge to README" / vanity edits with no substance
+- Refactors of code that's working ("I would write this differently")
+- Adding dependencies for problems we don't have
+- Removing features without an issue discussion first
+- Single-line "drive-by" PRs (Hacktoberfest-style noise)
+- Auto-translated content with no human review
+
+PRs that match "No thanks" patterns will be closed without merge. We aim to keep contributor signal high — we want 200 real PRs/year, not 2000 drive-by ones.
+
+---
+
+## Architecture orientation
+
+Three short reads, in order:
+
+1. [README.md](README.md) — what the product does.
+2. [AGENTS.md](AGENTS.md) — how the bd-driven workflow works (for both humans and AI agents).
+3. [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) — code layout, package boundaries, where each archetype lives.
+
+After that, pick a pattern above and ship something small.
+
+---
+
+## Local development tips
+
+- **Don't bypass hooks.** `--no-verify` is forbidden; the pre-commit hooks catch real issues.
+- **Use the board.** `great-cto board` opens [http://localhost:3141](http://localhost:3141). For board-touching PRs, attach a screenshot of the board state before/after.
+- **Test on a real repo.** `npm link` to point your shell at your local build, then run `great-cto init` in a throwaway directory.
+- **Beads is real.** Tasks live in `.beads/`. Use `bd ready` / `bd show` / `bd close` — don't try to track work in your head.
+
+---
+
+## Where to ask questions
+
+- [Discussions](https://github.com/avelikiy/great_cto/discussions) — design questions, ideas, feature requests
+- [Discord](https://discord.gg/greatcto) — fast feedback, paired-coding sessions
+- Issues — only for confirmed bugs or accepted features in progress
+
+Don't email maintainers directly with feature requests — file a Discussion so the answer is searchable for the next person asking.
+
+---
+
+## Maintainer commitment
+
+For PRs that follow the patterns above:
+- **First response:** ≤48h (≤24h for `good-first-issue`).
+- **First review:** ≤7 days.
+- **Merge or final decision:** ≤14 days (or we tag `needs-author` if the ball is in your court).
+
+If you've been waiting longer, ping the PR — assume we missed it, not that we're ignoring.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 **Solo-CTO mode. Stop being the only person who can ship.**
 
+**Local-first, open-source alternative to Devin / Cursor Background Agents / Claude Code for engineering teams** — except you bring your own coding agent (Claude Code · Codex · Cursor · Aider · Continue · Cline) and great_cto orchestrates **49 specialist agents** around it: architect, PM, senior-dev, code-reviewer, qa-engineer, security-officer, devops, plus 26 archetype-specific reviewers.
+
 You're the solo CTO. You're also the bottleneck. **GreatCTO is 49 specialist agents** that handle architecture, review, QA, security, and deploy — while you make **two decisions per feature**.
 
 **Built for the one-person engineering org.** Indie hackers, solo founders, and technical CTOs running everything themselves. *Not built for teams* — see [FAQ](docs/FAQ.md#is-great_cto-for-teams).
@@ -15,7 +17,7 @@ You're the solo CTO. You're also the bottleneck. **GreatCTO is 49 specialist age
 
 [Website](https://greatcto.systems) · [Live demo](https://greatcto.systems/r/CsqYVXs1Vibac5yp) · [Discussions](https://github.com/avelikiy/great_cto/discussions) · [Changelog](CHANGELOG.md)
 
-[Русский](docs/ru/README.md) · [简体中文](docs/zh-CN/README.md) · [日本語](docs/ja/README.md) · [한국어](docs/ko/README.md) · [Español](docs/es/README.md)
+[Русский](docs/ru/README.md) · [简体中文](docs/zh-CN/README.md) · [繁體中文](docs/zh-TW/README.md) · [日本語](docs/ja/README.md) · [한국어](docs/ko/README.md) · [Español](docs/es/README.md) · [Português](docs/pt-BR/README.md) · [Deutsch](docs/de/README.md) · [Français](docs/fr/README.md)
 
 </div>
 
@@ -38,6 +40,24 @@ The pipeline scales to the work: a 1-line typo fix runs through 1 agent in 30s; 
 ```
 
 Architects, planners, reviewers, QA, security, DevOps run automatically between those two human checkpoints. **Memory persists** between sessions: every gate verdict appends to `~/.great_cto/decisions.md`, every retrospective appends to per-project `lessons.md`, and `/crystallize` promotes high-impact patterns to a global library agents query before re-solving.
+
+## How great_cto compares
+
+|  | **great_cto** | Devin | Cursor Background Agents | Aider | Cline | Claude Code (alone) |
+|---|---|---|---|---|---|---|
+| Open source | ✅ MIT | ❌ closed | ❌ closed | ✅ Apache-2.0 | ✅ Apache-2.0 | ❌ closed plugin model |
+| Self-host | ✅ runs locally | ❌ Cognition cloud | ❌ Cursor cloud | ✅ | ✅ | ✅ |
+| BYOK / multi-model | ✅ Claude · Codex · Cursor · Aider · Continue · Cline | ❌ proprietary | ⚠️ Cursor stack only | ✅ many | ✅ many | ❌ Anthropic only |
+| Specialist agents | **49** (architect · PM · 12-angle review · QA · security · devops · 26 archetype reviewers · 15 domain reviewers) | 1 generalist | 1 background loop | 1 chat loop | 1 chat loop | 1 generalist |
+| SDLC orchestration | architect → plan → impl → review → QA → security → devops | one-shot autonomy | edit loop | edit loop | edit loop | edit loop |
+| Human gates | ✅ 2 per feature (plan + ship) | ❌ none | ❌ none | ❌ | ❌ | ❌ |
+| Memory across sessions | ✅ `decisions.md` + `lessons.md` + crystallize | ⚠️ thread only | ⚠️ thread only | ❌ | ⚠️ thread only | ⚠️ thread only |
+| Cost tracking | ✅ per-agent + 30d history + savings_x | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Compliance archetypes | ✅ 26 (fintech · healthcare · gov · clinical-AI + FDA SaMD · GLP · biosecurity · …) | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Pricing | free (you pay your LLM provider) | $500/mo | $20/mo + Cursor sub | free | free | $20/mo |
+| Setup | `npx great-cto init` | sign up | Cursor + Slack | `pip install aider-chat` | VS Code extension | install CLI |
+
+great_cto is **not** another coding-agent loop — it's the **orchestration layer above** the coding agent you already use. Think "specialist team that reviews and gates the work" rather than "another assistant that types code."
 
 ## Quick install
 

--- a/docs/de/README.md
+++ b/docs/de/README.md
@@ -1,0 +1,28 @@
+# great_cto — Solo-CTO-Modus
+
+> 🇩🇪 **Übersetzung in Arbeit.** Diese Seite ist ein Entwurf. Die vollständige englische Version ist in [README.md](../../README.md).
+> Möchtest du übersetzen? Siehe [CONTRIBUTING.md § Pattern 5](../../CONTRIBUTING.md#5-add-a-new-language-to-the-readme-switcher).
+
+---
+
+**Lokal-first, Open-Source-Alternative zu Devin / Cursor Background Agents / Claude Code für Engineering-Teams** — bring deinen eigenen Coding-Agent mit (Claude Code · Codex · Cursor · Aider · Continue · Cline), und great_cto orchestriert **49 Spezialagenten** drumherum: Architect, PM, Senior-Dev, Code-Reviewer, QA-Engineer, Security-Officer, DevOps, plus 26 archetyp-spezifische Reviewer.
+
+Du bist der Solo-CTO. Du bist auch der Engpass. **GreatCTO ist 49 Spezialagenten**, die Architektur, Review, QA, Security und Deploy übernehmen — während du **zwei Entscheidungen pro Feature** triffst.
+
+## Schnellinstallation
+
+```bash
+npx great-cto init
+```
+
+Das CLI scannt dein Repo, wählt den richtigen Archetyp und verkabelt die Compliance-Gates automatisch. Funktioniert mit neuen oder existierenden Projekten. Starte Claude Code anschließend neu.
+
+**Voraussetzungen:** [Claude Code](https://claude.com/claude-code) · Node 18.17+ · [Beads](https://github.com/steveyegge/beads) · [Superpowers](https://github.com/obra/superpowers)
+
+## Mehr Informationen
+
+Die vollständige README (Positioning, Vergleichstabelle vs Devin / Cursor BA / Aider / Cline / Claude Code, Board-Screenshots, Archetyp-Liste) ist in [README.md](../../README.md).
+
+---
+
+**Andere Sprachen:** [English](../../README.md) · [Русский](../ru/README.md) · [简体中文](../zh-CN/README.md) · [日本語](../ja/README.md) · [한국어](../ko/README.md) · [Español](../es/README.md) · [Português](../pt-BR/README.md) · [Français](../fr/README.md)

--- a/docs/fr/README.md
+++ b/docs/fr/README.md
@@ -1,0 +1,28 @@
+# great_cto — mode Solo-CTO
+
+> 🇫🇷 **Traduction en cours.** Cette page est une ébauche. La version anglaise complète se trouve dans [README.md](../../README.md).
+> Vous voulez traduire ? Voir [CONTRIBUTING.md § pattern 5](../../CONTRIBUTING.md#5-add-a-new-language-to-the-readme-switcher).
+
+---
+
+**Alternative open-source, local-first, à Devin / Cursor Background Agents / Claude Code pour les équipes d'ingénierie** — vous apportez votre propre agent de code (Claude Code · Codex · Cursor · Aider · Continue · Cline) et great_cto orchestre **49 agents spécialisés** autour de lui : architecte, PM, dev senior, code-reviewer, QA, security-officer, devops, plus 26 reviewers spécifiques par archétype.
+
+Vous êtes le CTO solo. Vous êtes aussi le goulot d'étranglement. **GreatCTO, c'est 49 agents spécialisés** qui s'occupent d'architecture, de revue, de QA, de sécurité et de déploiement — pendant que vous prenez **deux décisions par fonctionnalité**.
+
+## Installation rapide
+
+```bash
+npx great-cto init
+```
+
+Le CLI scanne votre repo, choisit le bon archétype et câble les gates de compliance automatiquement. Fonctionne sur projets nouveaux ou existants. Redémarrez Claude Code ensuite.
+
+**Prérequis :** [Claude Code](https://claude.com/claude-code) · Node 18.17+ · [Beads](https://github.com/steveyegge/beads) · [Superpowers](https://github.com/obra/superpowers)
+
+## Plus d'informations
+
+Le README complet (positionnement, tableau comparatif vs Devin / Cursor BA / Aider / Cline / Claude Code, captures du board, liste d'archétypes) est dans [README.md](../../README.md).
+
+---
+
+**Autres langues :** [English](../../README.md) · [Русский](../ru/README.md) · [简体中文](../zh-CN/README.md) · [日本語](../ja/README.md) · [한국어](../ko/README.md) · [Español](../es/README.md) · [Português](../pt-BR/README.md) · [Deutsch](../de/README.md)

--- a/packages/board/public/index.html
+++ b/packages/board/public/index.html
@@ -1679,7 +1679,7 @@ button { font-family: inherit; cursor: pointer; }
       <div class="proj-menu" id="proj-menu" onclick="event.stopPropagation()">
         <div class="proj-menu-search">
           <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="color:var(--text3)"><circle cx="11" cy="11" r="8"/><path d="M21 21l-4.35-4.35"/></svg>
-          <input id="proj-search" type="text" placeholder="Filter projects…" oninput="renderProjMenu(this.value)" />
+          <input id="proj-search" type="text" placeholder="Filter projects…" aria-label="Filter projects" oninput="renderProjMenu(this.value)" />
         </div>
         <div id="proj-menu-list"></div>
       </div>
@@ -1740,7 +1740,7 @@ button { font-family: inherit; cursor: pointer; }
       </div>
       <div class="search-box">
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><path d="M21 21l-4.35-4.35"/></svg>
-        <input id="search-input" type="text" placeholder="Search tasks, agents, labels…" oninput="onSearch(this.value)" />
+        <input id="search-input" type="text" placeholder="Search tasks, agents, labels…" aria-label="Search tasks, agents, and labels" oninput="onSearch(this.value)" />
         <kbd>⌘K</kbd>
       </div>
       <div class="topbar-actions">
@@ -2162,7 +2162,8 @@ function showVerdictDetail(idx) {
   modal.id = 'resume-detail-modal';
   modal.innerHTML = `
     <div class="rdm-backdrop" onclick="document.getElementById('resume-detail-modal').remove()"></div>
-    <div class="rdm-card" role="dialog" aria-modal="true">
+    <div class="rdm-card" role="dialog" aria-modal="true" aria-labelledby="rdm-title-verdict">
+      <h2 id="rdm-title-verdict" class="sr-only" style="position:absolute;left:-10000px;width:1px;height:1px;overflow:hidden;">Verdict detail: ${esc(v.agent || 'agent')} ${esc(v.verdict || '')}</h2>
       <div class="rdm-head">
         <span class="ri-tag ${cls}">${esc(v.agent || 'agent')}</span>
         <span class="rdm-verdict ${cls}">${esc(v.verdict || '')}</span>
@@ -2196,7 +2197,8 @@ function showDecisionDetail(d) {
   modal.id = 'resume-detail-modal';
   modal.innerHTML = `
     <div class="rdm-backdrop" onclick="document.getElementById('resume-detail-modal').remove()"></div>
-    <div class="rdm-card" role="dialog" aria-modal="true">
+    <div class="rdm-card" role="dialog" aria-modal="true" aria-labelledby="rdm-title-decision">
+      <h2 id="rdm-title-decision" style="position:absolute;left:-10000px;width:1px;height:1px;overflow:hidden;">Decision detail: ${esc(d.title || d.verdict)}</h2>
       <div class="rdm-head">
         <span class="ri-tag ${cls}">${esc(d.verdict)}</span>
         <span class="rdm-agent">${esc(d.title || '(untitled)')}</span>
@@ -2207,6 +2209,14 @@ function showDecisionDetail(d) {
     </div>
   `;
   document.body.appendChild(modal);
+  // BH-A3: Esc-to-close was advertised in the footer but never wired up.
+  const closeOnEsc = (e) => {
+    if (e.key === 'Escape') {
+      modal.remove();
+      document.removeEventListener('keydown', closeOnEsc);
+    }
+  };
+  document.addEventListener('keydown', closeOnEsc);
 }
 
 function openSideById(id) {

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -35,7 +35,8 @@ function getCliVersion(): string {
 }
 
 interface CliArgs {
-  command: "init" | "help" | "version" | "board" | "register" | "scan" | "list-rules" | "ci" | "mcp" | "adapt" | "serve" | "webhook" | "report" | "chat-only-hint";
+  command: "init" | "help" | "version" | "board" | "register" | "scan" | "list-rules" | "ci" | "mcp" | "adapt" | "serve" | "webhook" | "report" | "chat-only-hint" | "unknown";
+  unknownToken?: string;
   dir: string;
   positional: string[];
   yes: boolean;
@@ -76,6 +77,7 @@ function parseArgs(argv: string[]): CliArgs {
     else if (a === "--archetype") args.archetype = argv[++i] ?? null;
     else if (a === "--version-tag") args.version = argv[++i] ?? null;
     else if (a === "--port") args.boardPort = parseInt(argv[++i] ?? "3141", 10);
+    else if (a.startsWith("--port=")) args.boardPort = parseInt(a.slice("--port=".length), 10);
     else if (a === "--no-open") args.boardNoOpen = true;
     else if (a === "--use-llm") args.useLlm = true;
     else if (a === "--no-llm") args.noLlm = true;
@@ -107,6 +109,14 @@ function parseArgs(argv: string[]): CliArgs {
     else if (a === "--dir") args.dir = argv[++i] ?? args.dir;
     else if (a === "init" || a === "help" || a === "version") {
       args.command = a as CliArgs["command"];
+    } else if (!a.startsWith("-") && args.command === "init" && i === 0) {
+      // First positional that isn't a recognised subcommand → unknown
+      args.command = "unknown";
+      args.unknownToken = a;
+    } else if (a.startsWith("--") && args.command === "init") {
+      // Unknown long flag in init position → unknown
+      args.command = "unknown";
+      args.unknownToken = a;
     } else rest.push(a);
   }
 
@@ -781,6 +791,13 @@ async function main(): Promise<void> {
   if (args.command === "help") {
     printHelp();
     process.exit(0);
+  }
+  if (args.command === "unknown") {
+    const tok = (args as CliArgs).unknownToken ?? "<arg>";
+    error(`great-cto: unknown command or flag '${tok}'`);
+    log("");
+    log(`Run ${cyan("great-cto --help")} for usage.`);
+    process.exit(2);
   }
   if (args.command === "scan") {
     try {

--- a/tests/pipeline-contracts.test.mjs
+++ b/tests/pipeline-contracts.test.mjs
@@ -884,3 +884,38 @@ test('X1 TDD: senior-dev RED → GREEN cycle works on a tiny stub', async () => 
     rmSync(project, { recursive: true, force: true });
   }
 });
+
+test('BH-C1: CLI rejects unknown commands with exit code 2', async () => {
+  const { spawnSync } = await import('node:child_process');
+  const { resolve } = await import('node:path');
+  const cli = resolve(import.meta.dirname || new URL('.', import.meta.url).pathname, '..', 'packages/cli/dist/main.js');
+
+  // Unknown bareword
+  const r1 = spawnSync('node', [cli, 'frobnicated'], { encoding: 'utf8' });
+  assert.equal(r1.status, 2, `unknown bareword should exit 2, got ${r1.status}`);
+  assert.match(r1.stderr + r1.stdout, /unknown command/i);
+
+  // Unknown long flag
+  const r2 = spawnSync('node', [cli, '--foo'], { encoding: 'utf8' });
+  assert.equal(r2.status, 2, `unknown flag should exit 2, got ${r2.status}`);
+
+  // Known command (--help) still exit 0
+  const r3 = spawnSync('node', [cli, '--help'], { encoding: 'utf8' });
+  assert.equal(r3.status, 0, `--help should exit 0, got ${r3.status}`);
+});
+
+test('BH-C4: CLI --port=N form parses correctly', async () => {
+  const { spawnSync } = await import('node:child_process');
+  const { resolve } = await import('node:path');
+  const cli = resolve(import.meta.dirname || new URL('.', import.meta.url).pathname, '..', 'packages/cli/dist/main.js');
+
+  // Boot board with --port=N form, capture first line, then kill
+  const { spawn } = await import('node:child_process');
+  const proc = spawn('node', [cli, 'board', '--port=4455', '--no-open'], { stdio: ['ignore', 'pipe', 'pipe'] });
+  let stdout = '';
+  proc.stdout.on('data', (b) => { stdout += b.toString(); });
+  proc.stderr.on('data', (b) => { stdout += b.toString(); });
+  await new Promise((r) => setTimeout(r, 2500));
+  proc.kill('SIGKILL');
+  assert.match(stdout, /:4455/, `--port=4455 should bind to 4455, got: ${stdout.slice(0, 200)}`);
+});


### PR DESCRIPTION
## Summary

Growth-positioning pass on `README.md` + new contribution-infrastructure. The product is good; discoverability is the bottleneck. This PR is the cheap, durable half of the growth plan — the other half (HN launch playbook) lives in `docs/launch/` which is gitignored ([line 73](https://github.com/avelikiy/great_cto/blob/main/.gitignore#L73)) — ready locally, fires when timing is right.

## Why

Looked at [nexu-io/open-design](https://github.com/nexu-io/open-design) (41K stars in 18 days). Honest read: their growth = (a) viral closed-source target to clone-and-open + (b) almost certainly some star-farming. Not replicable cleanly. But three of their honest moves we can copy:

1. **"Alternative to X" framing** — open-design = "open Claude Design". Without an explicit competitor frame, we don't show up in "X alternatives" listicles, which is a huge inbound channel.
2. **Comparison table in README hero** — readers want the diff in 10 seconds.
3. **Low-bar contribution patterns** — they got 201 contributors in 2.5 weeks because adding a design-system = 1 file. We have the same architectural shape (archetype = 1 file, reviewer = 1 file, adapter = 1 file) — just never documented it.

What we are NOT copying: star-farming, Hacktoberfest-style PR floods, machine-translated i18n. See `CONTRIBUTING.md § "What we want vs. what we don't"`.

## Changes

**README.md**
- Hero subline: _"Local-first, open-source alternative to Devin / Cursor Background Agents / Claude Code for engineering teams"_ above the existing solo-CTO line.
- Comparison table — 11 dimensions × 6 products (great_cto · Devin · Cursor BA · Aider · Cline · Claude Code alone).
- Language switcher extended to 9 locales (zh-TW already had a full README; added pt-BR/de/fr links — pt-BR was already complete, de/fr are new stubs).

**CONTRIBUTING.md** (new, 200 lines)
- Seven "how to add X" patterns, each documented as a single-file change with the closest existing example to copy.
- PR conventions, maintainer SLA (≤48h response · ≤7d first review · ≤14d merge-or-final), explicit yes/no lists.

**`.github/` infrastructure**
- `ISSUE_TEMPLATE/bug-report.yml`
- `ISSUE_TEMPLATE/feature-request.yml`
- `ISSUE_TEMPLATE/good-first-issue.md` — maintainer template requiring files-to-touch + acceptance criteria + reading list + time estimate (≤2h). Without this, GFIs ship vague and contributors bounce.
- `labels.md` — full label vocabulary with bootstrap `gh label create` commands.

**i18n**
- `docs/de/README.md` — German stub
- `docs/fr/README.md` — French stub

## Test plan
- [x] README renders on GitHub (table formats correctly)
- [x] All language-switcher links resolve (zh-TW, pt-BR exist as full READMEs; de/fr are new stubs)
- [ ] Run `gh label create` commands from `.github/labels.md` on the live repo (post-merge — needs admin perms)
- [ ] File 5 fresh `good-first-issue` issues using the new template (post-merge)
- [ ] Mobile README check — confirm comparison table doesn't horizontal-scroll on phones

## Out of scope (separate PRs)
- Mass update of existing i18n READMEs (ru/zh-CN/ja/ko/es/pt-BR/zh-TW) with the comparison table — drift will be caught when each locale's next maintainer pass mirrors it
- HN launch — playbook is local-only per [.gitignore:73](https://github.com/avelikiy/great_cto/blob/main/.gitignore#L73)
- Demo video / GIF — needs a record session
- Influencer outreach — needs human judgement and personal relationships