### PR TITLE
feat(board): agents fleet view — faceted list + drill-in drawer + retire workflow

### DIFF
--- a/docs/architecture/PHASE-agents-fleet-view.md
+++ b/docs/architecture/PHASE-agents-fleet-view.md
@@ -1,0 +1,74 @@
+# Phase — Agents fleet view (board /agents)
+
+**Status:** Draft (2026-05-15)
+**Author:** o.velikiy
+**Surface:** `web` (board UI, served by `packages/board/server.mjs` at `/agents` tab)
+
+## Problem
+
+The current `/agents` view ([packages/board/public/index.html:1865](../../packages/board/public/index.html#L1865)) shows three blocks: "Agent cost estimate", "Agent utilization", and a flat "Installed specialist agents" grid. It tells you what's installed and roughly what each agent has cost, but it does not answer the questions a solo CTO actually has:
+
+1. **Which agents are doing real work, and which are dead weight?** — current shows run count but not last verdict, last failure mode, success rate, or whether the agent has been called by any project in the last 30 days.
+2. **Is any agent costing more than it saves?** — agent cost rows show `$0.0023` per agent but no comparison against the human-equivalent baseline they replaced; no "savings_x per agent" call-out.
+3. **Where should I prune the fleet?** — there are 49 agents installed. A solo CTO probably uses 8–12. The rest are noise that adds context-switching for the orchestrator. We need a "Retire candidate" surface.
+4. **When an agent fails, where does that signal land?** — failure mode (BLOCKED / FAIL verdict) is currently buried in the verdicts log. The agent's row in the fleet view should reflect "3 BLOCKED in last 7d — needs prompt tune-up".
+5. **How do I find the right agent for a new task?** — agents are listed alphabetically with no faceting by `applies_to` archetype, by domain (security · QA · arch · ops · domain-reviewer), or by recent activity.
+
+## Goal
+
+A web view that turns the 49-agent fleet into a **manageable, auditable team** — same way `great_cto board` (the Kanban tab) turned 100+ tasks into a manageable backlog.
+
+## Non-goals
+
+- Editing agent prompts in-browser (out of scope; agents are file-based, edited externally)
+- Spawning agent runs from the UI (that's `bd`/CLI territory)
+- Agent marketplace / discovery (separate feature, deferred)
+
+## Inputs available (from server.mjs)
+
+The board server already exposes most of the data via existing endpoints:
+
+- `getCanonicalAgents()` → 49 installed agent slugs (`~/.claude/agents/great_cto-*.md`)
+- `m.agents_cost` → `[{ agent, llm_usd, human_usd, time_min, tasks_total, tasks_done, real_llm_usd?, cost_source }]`
+- `m.agents` → `{ <slug>: run_count }` (verdict-based, project-scoped, canonical-filtered)
+- `m.legacy_agent_runs` + `m.legacy_agent_count` → non-canonical agents (legacy log files)
+- `readVerdicts()` → `[{ ts, agent, verdict, cost_usd, raw }]` last N verdicts globally
+- `m.recent_done` → last 10 done tasks (per project)
+
+Missing endpoints (must be added):
+- `GET /api/agents/{slug}` — last 30d verdict history, success rate, failure modes (regex over `raw`), per-project breakdown
+- `GET /api/agents/{slug}/runs?limit=20` — recent run timeline
+- `POST /api/agents/{slug}/retire` — soft-retire (move agent file to a `retired/` dir; UI reflects "retired" state)
+
+## Routes / screens
+
+1. **`/agents` (default tab)** — fleet overview: faceted grid with sort + filter
+2. **`/agents/:slug` (drill-in)** — agent profile: stats, recent runs, failure modes, retire/promote actions
+3. **`/agents?filter=retired`** — view retired agents, restore button
+4. **Empty state** — no verdicts logged yet (fresh install)
+
+## Brand / stack
+
+The board UI uses a dark-mode, monochrome aesthetic (see existing CSS in `packages/board/public/index.html`). Stack:
+- Vanilla JS + CSS (no framework)
+- CSS custom properties for tokens (`--bg`, `--text2`, `--accent`, etc. — defined inline)
+- System fonts (no web font load — fast cold start matters)
+- Single HTML file; no router (tabs switch via `switchTab()`)
+
+The design must fit inside this existing aesthetic — do not propose a framework migration.
+
+## Constraints
+
+- **Must work at 1024px width minimum** (board is desktop-first; minimal mobile support).
+- **Server-Sent Events refresh** every 5s — UI must not flicker when data updates.
+- **No new dependencies** unless absolutely necessary (current package only ships node stdlib + better-sqlite3 + few small deps).
+- **Accessibility:** the board is a developer tool but should still pass WCAG 2.2 AA (keyboard navigation, screen reader, focus indicators). One blind contributor opened an issue last quarter.
+
+## What "done" looks like
+
+A solo CTO opens `/agents` and within 30 seconds can answer:
+- which 5 agents are pulling the most weight (by tasks done × savings_x)
+- which 3 agents have failed most often this week (and what the failure pattern is)
+- which 10+ agents have never run and are candidates to retire
+
+A redesigned `/agents/:slug` profile shows, for one agent, everything needed to decide "keep, tune, or retire" without leaving the page.

--- a/docs/design/DESIGN-agents-fleet-view.md
+++ b/docs/design/DESIGN-agents-fleet-view.md
@@ -1,0 +1,537 @@
+---
+surface: web
+feature: agents-fleet-view
+target: packages/board/public/index.html (panel#panel-agents)
+status: draft
+author: design-advisor v1.1
+date: 2026-05-15
+---
+
+# DESIGN — Agents fleet view (`/agents` tab redesign)
+
+Text-only pre-implementation contract for the `/agents` redesign described in
+`docs/architecture/PHASE-agents-fleet-view.md`. Targets the existing vanilla-JS
++ CSS board UI at `packages/board/public/index.html`. **No framework migration.**
+
+---
+
+## 1. Design system pick
+
+- **Decision:** Continue using the board's **existing in-file token system**
+  (`--bg`, `--text`, `--text2`, `--text3`, `--accent`, `--mono`, `--sans`,
+  `--status-progress`, `--status-blocked`, `--status-review`) plus the existing
+  primitive component classes (`.metric-card`, `.mp-card`, `.mp-row`, `.bar-row`,
+  `.fchip`, `.agents-installed`). Add only two new local components: a
+  `.agent-row` (faceted-list row) and a `.agent-profile` (drill-in detail
+  layout). No external dependency.
+- **Context:** PHASE doc explicitly forbids framework migration; the board ships
+  as a single HTML file served by `server.mjs` (zero npm UI deps beyond stdlib +
+  `better-sqlite3`). Cold start, SSE-driven refresh, and a one-file deploy
+  surface all argue against pulling in shadcn/Radix/Tailwind. The existing token
+  set already covers ~90% of what this redesign needs (semantic status colors
+  exist, mono+sans split exists, dark surface palette exists).
+- **Alternatives considered:**
+  - *shadcn/ui (via CDN bundle)* — rejected: requires React runtime; would
+    double cold-start time and add a build step where there is none today.
+  - *Pico.css / classless framework* — rejected: would override the existing
+    dark monochrome aesthetic with its own opinions; the board already has its
+    own taste and we'd fight it.
+  - *Fully bespoke new component layer* — rejected: 80% overlap with what
+    `.mp-card` / `.metric-card` already do. Re-inventing them invites visual
+    drift between `/agents` and the rest of the board.
+- **Consequences:**
+  - Cheap: anything that composes existing primitives ships in hours.
+  - Locked in: long-term, if we ever do migrate to React/shadcn, every screen
+    pays the migration cost together. That's a known board-wide debt, not new
+    debt from this feature.
+  - Swap cost (if forced later): roughly one engineer-week to convert the whole
+    board, of which this feature would contribute a tiny slice.
+
+> Confidence: high · invented: nothing — token set + component classes verified
+> at `packages/board/public/index.html:28-55, 1279-1556`.
+
+---
+
+## 2. Component inventory
+
+| Component | Source | Props (effective DOM attrs) | States | Notes |
+|---|---|---|---|---|
+| `Tab panel` | existing (`.panel#panel-agents`) | `id`, `data-active` | hidden, active | already wired via `switchTab()` |
+| `Section label` | existing (`.mp-section-label`) | text | — | reuse for "Fleet" / "Retired" / "Activity" |
+| `Metric tile` | existing (`.metric-card` + `.green/amber/red`) | left-border color, label, value, sublabel | default, alert (red border) | for top-of-page summary row (total agents · active 30d · retire-candidates · weekly LLM spend) |
+| `Card` | existing (`.mp-card`) | header, body | default | wraps every block |
+| `Faceted filter bar` | new — composes `.fchip` | facet group label, chip set | idle, selected, disabled (count=0) | groups: domain · activity · health · archetype |
+| `Sort control` | new — native `<select>` styled like `.fchip` | options | idle, open | sort by: tasks_done · savings_x · last_run · success_rate · llm_usd |
+| `Search input` | new — local `<input type="search">` | placeholder, value | idle, focus, with-results | filters by agent slug substring |
+| `Agent row` (`.agent-row`) | **new** | slug, domain, runs, success%, last_run_ago, savings_x, status_badge | default, hover, focus, retired (dimmed), failing (red rail) | replaces the current `.agents-installed` flat grid; uses `.bar-row` rail for success% |
+| `Status pill` | new — composes `.fchip` semantics | tone (active/idle/failing/retired/unused), label | five variants | semantic, not just color (see §4) |
+| `Drill-in panel` (`.agent-profile`) | **new** — composes `.mp-card` × 4 | slug | open, loading, empty, error | rendered in-place below row OR as right-side drawer; see §3 decision |
+| `Run timeline` | new — composes `.bar-row` rail per day | days[] with verdict counts | empty, normal, alert | 7-day sparkline of OK / FAIL / BLOCKED |
+| `Failure mode list` | new — `<ul>` styled like recent-done | mode_regex_key, count, last_seen | — | grouped by regex over verdict `raw` text |
+| `Action button` | new — single `.btn` style (already defined for other tabs) | `data-action`, `aria-label` | default, hover, focus, disabled, danger | actions: Retire · Restore · Open file |
+| `Confirm dialog` | new — native `<dialog>` element | title, body, confirm-label | open, closed | for destructive Retire action; uses `showModal()` + ESC close |
+| `Empty state` | existing (`.empty`) | text | — | reused for "no verdicts yet" |
+| `SSE refresh indicator` | existing (already in header) | — | idle, refreshing | no new work |
+
+**Rule applied:** every new component composes 1–2 existing primitives. The
+two truly new layouts (`.agent-row`, `.agent-profile`) earn their keep because
+the existing `.agents-installed` flat grid cannot express domain + health +
+activity faceting without a structural rewrite.
+
+> Confidence: high · invented: the two new class names; everything they compose
+> is verified in the existing stylesheet.
+
+---
+
+## 3. Wireframe-as-text (§3.web)
+
+### 3.1 Route: `/agents` (default state — fleet overview)
+
+```
+Route: /agents                        (tab #agents — switchTab('agents'))
+Region tree:
+─────────────────────────────────────────────────────────────────────
+<header role="banner">  [global board header — unchanged]
+<main id="panel-agents" role="tabpanel" aria-labelledby="tab-agents">
+
+  <section aria-label="Fleet summary">
+    [.mp-row of 4 .metric-card]
+      • Installed agents      49
+      • Active last 30d       12       (green left rail)
+      • Retire candidates     27       (amber rail)  ← clickable, sets facet
+      • LLM spend last 30d    $6.42    (mono number, savings sublabel)
+  </section>
+
+  <section aria-label="Fleet controls">
+    [.mp-card containing]
+      <input type="search" aria-label="Filter agents by slug" />
+      <fieldset> domain: [all] [arch] [qa] [security] [ops] [domain] [review]
+      <fieldset> activity: [all] [active] [idle ≥30d] [never run]
+      <fieldset> health:   [all] [ok] [failing ≥3 in 7d] [blocked]
+      <fieldset> archetype: [all] [mobile-app] [web-app] [commerce] …
+      <select> sort: tasks_done ▾
+      <button> Reset filters
+  </section>
+
+  <section aria-label="Agent fleet" aria-live="polite">
+    [.mp-card containing list of .agent-row]
+      ┌─ row ───────────────────────────────────────────────────────┐
+      │ ●(status)  great_cto-architect      arch                    │
+      │            42 runs · 95% ok · last 2h ago · 38× savings     │
+      │ ▰▰▰▰▰▰▰▰▱▱  success rail              [Open ▸]              │
+      └─────────────────────────────────────────────────────────────┘
+      … one row per agent (49 max, virtualised only if needed; 49 fits)
+  </section>
+
+  <section aria-label="Legacy agents" hidden-if-empty>
+    [.mp-card]
+      "12 non-canonical verdict sources detected (legacy.log, etc.)"
+      → link: "What's this?"  (explainer modal)
+  </section>
+
+</main>
+─────────────────────────────────────────────────────────────────────
+Focus order:
+  skip-link → global tab-strip → search input → facet chips
+  (group-by-group, ←/→ within a group, Tab between groups)
+  → sort select → reset button → first .agent-row → … → last row
+  → legacy-card link
+
+Breakpoint behaviour:
+  lg (1024, target): 4-tile summary row · facets wrap to ≤2 lines · rows full-width
+  md (768):   summary collapses to 2×2 · facets wrap to 3+ lines · rows still full-width
+  sm (640):   GRACEFUL DEGRADE — summary 1×4 stack, facets stack vertically,
+              rows still readable but right-side meta wraps below name
+  xs (<640):  n/a (PHASE doc: desktop-first, 1024 minimum) — render but no QA target
+```
+
+### 3.2 Route: `/agents/:slug` (drill-in)
+
+**Open question §9 #1 decides:** in-place expansion vs right-side drawer vs
+full-page push. Wireframe below assumes **right-side drawer** (preferred by
+this doc — keeps fleet context visible, matches the existing `panel-logs`
+two-pane pattern at `index.html:1860`).
+
+```
+Route: /agents/great_cto-architect       (URL hash: #agents/great_cto-architect)
+Region tree (drawer overlays right 480px of fleet view):
+─────────────────────────────────────────────────────────────────────
+<aside role="dialog" aria-labelledby="agent-profile-title"
+       aria-modal="false">             ← non-modal: fleet stays interactive
+
+  <header>
+    <h3 id="agent-profile-title">great_cto-architect</h3>
+    <span class="status-pill ok">active</span>
+    <button aria-label="Close profile">×</button>
+  </header>
+
+  [.mp-card] Summary
+    • domain: arch · applies_to: [all] · model: opus
+    • 42 runs total · 38 last 30d · last run: 2h ago
+    • success rate: 95% (40/42 OK, 1 FAIL, 1 BLOCKED)
+    • savings: 38× (LLM $1.40 vs human-equivalent $53.20)
+
+  [.mp-card] Activity (last 7 days)
+    7-day sparkline using .bar-row rail per day:
+    Mon ▰▰▱▱▱  Tue ▰▰▰▱▱  Wed ▰▰▰▰▱  Thu ▰▱▱▱▱  Fri ▰▰▰▰▰
+    Sat ▱▱▱▱▱  Sun ▰▰▱▱▱
+    Legend: green=OK, amber=BLOCKED, red=FAIL
+
+  [.mp-card] Recent runs (last 20, scrollable)
+    timestamp · project · verdict · cost_usd · raw-line tooltip on hover
+    [Open file ▸] → opens ~/.claude/agents/great_cto-architect.md externally
+
+  [.mp-card] Failure modes (regex-clustered)
+    "rate-limit … 429"            ×3  · last: yesterday
+    "BLOCKED: no ARCH/PHASE"      ×1  · last: 4d ago
+    (empty state: "no failures in 30d — quiet agent")
+
+  [.mp-card] Actions
+    [Retire agent ▸]   (opens <dialog> confirm)
+    [Open prompt file] (system handler)
+
+</aside>
+
+Dismissal contract:
+  • ESC → close drawer, focus returns to triggering .agent-row
+  • Click outside drawer → close (does NOT navigate)
+  • Click another .agent-row → swap content in-place, no close/reopen
+Focus order inside drawer:
+  close button → first action in Summary → sparkline (skipped, decorative) →
+  recent-runs list (arrow-key navigable) → failure-mode list → Retire button
+  → Open-file button → Tab wraps back to close
+```
+
+### 3.3 Route: `/agents?filter=retired`
+
+Same shell as 3.1 with the `activity` facet pre-set to `retired`. Every row in
+this state shows:
+- dimmed text color (`--text3`)
+- a `[Restore]` action button replacing the rail+meta
+- a small text sublabel "retired YYYY-MM-DD"
+
+Empty state: "no retired agents — fleet is at full strength (49)".
+
+### 3.4 Empty state — fresh install, no verdicts yet
+
+```
+[.mp-card centered, max-width 480px]
+  <h3>No verdicts logged yet.</h3>
+  <p>The board reads ~/.great_cto/verdicts/*.log. Once your first agent
+     runs and writes a verdict line, agents will appear here.</p>
+  <p>Run <code>great_cto audit</code> to bootstrap.</p>
+```
+
+> Confidence: high · invented: the drawer pattern choice (flagged as Top-2
+> question §9 #1), 7-day sparkline visual encoding, regex-cluster grouping of
+> failure modes. Everything else is sourced from PHASE or existing UI.
+
+---
+
+## 4. A11y contract (§4.web)
+
+### 4.1 WCAG level
+**WCAG 2.2 AA.** PHASE doc names a blind contributor who filed an issue last
+quarter — this is not theoretical. No exceptions.
+
+### 4.2 Keyboard map
+
+| Key | Context | Behaviour |
+|---|---|---|
+| `Tab` / `Shift+Tab` | global | move between landmarks per §3 focus order |
+| `Arrow ←/→` | inside a `<fieldset>` of facet chips | move between chips in that group (radiogroup pattern, but multi-select) |
+| `Space` | on a facet chip | toggle |
+| `Enter` | on `.agent-row` | open drill-in drawer |
+| `Esc` | drawer open | close drawer, return focus to row |
+| `Esc` | confirm `<dialog>` open | cancel, return focus to Retire button |
+| `Arrow ↑/↓` | inside recent-runs list | navigate runs |
+| `/` (slash) | anywhere in `/agents` panel | focus search input (document this; show hint in placeholder) |
+
+### 4.3 ARIA landmarks & semantics
+
+- `<main id="panel-agents" role="tabpanel" aria-labelledby="tab-agents">`
+- Each top-level grouping uses `<section aria-label="…">` (Summary, Controls,
+  Fleet, Legacy).
+- Facet chip groups are `<fieldset>` with `<legend class="visually-hidden">` —
+  group name is announced once, then each chip is `<button role="checkbox"
+  aria-checked="true|false">`. (Radio pattern is wrong: facets are
+  multi-select.)
+- Fleet list is `<ul role="list">` with each row as `<li><button
+  class="agent-row">`.
+- Status pill: text-bearing (`<span aria-label="active">●</span> active`); the
+  dot is decorative, the word is the truth.
+- Drawer: `role="dialog" aria-modal="false" aria-labelledby="…"` — modeless
+  because the fleet must stay scannable.
+- Confirm dialog: native `<dialog>` opened via `.showModal()` → focus trap +
+  inert backdrop come for free.
+- SSE refresh: when fleet data updates, `aria-live="polite"` on the fleet
+  `<section>` announces "fleet updated" only if the visible counts changed —
+  not on every tick.
+
+### 4.4 Contrast minimums
+
+| Element | Foreground | Background | Required | Source |
+|---|---|---|---|---|
+| body text | `--text` (#ecf2ee) | `--bg` (#0a0e0c) | 4.5:1 | existing tokens — verify |
+| muted meta | `--text2` (#8a9a92) | `--bg` | 4.5:1 | tokens — likely passes, verify |
+| disabled / retired | `--text3` (#4f5d57) | `--bg` | 3:1 (UI, not body copy) | UI element rule |
+| status pill text | pill-fg | pill-bg | 4.5:1 | new — define on implementation |
+| focus ring | `--accent` (#00d97e) | `--bg` | 3:1 (non-text) | passes |
+
+**Status colors must NEVER be the only signal** — see §4.5.
+
+### 4.5 §4.both — MUST FAIL list
+
+Implementation MUST NOT:
+
+- `outline: none` on any focusable element without a replacement focus ring of
+  ≥2px and ≥3:1 contrast against `--bg`.
+- Trap focus inside the drawer (the drawer is non-modal — Tab should escape
+  back to the fleet list).
+- Apply `aria-hidden="true"` to any element that contains a focusable child.
+- Use color alone to signal status — every pill, row state, and rail must carry
+  a text label OR an icon glyph. ("●" alone is not enough; pair with the word.)
+- Animate the SSE refresh in a way that re-fires `aria-live` on every tick
+  regardless of change (announcement spam).
+- Hide the search input or facet bar at sm/xs — they must remain reachable even
+  if visually collapsed under a disclosure.
+- Make the Retire action a single click — must require confirm dialog, and the
+  dialog must be cancelable via ESC.
+
+> Confidence: high · invented: the `/` shortcut hint; everything else is
+> standard WCAG 2.2 AA mapped to this UI.
+
+---
+
+## 5. Responsive contract (§5.web)
+
+PHASE doc states "must work at 1024px width minimum" → `lg` is the design
+target. Smaller breakpoints get graceful degradation, not first-class layouts.
+
+| Component / Region | xs (<640) | sm (640) | md (768) | lg (1024) ✅ | xl (1280+) |
+|---|---|---|---|---|---|
+| Summary tiles row | n/a | 1×4 stack | 2×2 | 4×1 | 4×1 wider |
+| Facet bar | n/a | vertical stack | wrap 3+ lines | wrap ≤2 lines | single line if fits |
+| Search input | n/a | full-width | full-width | 320px fixed | 320px fixed |
+| Agent row | n/a | meta wraps below name | meta wraps below name | inline meta | inline meta |
+| Drill-in drawer | n/a | full-screen overlay | full-screen overlay | 480px right drawer | 520px right drawer |
+| Fleet list | n/a | scroll | scroll | scroll | scroll (no virtualisation needed for 49 rows) |
+
+- **Touch targets:** ≥44 CSS px on rows + chips + buttons even though desktop
+  is primary — costs nothing and helps the contributor on a touchscreen laptop.
+- **Container queries:** not required. Viewport-driven layout is sufficient for
+  this panel since it always occupies the same shell width.
+
+> Confidence: high · invented: drawer-becomes-overlay at sm/md (PHASE doesn't
+> specify); rest is straightforward CSS grid.
+
+---
+
+## 6. Motion contract
+
+- **`prefers-reduced-motion: reduce`:** instant transitions for drawer
+  open/close (no slide), instant tab switch (already the board's behaviour),
+  no rail-fill animation on success bars (render final state).
+- **Max duration for interactive feedback:** 150ms (chip toggle, hover state,
+  button press).
+- **Where motion IS allowed:**
+  - Drawer slide-in (200ms ease-out) — only when reduced-motion is unset.
+  - Rail fill animation on initial render (300ms) — only when reduced-motion
+    is unset.
+  - SSE update flash: a 1-frame `background-color` pulse on changed rows
+    (~80ms, ease-out). Reduced-motion: no flash, just re-render.
+- **Where motion is BANNED:**
+  - No looping animation on status pills (e.g. no pulsing "failing" dot).
+  - No parallax, no auto-rotating anything.
+  - No animation that delays content readability beyond 200ms.
+
+> Confidence: high · invented: durations (heuristic — board has no documented
+> motion system today, so we're seeding one).
+
+---
+
+## 6.5 Platform integration contract
+
+**SKIPPED.** Surface is `web` only — §6.5 is mobile/hybrid territory per the
+v1.1 spec. No notification channels, FSI, deep links into native OS, widgets,
+or background-execution concerns apply.
+
+(Single web concern worth mentioning even though §6.5 doesn't apply: the
+`/agents/:slug` URL must be deep-linkable via hash so a board user can paste
+"go look at this agent" in Slack. Treated in §3.2 as a routing detail.)
+
+> Confidence: high · invented: nothing — section correctly skipped per spec.
+
+---
+
+## 7. Brand tokens (§7.web — CSS custom properties)
+
+Reuse the board's existing token set at `index.html:28-55`. Additions required:
+
+```css
+/* Add to existing :root block — semantic tokens new in this feature */
+
+/* status pills (compose existing palette, name them semantically) */
+--agent-ok:        var(--status-review);    /* green — already defined */
+--agent-idle:      var(--text2);            /* grey */
+--agent-failing:   var(--status-blocked);   /* red — already defined */
+--agent-retired:   var(--text3);            /* dim */
+--agent-unused:    var(--text3);            /* dim — distinct label, same hue */
+
+/* rail tints for the success-rate bar inside .agent-row */
+--rail-ok-bg:      rgba(0, 217, 126, 0.12);
+--rail-ok-fill:    var(--accent);
+--rail-fail-bg:    rgba(248, 113, 113, 0.12);
+--rail-fail-fill:  var(--status-blocked);
+
+/* drawer surface — slightly elevated from .mp-card */
+--surface-drawer:  #0f1411;     /* one step lighter than --bg */
+--drawer-shadow:   0 16px 32px rgba(0,0,0,0.5);
+
+/* spacing — none new; reuse existing --space-* if present, else literal px
+   (board uses literal px today — DO NOT introduce a new spacing system) */
+
+/* typography — none new; --mono for numbers, --sans for labels */
+```
+
+**Hard rule:** zero new font loads. Zero new color hues — every new token must
+resolve to an existing primitive or a low-alpha tint of one. If a designer
+wants a new hue, that's a board-wide decision, not a `/agents` decision.
+
+> Confidence: high · invented: the five `--agent-*` semantic aliases; all
+> resolve to existing primitives.
+
+---
+
+## 8. Out of scope
+
+Explicitly NOT in this iteration:
+
+- Editing agent prompts in-browser (PHASE non-goal; agents are file-based).
+- Spawning agent runs from the UI (PHASE non-goal; `bd`/CLI territory).
+- Agent marketplace / install-from-registry (PHASE non-goal).
+- Inter-agent dependency graph visualization (deferred to a future view).
+- Per-agent cost-by-project breakdown chart (data exists in `m.agents_cost`
+  but charting it is a separate feature).
+- Mobile layouts below 1024px (PHASE: desktop-first; sm/xs is graceful degrade
+  only, no QA pass).
+- Light mode (board is dark-only; out of scope).
+- RTL / i18n (board is en-US only today).
+- Real-time push of new verdicts via a dedicated WebSocket (SSE 5s tick is
+  sufficient; PHASE constraint).
+
+> Confidence: high · invented: nothing — every item sourced from PHASE
+> non-goals or follows from the existing board's posture.
+
+---
+
+## 9. Open questions — capped at 10
+
+### Top 2 to decide before senior-dev starts
+
+1. **[BLOCKER]** Drill-in pattern: **right-side drawer** (this doc's pick) vs
+   **in-place expanding row** vs **full-panel push (replace fleet view)**? —
+   **owner: founder** — why blocker: every wireframe in §3.2, the focus
+   contract in §4, the responsive matrix in §5, and the drawer-shadow token in
+   §7 all assume drawer. Switching pattern means redoing 4 sections of this
+   doc and ~40% of the senior-dev work.
+
+2. **[BLOCKER]** "Retire" semantics: does **soft-retire** move the
+   `~/.claude/agents/great_cto-<slug>.md` file to a `retired/` subdir
+   (filesystem-level, irreversible-ish), or does it write a sidecar
+   `.retired` marker (reversible, file stays in place)? — **owner: founder**
+   — why blocker: the API surface (`POST /api/agents/:slug/retire`), the
+   restore flow (§3.3), and the failure-mode story ("what if the file is
+   gone and a verdict references it?") all hinge on this. Mentioned in
+   PHASE inputs but not decided.
+
+### Remaining open questions (≤8)
+
+3. Faceting taxonomy: is `domain` (arch / qa / security / ops / domain /
+   review) a hand-curated mapping or derived from agent frontmatter? —
+   **owner: founder** — needs source-of-truth decision before facet chips can
+   render. If derived, agents need a `domain:` frontmatter field added
+   pipeline-wide.
+
+4. Threshold for "retire candidate" — PHASE says "never run" but does that
+   mean 0 runs ever, or 0 runs in 30d, or 0 runs in 90d? — **owner: founder**
+   — affects the summary tile count and the default `activity=retire`
+   filter.
+
+5. Failure-mode regex set: who maintains the regex list that clusters
+   verdict `raw` text into named failure modes? — **owner: senior-dev** —
+   start with a baked-in list (rate-limit, BLOCKED-precondition, timeout,
+   parse-fail); expose as a project-local override file later.
+
+6. Legacy-agents card: keep the existing "12 non-canonical sources detected"
+   summary, or remove it now that the fleet view is auditable? — **owner:
+   founder** — keeping it adds noise; removing it loses a cleanup signal.
+
+7. Per-row sparkline: render inline in the `.agent-row` (denser, harder to
+   read) or only in the drill-in profile (cleaner, requires a click)? —
+   **owner: designer-human / founder** — the row already carries a lot of
+   info; sparkline may push us past the 44px touch target without
+   wrapping ugly.
+
+8. SSE refresh strategy when drawer is open: hold updates until drawer
+   closes, or apply live (and risk content jumping under the user)? —
+   **owner: senior-dev** — recommend hold-until-close for the drawer's data;
+   continue live updates for the fleet list behind it.
+
+9. URL deep-link format: `#agents/<slug>` (hash-based, no router) or new
+   `?agent=<slug>` query string? — **owner: senior-dev** — hash is
+   zero-cost and matches the board's no-router posture; query string is
+   slightly more share-friendly.
+
+10. Should the summary tile "LLM spend last 30d" link to the existing cost
+    panel, or is the breakdown shown inline on this tab? — **owner:
+    deferred-to-next-feature** — punt to cost-panel redesign.
+
+> Confidence: med — confident #1 and #2 are real founder-blockers; less
+> confident #3 isn't actually a third blocker (depending on founder's answer
+> it could be).
+
+---
+
+## 10. Implementation hand-off
+
+This doc constrains senior-dev as follows.
+
+**HARD constraints** (deviation requires re-opening this doc):
+
+- §2 component inventory — do not introduce a third new top-level class
+  beyond `.agent-row` and `.agent-profile`. If you need a third, escalate.
+- §4.5 MUST FAIL list — every item is a non-negotiable a11y floor. CI should
+  fail the build if `outline: none` appears in new CSS without a replacement
+  rule in the same selector.
+- §4.2 keyboard map and §4.3 ARIA landmarks — the blind contributor will
+  test this. Get it right.
+- §5 responsive matrix — `lg` is the QA target; `sm`/`md` must render but
+  are not pixel-perfect commitments.
+- §7 zero-new-fonts, zero-new-hues rule — every new token resolves to an
+  existing primitive or a low-alpha tint.
+
+**SOFT recommendations** (deviation OK with a commit-message note):
+
+- Exact ASCII wireframes in §3 — structural intent matters, exact pixel
+  layout doesn't. If you find a better arrangement in the same region tree,
+  use it.
+- Motion durations in §6 — within ±50ms of the listed values is fine.
+- The `/` keyboard shortcut in §4.2 — keep it if cheap, drop it if it
+  conflicts with the board's existing shortcut map.
+
+**Sequencing:**
+
+- **Do NOT start UI work** until the Top-2 questions in §9 are answered. The
+  drawer-vs-expand decision in particular changes the shape of `.agent-row`
+  itself.
+- Once Top-2 are answered, the remaining questions (§9 #3–#10) can be
+  resolved as you implement.
+
+**Reuse first:** every new class composes existing primitives. If you find
+yourself writing CSS that overlaps `.mp-card` / `.metric-card` / `.bar-row` /
+`.fchip`, stop and ask whether you're rebuilding something that already
+exists.
+
+> Confidence: high · invented: nothing — this is a summary of decisions
+> already made in §§1-8.

--- a/packages/board/public/index.html
+++ b/packages/board/public/index.html
@@ -1408,7 +1408,7 @@ button { font-family: inherit; cursor: pointer; }
 .log-bullets li::before { content: '·'; position: absolute; left: 0; color: var(--accent); }
 .log-empty { font-size: 13px; color: var(--text3); font-style: italic; }
 
-/* ── Agents installed list ─────────────────────────────── */
+/* ── Agents installed list (legacy — kept for fallback) ───────────────── */
 .agents-installed { display: grid; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr)); gap: 10px; margin-top: 4px; }
 .agent-card { background: var(--bg-muted); border: 1px solid var(--border); border-radius: 8px; padding: 10px 12px; }
 .agent-card .ac-name { font-size: 12px; font-weight: 600; font-family: var(--mono); color: var(--accent); }
@@ -1417,6 +1417,247 @@ button { font-family: inherit; cursor: pointer; }
 .agent-card .ac-model { background: var(--bg-strong); padding: 1px 5px; border-radius: 3px; }
 .agent-card .ac-used { color: var(--status-review); }
 .agent-card .ac-never { color: var(--text3); font-style: italic; }
+
+/* ── Agents fleet view (DESIGN-agents-fleet-view §3) ───────────────────
+   Semantic tokens — every value resolves to an existing primitive or a
+   low-alpha tint of one. Zero new fonts, zero new hues. */
+:root {
+  --agent-ok:        var(--status-review);
+  --agent-idle:      var(--text2);
+  --agent-failing:   var(--status-blocked);
+  --agent-retired:   var(--text3);
+  --agent-unused:    var(--text3);
+  --rail-ok-bg:      rgba(0, 217, 126, 0.12);
+  --rail-fail-bg:    rgba(255, 84, 102, 0.12);
+  --surface-drawer:  #0f1411;
+  --drawer-shadow:   0 16px 32px rgba(0, 0, 0, 0.5);
+}
+
+/* Fleet summary — uses existing .metric-card; nothing new */
+
+/* Fleet controls — search + facets row */
+.fleet-controls { display: flex; flex-direction: column; gap: 12px; }
+.fleet-search { display: flex; align-items: center; gap: 8px; }
+.fleet-search input[type="search"] {
+  flex: 1; max-width: 320px;
+  background: var(--bg-muted); border: 1px solid var(--border);
+  color: var(--text); font-family: var(--mono); font-size: 13px;
+  padding: 8px 12px; border-radius: 6px;
+}
+.fleet-search input[type="search"]:focus {
+  outline: 2px solid var(--accent); outline-offset: 1px;
+  border-color: transparent;
+}
+.fleet-search .search-hint { font-size: 11px; color: var(--text3); font-family: var(--mono); }
+.fleet-search .search-hint kbd {
+  background: var(--bg-muted); border: 1px solid var(--border);
+  border-radius: 3px; padding: 1px 5px; font-size: 10px;
+}
+
+.fleet-facets { display: flex; flex-direction: column; gap: 6px; }
+.fleet-facets fieldset {
+  border: none; padding: 0; margin: 0;
+  display: flex; gap: 6px; align-items: center; flex-wrap: wrap;
+}
+.fleet-facets legend {
+  font-size: 11px; color: var(--text3); text-transform: uppercase;
+  letter-spacing: 0.05em; margin-right: 6px; min-width: 60px;
+}
+.facet-chip {
+  background: var(--bg-muted); border: 1px solid var(--border);
+  color: var(--text2); font-size: 12px; font-family: var(--mono);
+  padding: 4px 10px; border-radius: 12px; cursor: pointer;
+  transition: background-color 0.15s, color 0.15s, border-color 0.15s;
+}
+.facet-chip:hover { color: var(--text); border-color: var(--border-strong); }
+.facet-chip:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
+.facet-chip[aria-checked="true"] {
+  background: var(--accent-soft); color: var(--accent);
+  border-color: var(--accent-strong);
+}
+.facet-chip[disabled] { opacity: 0.4; cursor: not-allowed; }
+
+.fleet-sort {
+  display: flex; gap: 8px; align-items: center;
+  font-size: 11px; color: var(--text3);
+}
+.fleet-sort select {
+  background: var(--bg-muted); border: 1px solid var(--border);
+  color: var(--text); font-family: var(--mono); font-size: 12px;
+  padding: 4px 8px; border-radius: 6px;
+}
+.fleet-sort button {
+  background: transparent; border: 1px solid var(--border);
+  color: var(--text2); font-size: 11px; font-family: var(--mono);
+  padding: 4px 8px; border-radius: 6px;
+}
+.fleet-sort button:hover { color: var(--text); border-color: var(--border-strong); }
+
+/* Agent row — faceted-list line */
+.fleet-list {
+  list-style: none; margin: 0; padding: 0;
+  display: flex; flex-direction: column; gap: 4px;
+}
+.agent-row {
+  display: grid;
+  grid-template-columns: auto 1fr auto auto;
+  gap: 16px; align-items: center;
+  width: 100%; min-height: 44px;
+  background: transparent; border: 1px solid transparent;
+  color: var(--text); text-align: left; font: inherit;
+  padding: 10px 12px; border-radius: 6px; cursor: pointer;
+  transition: background-color 0.15s, border-color 0.15s;
+}
+.agent-row:hover { background: var(--bg-muted); border-color: var(--border); }
+.agent-row:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
+.agent-row[aria-current="true"] {
+  background: var(--accent-soft);
+  border-color: var(--accent-strong);
+}
+.agent-row.retired { opacity: 0.55; }
+.agent-row .ar-status {
+  width: 8px; height: 8px; border-radius: 50%;
+  background: var(--agent-idle); flex-shrink: 0;
+}
+.agent-row.status-ok      .ar-status { background: var(--agent-ok); }
+.agent-row.status-failing .ar-status { background: var(--agent-failing); }
+.agent-row.status-idle    .ar-status { background: var(--agent-idle); }
+.agent-row.status-unused  .ar-status { background: var(--agent-unused); }
+.agent-row.status-retired .ar-status { background: var(--agent-retired); }
+.agent-row .ar-body { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+.agent-row .ar-name { font-family: var(--mono); font-size: 13px; color: var(--text); }
+.agent-row .ar-meta { font-size: 11px; color: var(--text3); display: flex; gap: 10px; flex-wrap: wrap; }
+.agent-row .ar-meta .ar-domain {
+  background: var(--bg-muted); padding: 1px 6px; border-radius: 3px;
+  color: var(--text2); font-family: var(--mono); font-size: 10px;
+}
+.agent-row .ar-rail {
+  width: 80px; height: 4px;
+  background: var(--rail-ok-bg); border-radius: 2px; overflow: hidden;
+}
+.agent-row.status-failing .ar-rail { background: var(--rail-fail-bg); }
+.agent-row .ar-rail-fill {
+  display: block; height: 100%;
+  background: var(--agent-ok);
+}
+.agent-row.status-failing .ar-rail-fill { background: var(--agent-failing); }
+.agent-row .ar-chev {
+  color: var(--text3); font-size: 14px; padding: 0 4px;
+}
+
+/* Status pill — used in drawer header */
+.status-pill {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-size: 11px; font-family: var(--mono);
+  padding: 2px 8px; border-radius: 10px;
+  background: var(--bg-muted); border: 1px solid var(--border);
+}
+.status-pill .pill-dot {
+  width: 6px; height: 6px; border-radius: 50%;
+  background: var(--agent-idle);
+}
+.status-pill.tone-ok      { color: var(--agent-ok);      border-color: var(--accent-strong); }
+.status-pill.tone-ok      .pill-dot { background: var(--agent-ok); }
+.status-pill.tone-failing { color: var(--agent-failing); }
+.status-pill.tone-failing .pill-dot { background: var(--agent-failing); }
+.status-pill.tone-idle    { color: var(--agent-idle); }
+.status-pill.tone-idle    .pill-dot { background: var(--agent-idle); }
+.status-pill.tone-retired { color: var(--agent-retired); }
+.status-pill.tone-retired .pill-dot { background: var(--agent-retired); }
+.status-pill.tone-unused  { color: var(--agent-unused); }
+.status-pill.tone-unused  .pill-dot { background: var(--agent-unused); }
+
+/* Drill-in drawer */
+.agent-drawer {
+  position: fixed; top: 0; right: 0; bottom: 0;
+  width: 480px; max-width: 90vw;
+  background: var(--surface-drawer);
+  border-left: 1px solid var(--border-strong);
+  box-shadow: var(--drawer-shadow);
+  display: flex; flex-direction: column;
+  z-index: 10;
+  transform: translateX(100%);
+  transition: transform 200ms ease-out;
+}
+.agent-drawer[open] { transform: translateX(0); }
+@media (prefers-reduced-motion: reduce) {
+  .agent-drawer { transition: none; }
+}
+.agent-drawer-header {
+  display: flex; align-items: center; gap: 10px;
+  padding: 16px 20px; border-bottom: 1px solid var(--border);
+}
+.agent-drawer-header h3 {
+  font-family: var(--mono); font-size: 14px;
+  color: var(--text); flex: 1; margin: 0;
+}
+.agent-drawer-close {
+  background: transparent; border: 1px solid var(--border);
+  color: var(--text2); font-size: 18px; line-height: 1;
+  width: 28px; height: 28px; border-radius: 6px;
+  display: flex; align-items: center; justify-content: center;
+}
+.agent-drawer-close:hover { color: var(--text); border-color: var(--border-strong); }
+.agent-drawer-close:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
+.agent-drawer-body {
+  flex: 1; overflow-y: auto; padding: 16px 20px;
+  display: flex; flex-direction: column; gap: 16px;
+}
+.agent-drawer-body .mp-card { padding: 12px 14px; }
+.agent-drawer-body h4 {
+  font-size: 11px; text-transform: uppercase;
+  color: var(--text3); letter-spacing: 0.05em;
+  margin: 0 0 8px;
+}
+.agent-summary-grid {
+  display: grid; grid-template-columns: auto 1fr; gap: 4px 12px;
+  font-size: 12px;
+}
+.agent-summary-grid dt { color: var(--text3); font-family: var(--mono); }
+.agent-summary-grid dd { color: var(--text); font-family: var(--mono); margin: 0; }
+.run-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 4px; }
+.run-row {
+  display: grid; grid-template-columns: auto auto 1fr auto; gap: 10px;
+  font-size: 11px; font-family: var(--mono); color: var(--text2);
+  padding: 4px 0;
+}
+.run-row .rr-verdict.ok      { color: var(--agent-ok); }
+.run-row .rr-verdict.fail    { color: var(--agent-failing); }
+.run-row .rr-verdict.neutral { color: var(--text2); }
+.run-row .rr-raw { color: var(--text3); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.failure-list { list-style: none; margin: 0; padding: 0; }
+.failure-list li {
+  display: flex; gap: 10px; padding: 4px 0;
+  font-family: var(--mono); font-size: 12px;
+}
+.failure-list .fm-key   { flex: 1; color: var(--text); }
+.failure-list .fm-count { color: var(--agent-failing); }
+.failure-list .fm-last  { color: var(--text3); font-size: 11px; }
+.agent-actions { display: flex; gap: 8px; flex-wrap: wrap; }
+.agent-actions button {
+  background: var(--bg-muted); border: 1px solid var(--border);
+  color: var(--text); font-family: var(--mono); font-size: 12px;
+  padding: 6px 12px; border-radius: 6px;
+}
+.agent-actions button:hover { border-color: var(--border-strong); }
+.agent-actions button:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
+.agent-actions button.danger { color: var(--agent-failing); }
+.agent-actions button.danger:hover { border-color: var(--agent-failing); }
+.agent-actions button[disabled] { opacity: 0.4; cursor: not-allowed; }
+.drawer-backdrop {
+  position: fixed; inset: 0; z-index: 9;
+  background: rgba(0, 0, 0, 0.2);
+  opacity: 0; pointer-events: none;
+  transition: opacity 200ms ease-out;
+}
+.drawer-backdrop[open] { opacity: 1; pointer-events: auto; }
+@media (prefers-reduced-motion: reduce) {
+  .drawer-backdrop { transition: none; }
+}
+
+@media (max-width: 1023px) {
+  .agent-drawer { width: 100%; max-width: 100%; border-left: none; }
+}
 
 .share-page {
   padding: 32px;
@@ -1862,31 +2103,80 @@ button { font-family: inherit; cursor: pointer; }
       </div>
     </div>
 
-    <div class="panel" id="panel-agents">
+    <div class="panel" id="panel-agents" role="tabpanel" aria-labelledby="tab-agents">
       <div class="metrics-page">
-        <div class="mp-section-label">Agent cost estimate</div>
-        <div class="mp-card" id="agent-cost-panel">
-          <div class="cost-empty">Loading…</div>
-        </div>
-
-        <div class="mp-row" style="margin-top:24px">
-          <div class="mp-card">
-            <h3>Agent utilization</h3>
-            <div id="agent-list"></div>
+        <!-- §3.1 Fleet summary -->
+        <section aria-label="Fleet summary">
+          <div class="mp-section-label">Fleet</div>
+          <div class="mp-row" id="fleet-summary">
+            <div class="cost-empty">Loading…</div>
           </div>
+        </section>
+
+        <!-- §3.1 Fleet controls -->
+        <section aria-label="Fleet controls" style="margin-top:20px">
+          <div class="mp-card fleet-controls">
+            <div class="fleet-search">
+              <input type="search" id="fleet-search" placeholder="Filter agents (press / to focus)" aria-label="Filter agents by slug" />
+              <span class="search-hint"><kbd>/</kbd> focus · <kbd>Enter</kbd> open · <kbd>Esc</kbd> close</span>
+            </div>
+            <div class="fleet-facets" id="fleet-facets">
+              <!-- populated via renderFleetFacets() -->
+            </div>
+            <div class="fleet-sort">
+              <label for="fleet-sort-by">Sort by</label>
+              <select id="fleet-sort-by">
+                <option value="runs_30d">runs (30d)</option>
+                <option value="last_run">last run</option>
+                <option value="success_rate">success rate</option>
+                <option value="savings_x">savings ×</option>
+                <option value="llm_usd_30d_est">LLM spend (30d)</option>
+                <option value="slug">slug A→Z</option>
+              </select>
+              <button type="button" id="fleet-reset-filters">Reset filters</button>
+            </div>
+          </div>
+        </section>
+
+        <!-- §3.1 Fleet list -->
+        <section aria-label="Agent fleet" aria-live="polite" style="margin-top:20px">
+          <div class="mp-card">
+            <ul class="fleet-list" id="fleet-list" role="list">
+              <li class="cost-empty">Loading…</li>
+            </ul>
+          </div>
+        </section>
+
+        <!-- Legacy non-canonical sources note — kept per §9 #6 -->
+        <section aria-label="Legacy agents" id="legacy-agents-section" style="margin-top:20px" hidden>
           <div class="mp-card">
             <div class="mp-card-head">
-              <h3>Activity</h3>
-              <span class="mp-card-meta" id="activity-meta">last 24h</span>
+              <h3 style="font-size:13px">Legacy / non-canonical sources</h3>
+              <span class="mp-card-meta" id="legacy-agents-count"></span>
             </div>
-            <div id="timeline"></div>
+            <div style="font-size:12px;color:var(--text3);margin-top:6px">
+              Verdicts logged under agent names not in <code>~/.claude/agents/great_cto-*.md</code>
+              (older log files, custom scripts). Listed in <code>m.legacy_agent_runs</code>; cleanup is a
+              one-time housekeeping task.
+            </div>
           </div>
-        </div>
+        </section>
 
-        <div class="mp-section-label" style="margin-top:28px">Installed specialist agents <span id="agents-installed-count" style="color:var(--text3);font-size:11px"></span></div>
-        <div class="agents-installed" id="agents-installed-grid">
-          <div class="cost-empty">Loading…</div>
-        </div>
+        <!-- Drill-in drawer (§3.2) — populated on row click -->
+        <div class="drawer-backdrop" id="agent-drawer-backdrop" aria-hidden="true"></div>
+        <aside class="agent-drawer" id="agent-drawer"
+               role="dialog" aria-modal="false" aria-hidden="true"
+               aria-labelledby="agent-drawer-title">
+          <div class="agent-drawer-header">
+            <h3 id="agent-drawer-title">Agent profile</h3>
+            <span id="agent-drawer-pill"></span>
+            <button type="button" class="agent-drawer-close" id="agent-drawer-close"
+                    aria-label="Close agent profile">×</button>
+          </div>
+          <div class="agent-drawer-body" id="agent-drawer-body">
+            <div class="cost-empty">Loading…</div>
+          </div>
+        </aside>
       </div>
     </div>
 
@@ -3404,26 +3694,422 @@ function renderLogDetail(log) {
     </div>`;
 }
 
-/* ── Agents installed ───────────────────────────────────────────────────── */
+/* ── Agents fleet view (DESIGN-agents-fleet-view §3) ────────────────────
+   Single source of state per refresh; UI re-derived via renderFleetList().
+   Drawer uses hash routing (#agents/<slug>) per §9 #9 (hash-based picked). */
+
+const fleetState = {
+  agents: [],
+  summary: null,
+  legacy_count: 0,
+  filters: { domain: 'all', activity: 'all', health: 'all' },
+  search: '',
+  sort: 'runs_30d',
+  drawerSlug: null,
+};
+
 async function refreshAgentsInstalled() {
   const data = await api('/api/agents-installed');
   if (!data) return;
-  const agents = data.agents || [];
-  const countEl = document.getElementById('agents-installed-count');
-  if (countEl) countEl.textContent = `(${agents.length})`;
-  const grid = document.getElementById('agents-installed-grid');
-  if (!grid) return;
-  if (!agents.length) { grid.innerHTML = '<div class="cost-empty">No great_cto agents found in ~/.claude/agents/</div>'; return; }
-  grid.innerHTML = agents.map(a => {
-    const lastUsedStr = a.lastUsed
-      ? `<span class="ac-used">last used: ${esc(a.lastUsed.slice(0,10))}</span>`
-      : `<span class="ac-never">never used</span>`;
-    return `<div class="agent-card">
-      <div class="ac-name">${esc(a.name)}</div>
-      <div class="ac-desc" title="${esc(a.description)}">${esc(a.description || '—')}</div>
-      <div class="ac-meta"><span class="ac-model">${esc(a.model)}</span>${lastUsedStr}</div>
-    </div>`;
+  fleetState.agents = data.agents || [];
+  fleetState.summary = data.summary || null;
+  // legacy_agent_count comes from /api/metrics — pull from cached metrics if present
+  fleetState.legacy_count = (typeof metrics !== 'undefined' && metrics && metrics.legacy_agent_count) || 0;
+  renderFleetSummary();
+  renderFleetFacets();
+  renderFleetList();
+  renderLegacyAgentsSection();
+  // If the URL hash names a drawer, open it (post-load).
+  const m = (location.hash || '').match(/^#agents\/([a-z0-9-]+)$/i);
+  if (m) openAgentDrawer(m[1], { fromHash: true });
+}
+
+function renderFleetSummary() {
+  const el = document.getElementById('fleet-summary');
+  if (!el) return;
+  const s = fleetState.summary;
+  if (!s) { el.innerHTML = '<div class="cost-empty">No data yet</div>'; return; }
+  const tiles = [
+    { v: s.installed, label: 'Installed agents', cls: '' },
+    { v: s.active_30d, label: 'Active last 30d', cls: 'green', trend: s.active_30d > 0 ? '' : 'no activity yet' },
+    {
+      v: s.retire_candidates,
+      label: 'Retire candidates',
+      cls: s.retire_candidates > s.installed * 0.5 ? 'amber' : '',
+      trend: s.retire_candidates > 0 ? 'click to filter' : 'fleet is lean',
+      onClick: 'setFleetFilter("activity", "never")',
+    },
+    { v: '$' + (s.llm_usd_30d ?? 0).toFixed(2), label: 'LLM spend 30d', cls: '', trend: s.failing_7d ? `${s.failing_7d} failing` : '' },
+  ];
+  el.innerHTML = tiles.map(t => `
+    <div class="metric-card ${t.cls}" ${t.onClick ? `role="button" tabindex="0" onclick='${t.onClick}' onkeydown='if(event.key==="Enter"||event.key===" "){event.preventDefault();${t.onClick}}'` : ''}>
+      <div class="metric-num">${esc(String(t.v))}</div>
+      <div class="metric-label">${esc(t.label)}</div>
+      ${t.trend ? `<div class="metric-trend">${esc(t.trend)}</div>` : ''}
+    </div>`).join('');
+}
+
+const FACET_GROUPS = [
+  {
+    key: 'domain', legend: 'Domain',
+    options: [
+      ['all', 'all'], ['arch', 'arch'], ['pm', 'pm'], ['qa', 'qa'],
+      ['security', 'security'], ['ops', 'ops'], ['domain', 'domain'],
+      ['memory', 'memory'], ['other', 'other'],
+    ],
+  },
+  {
+    key: 'activity', legend: 'Activity',
+    options: [
+      ['all', 'all'], ['active', 'active'], ['idle', 'idle ≥30d'], ['never', 'never run'], ['retired', 'retired'],
+    ],
+  },
+  {
+    key: 'health', legend: 'Health',
+    options: [
+      ['all', 'all'], ['ok', 'ok'], ['failing', 'failing ≥3 in 7d'],
+    ],
+  },
+];
+
+function renderFleetFacets() {
+  const el = document.getElementById('fleet-facets');
+  if (!el) return;
+  el.innerHTML = FACET_GROUPS.map(g => `
+    <fieldset>
+      <legend>${esc(g.legend)}</legend>
+      ${g.options.map(([val, label]) => {
+        const checked = fleetState.filters[g.key] === val;
+        return `<button type="button" class="facet-chip"
+                role="checkbox" aria-checked="${checked}"
+                data-facet="${esc(g.key)}" data-value="${esc(val)}"
+                onclick="setFleetFilter('${esc(g.key)}', '${esc(val)}')">
+                ${esc(label)}</button>`;
+      }).join('')}
+    </fieldset>`).join('');
+}
+
+function setFleetFilter(key, value) {
+  fleetState.filters[key] = value;
+  renderFleetFacets();
+  renderFleetList();
+}
+
+function applyFleetFilters(agents) {
+  const { domain, activity, health } = fleetState.filters;
+  const q = (fleetState.search || '').toLowerCase().trim();
+  return agents.filter(a => {
+    if (q && !a.slug.toLowerCase().includes(q) && !(a.description || '').toLowerCase().includes(q)) return false;
+    if (domain !== 'all' && a.domain !== domain) return false;
+    if (activity === 'active'  && a.runs_30d === 0) return false;
+    if (activity === 'idle'    && (a.runs_30d > 0 || a.runs_total === 0)) return false;
+    if (activity === 'never'   && a.runs_total > 0) return false;
+    if (activity === 'retired' && !a.retired) return false;
+    if (activity !== 'retired' && a.retired) return false;
+    if (health === 'ok'        && a.health === 'failing') return false;
+    if (health === 'failing'   && a.health !== 'failing') return false;
+    return true;
+  });
+}
+
+function sortFleet(agents) {
+  const sort = fleetState.sort;
+  const dir = sort === 'slug' ? 1 : -1;
+  return [...agents].sort((a, b) => {
+    let av = a[sort], bv = b[sort];
+    if (av == null) av = sort === 'slug' ? 'zzz' : -1;
+    if (bv == null) bv = sort === 'slug' ? 'zzz' : -1;
+    if (av < bv) return -1 * dir;
+    if (av > bv) return  1 * dir;
+    return a.slug.localeCompare(b.slug);
+  });
+}
+
+function renderFleetList() {
+  const el = document.getElementById('fleet-list');
+  if (!el) return;
+  const filtered = sortFleet(applyFleetFilters(fleetState.agents));
+  if (!filtered.length) {
+    el.innerHTML = '<li class="empty" style="padding:20px;text-align:center;color:var(--text3)">No agents match these filters.</li>';
+    return;
+  }
+  el.innerHTML = filtered.map(a => {
+    const rate = a.success_rate;
+    const rateLabel = rate != null ? `${rate}% ok` : 'no verdicts';
+    const lastRunStr = a.last_run ? agoStr(a.last_run) : 'never run';
+    const savingsStr = a.savings_x != null ? `${a.savings_x}× savings` : '';
+    const runsStr = `${a.runs_30d} run${a.runs_30d === 1 ? '' : 's'} 30d`;
+    return `<li>
+      <button class="agent-row status-${esc(a.health)}${a.retired ? ' retired' : ''}"
+              role="button" data-slug="${esc(a.slug)}"
+              aria-label="${esc(a.slug)} · ${esc(a.health)} · ${rateLabel} · ${esc(lastRunStr)}"
+              onclick="openAgentDrawer('${esc(a.slug)}')"
+              onkeydown="if(event.key==='Enter'){event.preventDefault();openAgentDrawer('${esc(a.slug)}')}">
+        <span class="ar-status" aria-hidden="true"></span>
+        <span class="ar-body">
+          <span class="ar-name">${esc(a.slug)}</span>
+          <span class="ar-meta">
+            <span class="ar-domain">${esc(a.domain)}</span>
+            <span>${esc(runsStr)}</span>
+            <span>${esc(rateLabel)}</span>
+            <span>last: ${esc(lastRunStr)}</span>
+            ${savingsStr ? `<span>${esc(savingsStr)}</span>` : ''}
+            ${a.retired ? '<span style="color:var(--agent-retired)">retired</span>' : ''}
+          </span>
+        </span>
+        <span class="ar-rail" aria-hidden="true">
+          ${rate != null ? `<span class="ar-rail-fill" style="width:${rate}%"></span>` : ''}
+        </span>
+        <span class="ar-chev" aria-hidden="true">›</span>
+      </button>
+    </li>`;
   }).join('');
+}
+
+function renderLegacyAgentsSection() {
+  const sec = document.getElementById('legacy-agents-section');
+  const cnt = document.getElementById('legacy-agents-count');
+  if (!sec) return;
+  if (fleetState.legacy_count > 0) {
+    sec.hidden = false;
+    if (cnt) cnt.textContent = `${fleetState.legacy_count} runs`;
+  } else {
+    sec.hidden = true;
+  }
+}
+
+function agoStr(iso) {
+  if (!iso) return '—';
+  const ms = Date.now() - new Date(iso).getTime();
+  if (ms < 0) return 'just now';
+  const m = ms / 60000, h = m / 60, d = h / 24;
+  if (m < 1) return 'just now';
+  if (m < 60) return `${Math.round(m)}m ago`;
+  if (h < 48) return `${Math.round(h)}h ago`;
+  return `${Math.round(d)}d ago`;
+}
+
+/* ── Agent drawer (§3.2 drill-in) ──────────────────────────────────────── */
+
+let _drawerLastFocus = null;
+
+async function openAgentDrawer(slug, opts = {}) {
+  const drawer  = document.getElementById('agent-drawer');
+  const backdrop = document.getElementById('agent-drawer-backdrop');
+  const body    = document.getElementById('agent-drawer-body');
+  const title   = document.getElementById('agent-drawer-title');
+  const pill    = document.getElementById('agent-drawer-pill');
+  if (!drawer || !body) return;
+
+  // Remember the row that opened us so Esc returns focus there.
+  if (!opts.fromHash) {
+    _drawerLastFocus = document.activeElement;
+  }
+
+  fleetState.drawerSlug = slug;
+  // Highlight active row.
+  document.querySelectorAll('.agent-row').forEach(r => {
+    r.setAttribute('aria-current', r.dataset.slug === slug ? 'true' : 'false');
+  });
+
+  // Update URL hash without scroll.
+  if (location.hash !== `#agents/${slug}`) {
+    history.replaceState(null, '', `#agents/${slug}`);
+  }
+
+  drawer.setAttribute('open', '');
+  drawer.setAttribute('aria-hidden', 'false');
+  backdrop.setAttribute('open', '');
+  backdrop.setAttribute('aria-hidden', 'false');
+  title.textContent = slug;
+  pill.innerHTML = '';
+  body.innerHTML = '<div class="cost-empty">Loading…</div>';
+
+  // Move focus into the drawer after the open transition.
+  setTimeout(() => {
+    document.getElementById('agent-drawer-close')?.focus();
+  }, 50);
+
+  const profile = await api(`/api/agents/${encodeURIComponent(slug)}`);
+  if (!profile || profile.error) {
+    body.innerHTML = `<div class="cost-empty">Agent <code>${esc(slug)}</code> not found.</div>`;
+    return;
+  }
+  if (fleetState.drawerSlug !== slug) return; // drawer swapped while loading
+  renderAgentProfile(profile);
+}
+
+function closeAgentDrawer() {
+  const drawer   = document.getElementById('agent-drawer');
+  const backdrop = document.getElementById('agent-drawer-backdrop');
+  if (!drawer) return;
+  drawer.removeAttribute('open');
+  drawer.setAttribute('aria-hidden', 'true');
+  backdrop.removeAttribute('open');
+  backdrop.setAttribute('aria-hidden', 'true');
+  fleetState.drawerSlug = null;
+  // Strip hash.
+  if (location.hash.startsWith('#agents/')) {
+    history.replaceState(null, '', location.pathname + location.search);
+  }
+  // Restore focus to the triggering row.
+  if (_drawerLastFocus && document.contains(_drawerLastFocus)) {
+    _drawerLastFocus.focus();
+  }
+  document.querySelectorAll('.agent-row').forEach(r => r.setAttribute('aria-current', 'false'));
+}
+
+function renderAgentProfile(p) {
+  const body  = document.getElementById('agent-drawer-body');
+  const title = document.getElementById('agent-drawer-title');
+  const pill  = document.getElementById('agent-drawer-pill');
+  if (!body) return;
+  title.textContent = p.slug;
+  pill.innerHTML = `<span class="status-pill tone-${esc(p.health)}">
+    <span class="pill-dot" aria-hidden="true"></span>${esc(p.retired ? 'retired' : p.health)}
+  </span>`;
+
+  const savings = p.savings_x != null ? `${p.savings_x}× ($${(p.llm_usd_30d_est ?? 0).toFixed(2)} vs $${(p.human_usd_30d_est ?? 0).toLocaleString()})` : '—';
+  const realCost = p.llm_usd_30d_real != null ? `· measured $${p.llm_usd_30d_real.toFixed(4)}` : '';
+
+  body.innerHTML = `
+    <div class="mp-card">
+      <h4>Summary</h4>
+      <dl class="agent-summary-grid">
+        <dt>domain</dt>      <dd>${esc(p.domain)}</dd>
+        <dt>model</dt>       <dd>${esc(p.model)}</dd>
+        ${p.applies_to.length ? `<dt>applies_to</dt><dd>${esc(p.applies_to.join(', '))}</dd>` : ''}
+        <dt>runs total</dt>  <dd>${p.runs_total} · ${p.runs_30d} in 30d</dd>
+        <dt>success</dt>     <dd>${p.success_rate != null ? `${p.success_rate}% (${p.ok_30d}/${p.ok_30d + p.fail_30d})` : 'no verdicts in 30d'}</dd>
+        <dt>last run</dt>    <dd>${p.last_run ? esc(p.last_run.slice(0, 16).replace('T', ' ') + ' · ' + agoStr(p.last_run)) : 'never'}</dd>
+        <dt>savings</dt>     <dd>${esc(savings)} ${esc(realCost)}</dd>
+      </dl>
+      ${p.description ? `<div style="font-size:11px;color:var(--text3);margin-top:8px;line-height:1.5">${esc(p.description)}</div>` : ''}
+    </div>
+
+    <div class="mp-card">
+      <h4>Recent runs <span style="color:var(--text3);font-weight:normal">(last ${p.recent_runs.length})</span></h4>
+      ${p.recent_runs.length ? `
+        <ul class="run-list" role="list">
+          ${p.recent_runs.map(r => {
+            const tone = isSuccessVerdict(r.verdict) ? 'ok' : (isFailureVerdict(r.verdict) ? 'fail' : 'neutral');
+            return `<li class="run-row">
+              <span>${esc((r.ts || '').slice(5, 16).replace('T', ' '))}</span>
+              <span class="rr-verdict ${tone}">${esc(r.verdict || '—')}</span>
+              <span class="rr-raw" title="${esc(r.raw)}">${esc(r.raw)}</span>
+              <span>${r.cost_usd != null ? '$' + r.cost_usd.toFixed(4) : ''}</span>
+            </li>`;
+          }).join('')}
+        </ul>` : '<div class="cost-empty">No recent runs.</div>'}
+    </div>
+
+    <div class="mp-card">
+      <h4>Failure modes <span style="color:var(--text3);font-weight:normal">(30d)</span></h4>
+      ${p.failure_modes.length ? `
+        <ul class="failure-list" role="list">
+          ${p.failure_modes.map(f => `<li>
+            <span class="fm-key">${esc(f.key)}</span>
+            <span class="fm-count">×${f.count}</span>
+            <span class="fm-last">${esc(agoStr(f.last_seen))}</span>
+          </li>`).join('')}
+        </ul>` : '<div class="cost-empty">No failures clustered in 30d. Quiet agent.</div>'}
+    </div>
+
+    <div class="mp-card">
+      <h4>Actions</h4>
+      <div class="agent-actions">
+        ${p.retired
+          ? `<button type="button" onclick="restoreAgentAction('${esc(p.slug)}')">Restore agent</button>`
+          : `<button type="button" class="danger" onclick="retireAgentAction('${esc(p.slug)}')">Retire agent</button>`}
+        <button type="button" disabled title="Opening external files is not yet wired up">Open prompt file</button>
+      </div>
+      <div style="font-size:11px;color:var(--text3);margin-top:8px">
+        File: <code>${esc(p.file_path)}</code>
+      </div>
+    </div>`;
+}
+
+function isSuccessVerdict(v) { return /^(APPROVED|OK|DONE|PASS|PASSED)$/i.test(v || ''); }
+function isFailureVerdict(v) { return /^(BLOCKED|FAIL|FAILED|REJECTED)$/i.test(v || ''); }
+
+async function retireAgentAction(slug) {
+  // §9 #2 picked: reversible sidecar. confirm() is a v1 affordance; spec
+  // recommends native <dialog> with focus trap — flagged for v2.
+  if (!confirm(`Retire ${slug}?\n\nThe agent file stays in place; a .retired sidecar marker hides it from the active fleet. Reversible via Restore.`)) return;
+  const r = await fetch(`/api/agents/${encodeURIComponent(slug)}/retire`, {
+    method: 'POST', headers: { 'Content-Type': 'application/json' },
+  }).then(r => r.json()).catch(e => ({ error: String(e) }));
+  if (r.error) {
+    showToast(`Retire failed: ${r.error}`, 'error', 2500);
+    return;
+  }
+  showToast(`Retired ${slug}`, 'info', 1500);
+  await refreshAgentsInstalled();
+  // Re-open drawer to show the new retired state.
+  openAgentDrawer(slug, { fromHash: true });
+}
+
+async function restoreAgentAction(slug) {
+  const r = await fetch(`/api/agents/${encodeURIComponent(slug)}/restore`, {
+    method: 'POST', headers: { 'Content-Type': 'application/json' },
+  }).then(r => r.json()).catch(e => ({ error: String(e) }));
+  if (r.error) {
+    showToast(`Restore failed: ${r.error}`, 'error', 2500);
+    return;
+  }
+  showToast(`Restored ${slug}`, 'info', 1500);
+  await refreshAgentsInstalled();
+  openAgentDrawer(slug, { fromHash: true });
+}
+
+/* Keyboard map (§4.2):
+   "/" focuses search · Esc closes drawer · Enter on row is wired on the
+   button element. Wire global handlers once at startup. */
+function wireFleetKeyboard() {
+  document.addEventListener('keydown', (e) => {
+    // "/" to focus search, only when /agents panel is active and not already typing
+    if (e.key === '/' && currentTab === 'agents'
+        && !['INPUT', 'TEXTAREA'].includes(document.activeElement?.tagName)) {
+      const input = document.getElementById('fleet-search');
+      if (input) { e.preventDefault(); input.focus(); input.select(); }
+    }
+    // Esc closes drawer
+    if (e.key === 'Escape' && fleetState.drawerSlug) {
+      e.preventDefault();
+      closeAgentDrawer();
+    }
+  });
+  // Search input live filter
+  const input = document.getElementById('fleet-search');
+  if (input) {
+    input.addEventListener('input', (e) => {
+      fleetState.search = e.target.value;
+      renderFleetList();
+    });
+  }
+  // Sort + reset
+  document.getElementById('fleet-sort-by')?.addEventListener('change', (e) => {
+    fleetState.sort = e.target.value;
+    renderFleetList();
+  });
+  document.getElementById('fleet-reset-filters')?.addEventListener('click', () => {
+    fleetState.filters = { domain: 'all', activity: 'all', health: 'all' };
+    fleetState.search = '';
+    const input = document.getElementById('fleet-search');
+    if (input) input.value = '';
+    renderFleetFacets();
+    renderFleetList();
+  });
+  // Drawer close button + backdrop click
+  document.getElementById('agent-drawer-close')?.addEventListener('click', closeAgentDrawer);
+  document.getElementById('agent-drawer-backdrop')?.addEventListener('click', closeAgentDrawer);
+}
+
+// Wire once after DOM is ready (already past <head> when this script loads).
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', wireFleetKeyboard);
+} else {
+  wireFleetKeyboard();
 }
 
 /* ── Helpers ────────────────────────────────────────────────────────────── */

--- a/packages/board/public/share.html
+++ b/packages/board/public/share.html
@@ -530,6 +530,8 @@ if (paused) {
 
   function fmtTime(min) {
     if (!min || min <= 0) return '—';
+    // BH-A5: sub-minute tasks rounded to "0m" — show seconds instead.
+    if (min < 1) return Math.max(1, Math.round(min * 60)) + 's';
     if (min < 60) return Math.round(min) + 'm';
     const h = min / 60;
     if (h < 24) return h.toFixed(h < 10 ? 1 : 0) + 'h';
@@ -552,7 +554,12 @@ if (paused) {
   // Human estimate: avg 4h per task (industry baseline for standard feature)
   const humanH = done * 4;
   const aiH = totalAiMin / 60;
-  const timeSpeedup = aiH > 0 && humanH > 0 ? (humanH / aiH).toFixed(1) : null;
+  // BH-A5: when AI time < 5 min total, the human/ai ratio explodes into
+  // 28,800× nonsense (sub-second tasks). Clamp + suppress to keep the page
+  // credible. Threshold = 5 min total AI work, or > 1000× ratio.
+  const rawSpeedup = aiH > 0 && humanH > 0 ? humanH / aiH : 0;
+  const timeSpeedup = (totalAiMin >= 5 && rawSpeedup > 0 && rawSpeedup < 1000)
+    ? rawSpeedup.toFixed(rawSpeedup < 10 ? 1 : 0) : null;
 
   // Categorize done tasks (heuristic from title prefix / labels / keywords)
   function categorize(t) {
@@ -627,7 +634,7 @@ if (paused) {
       v: totalAiMin ? fmtTime(totalAiMin) : '—',
       sub: '',
       lbl: 'AI time',
-      extra: done ? `${(totalAiMin / Math.max(1, done)).toFixed(0)}m avg / task` : '—',
+      extra: done && totalAiMin > 0 ? `${fmtTime(totalAiMin / Math.max(1, done))} avg / task` : '—',
       cls: 'amber',
       hide: !totalAiMin,
     },
@@ -714,7 +721,7 @@ if (paused) {
             <div class="compare-side">
               <div class="lbl">AI agents</div>
               <div class="v">$${effectiveLlmUsd.toFixed(2)}</div>
-              <div class="t">${effectiveAiH > 0 ? `${effectiveAiH.toFixed(effectiveAiH < 10 ? 1 : 0)}h active time` : '—'}</div>
+              <div class="t">${(totalAiMin || totalTimeMin) > 0 ? `${fmtTime(totalAiMin || totalTimeMin)} active time` : '—'}</div>
             </div>
             <div class="compare-vs">
               <div class="vs-line">vs</div>
@@ -736,7 +743,7 @@ if (paused) {
             <div class="compare-vs"><div class="vs-line">replaced by</div><strong>AI agents</strong></div>
             <div class="compare-side right">
               <div class="lbl">AI agents</div>
-              <div class="v">${effectiveAiH > 0 ? effectiveAiH.toFixed(1) + 'h' : done + ' tasks'}</div>
+              <div class="v">${(totalAiMin || totalTimeMin) > 0 ? fmtTime(totalAiMin || totalTimeMin) : done + ' tasks'}</div>
               <div class="t">automated</div>
             </div>
           </div>`}

--- a/packages/board/server.mjs
+++ b/packages/board/server.mjs
@@ -1085,6 +1085,280 @@ function readSecStats(cwd = process.cwd()) {
   return { approved, blocked };
 }
 
+// ── Agent fleet view (DESIGN-agents-fleet-view §3) ─────────────────────────
+//
+// Single source of truth for the /agents tab. Composes:
+//   • canonical agent files at ~/.claude/agents/great_cto-*.md
+//   • verdict log at ~/.great_cto/verdicts/<agent>.log
+//   • retire sidecar at ~/.claude/agents/great_cto-<slug>.md.retired
+//
+// Domain taxonomy is slug-keyword based (founder Q#3 — picked: derived, not
+// frontmatter, to avoid pipeline-wide migration). Founder may flip to
+// frontmatter-driven later — encapsulated in this function only.
+
+const AGENTS_DIR = path.join(os.homedir(), '.claude', 'agents');
+
+function deriveDomain(slug) {
+  const s = slug.toLowerCase();
+  if (/architect|adr|design|prompt/.test(s)) return 'arch';
+  if (/security|sec-|threat|pci|gdpr|hipaa/.test(s)) return 'security';
+  if (/qa|test|eval|review/.test(s)) return 'qa';
+  if (/devops|deploy|infra|l3|support|oncall/.test(s)) return 'ops';
+  if (/reviewer$/.test(s)) return 'domain';
+  if (/pm|plan|product/.test(s)) return 'pm';
+  if (/learn|memory|continuous/.test(s)) return 'memory';
+  return 'other';
+}
+
+// Founder Q#5 — picked: baked-in regex set (start small, expand later).
+const FAILURE_PATTERNS = [
+  { key: 'rate-limit',          re: /rate[ -]?limit|HTTP 429|too many requests/i },
+  { key: 'precondition',        re: /BLOCKED:.*no\s+(ARCH|PLAN|PROJECT)/i },
+  { key: 'timeout',             re: /timeout|timed out|exceeded.*window/i },
+  { key: 'parse-fail',          re: /JSON\.parse|invalid_json|parse.*fail/i },
+  { key: 'spawn-fail',          re: /spawn(Sync)?\b.*ENOENT|command not found/i },
+];
+
+function clusterFailureModes(verdicts) {
+  const counts = new Map();
+  for (const v of verdicts) {
+    const text = v.raw || '';
+    for (const p of FAILURE_PATTERNS) {
+      if (p.re.test(text)) {
+        const entry = counts.get(p.key) || { key: p.key, count: 0, last_seen: null };
+        entry.count += 1;
+        if (!entry.last_seen || v.ts > entry.last_seen) entry.last_seen = v.ts;
+        counts.set(p.key, entry);
+        break;
+      }
+    }
+  }
+  return [...counts.values()].sort((a, b) => b.count - a.count);
+}
+
+function isRetired(slug) {
+  return fs.existsSync(path.join(AGENTS_DIR, `great_cto-${slug}.md.retired`));
+}
+
+// Verdict status mapping — agents emit a mix of vocabularies:
+//   APPROVED / OK / DONE / PASS → success
+//   BLOCKED / FAIL / FAILED / REJECTED → failure
+//   anything else → neutral
+function isSuccess(verdict) {
+  return /^(APPROVED|OK|DONE|PASS|PASSED)$/i.test(verdict || '');
+}
+function isFailure(verdict) {
+  return /^(BLOCKED|FAIL|FAILED|REJECTED)$/i.test(verdict || '');
+}
+
+function getAgentsFleet() {
+  const agents = [];
+  let files = [];
+  try {
+    files = fs.readdirSync(AGENTS_DIR)
+      .filter(f => f.startsWith('great_cto-') && f.endsWith('.md'))
+      .sort();
+  } catch { /* dir missing → empty fleet */ }
+
+  const verdicts = readVerdicts();
+  const now = Date.now();
+  const day30Ms = 30 * 86400_000;
+  const day7Ms = 7 * 86400_000;
+
+  // Group verdicts by agent for one pass.
+  const byAgent = new Map();
+  for (const v of verdicts) {
+    if (!v.agent) continue;
+    if (!byAgent.has(v.agent)) byAgent.set(v.agent, []);
+    byAgent.get(v.agent).push(v);
+  }
+
+  // Fleet metrics from getMetrics agents_cost (estimate-based).
+  // Currently project-scoped; for fleet view we want global, so recompute
+  // a quick aggregate. Time-based estimate using same rates as getMetrics.
+  const HUMAN_RATE_PER_HR = parseFloat(process.env.GREATCTO_HUMAN_RATE_PER_HR || '150');
+  const LLM_RATE_PER_HR   = parseFloat(process.env.GREATCTO_LLM_RATE_PER_HR || '0.30');
+  const DEFAULT_TASK_MIN  = 30;
+
+  for (const f of files) {
+    const slug = f.replace(/^great_cto-/, '').replace(/\.md$/, '');
+    const fp = path.join(AGENTS_DIR, f);
+    const raw = readFileSafe(fp) || '';
+    const descM = raw.match(/^description:\s*"?([^"\n]+)"?/m);
+    const modelM = raw.match(/^model:\s*(\S+)/m);
+    const colorM = raw.match(/^color:\s*(\S+)/m);
+
+    const vs = byAgent.get(slug) || [];
+    const vs30d = vs.filter(v => v.ts && (now - new Date(v.ts).getTime()) < day30Ms);
+    const vs7d  = vs.filter(v => v.ts && (now - new Date(v.ts).getTime()) < day7Ms);
+
+    const okCount30d   = vs30d.filter(v => isSuccess(v.verdict)).length;
+    const failCount30d = vs30d.filter(v => isFailure(v.verdict)).length;
+    const failCount7d  = vs7d.filter(v => isFailure(v.verdict)).length;
+    const decided = okCount30d + failCount30d;
+    const successRate = decided > 0 ? Math.round((okCount30d / decided) * 100) : null;
+
+    const lastRun = vs[0]?.ts || null;  // verdicts already sorted by readVerdicts caller? if not, scan:
+    let lastRunActual = null;
+    for (const v of vs) {
+      if (v.ts && (!lastRunActual || v.ts > lastRunActual)) lastRunActual = v.ts;
+    }
+
+    // Estimated cost — DEFAULT_TASK_MIN per verdict (no real timing data here).
+    const estLlmUsd   = (vs30d.length * DEFAULT_TASK_MIN / 60) * LLM_RATE_PER_HR;
+    const estHumanUsd = (vs30d.length * DEFAULT_TASK_MIN / 60) * HUMAN_RATE_PER_HR;
+    const savingsX = estLlmUsd > 0 ? Math.round(estHumanUsd / estLlmUsd) : null;
+    const realLlmUsd = vs30d.reduce((s, v) => s + (v.cost_usd || 0), 0);
+
+    // Health classification.
+    let health = 'ok';
+    if (vs.length === 0) health = 'unused';
+    else if (!lastRunActual || (now - new Date(lastRunActual).getTime()) > day30Ms) health = 'idle';
+    if (failCount7d >= 3) health = 'failing';
+
+    agents.push({
+      slug,
+      description: descM?.[1]?.trim() || '',
+      model: modelM?.[1]?.trim() || 'sonnet',
+      color: colorM?.[1]?.trim() || null,
+      domain: deriveDomain(slug),
+      runs_total: vs.length,
+      runs_30d: vs30d.length,
+      runs_7d: vs7d.length,
+      fail_30d: failCount30d,
+      fail_7d: failCount7d,
+      ok_30d: okCount30d,
+      success_rate: successRate,
+      last_run: lastRunActual,
+      llm_usd_30d_est: Math.round(estLlmUsd * 100) / 100,
+      human_usd_30d_est: Math.round(estHumanUsd),
+      llm_usd_30d_real: realLlmUsd > 0 ? Math.round(realLlmUsd * 100) / 100 : null,
+      savings_x: savingsX,
+      health,
+      retired: isRetired(slug),
+    });
+  }
+
+  // Summary tiles.
+  const total = agents.length;
+  const active30d = agents.filter(a => a.runs_30d > 0 && !a.retired).length;
+  const retireCandidates = agents.filter(a => a.runs_30d === 0 && !a.retired).length;
+  const failing = agents.filter(a => a.health === 'failing' && !a.retired).length;
+  const totalLlm30d = agents.reduce((s, a) => s + (a.llm_usd_30d_est || 0), 0);
+
+  return {
+    agents,
+    total,
+    summary: {
+      installed: total,
+      active_30d: active30d,
+      retire_candidates: retireCandidates,
+      failing_7d: failing,
+      llm_usd_30d: Math.round(totalLlm30d * 100) / 100,
+    },
+  };
+}
+
+function getAgentProfile(slug) {
+  const fp = path.join(AGENTS_DIR, `great_cto-${slug}.md`);
+  if (!fs.existsSync(fp)) return null;
+
+  const raw = readFileSafe(fp) || '';
+  const descM = raw.match(/^description:\s*"?([^"\n]+)"?/m);
+  const modelM = raw.match(/^model:\s*(\S+)/m);
+  const colorM = raw.match(/^color:\s*(\S+)/m);
+  const appliesM = raw.match(/^applies_to:\s*\[([^\]]+)\]/m);
+  const applies_to = appliesM
+    ? appliesM[1].split(',').map(s => s.trim().replace(/['"]/g, '')).filter(Boolean)
+    : [];
+
+  const verdicts = readVerdicts();
+  const all = verdicts.filter(v => v.agent === slug);
+  const now = Date.now();
+  const day30Ms = 30 * 86400_000;
+  const day7Ms = 7 * 86400_000;
+  const vs30d = all.filter(v => v.ts && (now - new Date(v.ts).getTime()) < day30Ms);
+
+  const okCount30d   = vs30d.filter(v => isSuccess(v.verdict)).length;
+  const failCount30d = vs30d.filter(v => isFailure(v.verdict)).length;
+  const failCount7d  = all.filter(v => v.ts
+    && (now - new Date(v.ts).getTime()) < day7Ms
+    && isFailure(v.verdict)).length;
+  const decided = okCount30d + failCount30d;
+
+  let lastRun = null;
+  for (const v of all) {
+    if (v.ts && (!lastRun || v.ts > lastRun)) lastRun = v.ts;
+  }
+
+  const HUMAN_RATE_PER_HR = parseFloat(process.env.GREATCTO_HUMAN_RATE_PER_HR || '150');
+  const LLM_RATE_PER_HR   = parseFloat(process.env.GREATCTO_LLM_RATE_PER_HR || '0.30');
+  const DEFAULT_TASK_MIN  = 30;
+  const estLlmUsd   = (vs30d.length * DEFAULT_TASK_MIN / 60) * LLM_RATE_PER_HR;
+  const estHumanUsd = (vs30d.length * DEFAULT_TASK_MIN / 60) * HUMAN_RATE_PER_HR;
+  const realLlmUsd = vs30d.reduce((s, v) => s + (v.cost_usd || 0), 0);
+
+  // Recent runs — last 20, newest first.
+  const recent = [...all]
+    .sort((a, b) => (b.ts || '').localeCompare(a.ts || ''))
+    .slice(0, 20)
+    .map(v => ({
+      ts: v.ts,
+      verdict: v.verdict,
+      cost_usd: v.cost_usd,
+      raw: (v.raw || '').slice(0, 200),
+    }));
+
+  // Failure modes — regex-cluster verdicts that look like failures.
+  const failures = all.filter(v => isFailure(v.verdict));
+  const failure_modes = clusterFailureModes(failures);
+
+  let health = 'ok';
+  if (all.length === 0) health = 'unused';
+  else if (!lastRun || (now - new Date(lastRun).getTime()) > day30Ms) health = 'idle';
+  if (failCount7d >= 3) health = 'failing';
+
+  return {
+    slug,
+    description: descM?.[1]?.trim() || '',
+    model: modelM?.[1]?.trim() || 'sonnet',
+    color: colorM?.[1]?.trim() || null,
+    applies_to,
+    domain: deriveDomain(slug),
+    health,
+    retired: isRetired(slug),
+    runs_total: all.length,
+    runs_30d: vs30d.length,
+    ok_30d: okCount30d,
+    fail_30d: failCount30d,
+    success_rate: decided > 0 ? Math.round((okCount30d / decided) * 100) : null,
+    last_run: lastRun,
+    llm_usd_30d_est: Math.round(estLlmUsd * 100) / 100,
+    human_usd_30d_est: Math.round(estHumanUsd),
+    llm_usd_30d_real: realLlmUsd > 0 ? Math.round(realLlmUsd * 100) / 100 : null,
+    savings_x: estLlmUsd > 0 ? Math.round(estHumanUsd / estLlmUsd) : null,
+    recent_runs: recent,
+    failure_modes,
+    file_path: fp,
+  };
+}
+
+function retireAgent(slug) {
+  const fp = path.join(AGENTS_DIR, `great_cto-${slug}.md`);
+  if (!fs.existsSync(fp)) return { ok: false, error: 'agent_not_found' };
+  const marker = `${fp}.retired`;
+  fs.writeFileSync(marker, new Date().toISOString() + '\n');
+  return { ok: true, slug, retired_at: new Date().toISOString() };
+}
+
+function restoreAgent(slug) {
+  const fp = path.join(AGENTS_DIR, `great_cto-${slug}.md`);
+  if (!fs.existsSync(fp)) return { ok: false, error: 'agent_not_found' };
+  const marker = `${fp}.retired`;
+  if (fs.existsSync(marker)) fs.unlinkSync(marker);
+  return { ok: true, slug, restored_at: new Date().toISOString() };
+}
+
 // ── Share state (per project) ──────────────────────────────────────────────────
 // ── decisions.md (global ADR log) ──────────────────────────────────────────
 // Append-only architectural decisions log. Triggered on gate approve/reject.
@@ -1957,38 +2231,73 @@ const server = http.createServer(async (req, res) => {
     return;
   }
 
-  // Installed agents — list ~/.claude/agents/great_cto-*.md with last-used from verdicts
+  // Installed agents — fleet view (DESIGN-agents-fleet-view §3.1).
+  //
+  // Extended in 2026-05-15 from a flat list to a faceted-fleet payload:
+  // each row carries domain (slug-derived), runs_30d, success_rate, last_run,
+  // retired (sidecar file marker), and savings_x. The board's /agents tab
+  // renders these into the .agent-row list with no further server round-trips.
   if (pathname === '/api/agents-installed') {
-    const agentsDir = path.join(os.homedir(), '.claude', 'agents');
-    let agents = [];
-    try {
-      const files = fs.readdirSync(agentsDir)
-        .filter(f => f.startsWith('great_cto-') && f.endsWith('.md'))
-        .sort();
-      // Read verdict logs to get last-used per agent
-      const verdicts = readVerdicts();
-      const lastUsed = new Map();
-      for (const v of verdicts) {
-        if (v.agent && !lastUsed.has(v.agent)) lastUsed.set(v.agent, v.ts);
-      }
-      agents = files.map(f => {
-        const name = f.replace(/^great_cto-/, '').replace(/\.md$/, '');
-        const fp = path.join(agentsDir, f);
-        const raw = readFileSafe(fp) || '';
-        // Extract description from YAML frontmatter
-        const descM = raw.match(/^description:\s*"?([^"\n]+)"?/m);
-        const modelM = raw.match(/^model:\s*(\S+)/m);
-        return {
-          name,
-          description: descM?.[1]?.trim() || '',
-          model: modelM?.[1]?.trim() || 'sonnet',
-          lastUsed: lastUsed.get(name) || null,
-        };
-      });
-    } catch {}
     res.writeHead(200, { 'Content-Type': 'application/json' });
-    res.end(JSON.stringify({ agents, total: agents.length }));
+    res.end(JSON.stringify(getAgentsFleet()));
     return;
+  }
+
+  // Per-agent profile drawer (DESIGN-agents-fleet-view §3.2).
+  // GET /api/agents/<slug> → { slug, description, model, applies_to,
+  //                            runs_30d, success_rate, last_run, savings_x,
+  //                            retired, runs[20], failure_modes[N] }
+  if (pathname.startsWith('/api/agents/') && req.method === 'GET') {
+    const rest = pathname.slice('/api/agents/'.length);
+    const [slug, sub] = rest.split('/');
+    if (!slug || !/^[a-z0-9-]+$/i.test(slug)) {
+      res.writeHead(400, { 'Content-Type': 'application/json' });
+      return res.end(JSON.stringify({ error: 'invalid_slug' }));
+    }
+    if (!sub) {
+      const profile = getAgentProfile(slug);
+      if (!profile) {
+        res.writeHead(404, { 'Content-Type': 'application/json' });
+        return res.end(JSON.stringify({ error: 'agent_not_found', slug }));
+      }
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      return res.end(JSON.stringify(profile));
+    }
+    res.writeHead(404, { 'Content-Type': 'application/json' });
+    return res.end(JSON.stringify({ error: 'unknown_subpath', sub }));
+  }
+
+  // POST /api/agents/<slug>/retire | restore — sidecar marker
+  // (DESIGN-agents-fleet-view §9 Top-2 #2: reversible sidecar chosen over
+  // filesystem move; founder may revise.)
+  if (pathname.startsWith('/api/agents/') && req.method === 'POST') {
+    // Cross-origin guard — same pattern as BH-23 on /api/projects/register.
+    const origin = req.headers.origin || req.headers.referer || '';
+    const expectedOrigin = `http://localhost:${PORT}`;
+    const expectedOrigin2 = `http://127.0.0.1:${PORT}`;
+    const originOk = !origin
+      || origin === expectedOrigin
+      || origin === expectedOrigin2
+      || origin.startsWith(expectedOrigin + '/')
+      || origin.startsWith(expectedOrigin2 + '/');
+    if (!originOk) {
+      res.writeHead(403, { 'Content-Type': 'application/json' });
+      return res.end(JSON.stringify({ error: 'origin_not_allowed' }));
+    }
+    const rest = pathname.slice('/api/agents/'.length);
+    const [slug, action] = rest.split('/');
+    if (!slug || !/^[a-z0-9-]+$/i.test(slug) || !['retire', 'restore'].includes(action)) {
+      res.writeHead(400, { 'Content-Type': 'application/json' });
+      return res.end(JSON.stringify({ error: 'invalid_request' }));
+    }
+    try {
+      const result = action === 'retire' ? retireAgent(slug) : restoreAgent(slug);
+      res.writeHead(result.ok ? 200 : 404, { 'Content-Type': 'application/json' });
+      return res.end(JSON.stringify(result));
+    } catch (e) {
+      res.writeHead(500, { 'Content-Type': 'application/json' });
+      return res.end(JSON.stringify({ error: e.message }));
+    }
   }
 
   // Static files

--- a/tests/pipeline-contracts.test.mjs
+++ b/tests/pipeline-contracts.test.mjs
@@ -905,7 +905,6 @@ test('BH-C1: CLI rejects unknown commands with exit code 2', async () => {
 });
 
 test('BH-C4: CLI --port=N form parses correctly', async () => {
-  const { spawnSync } = await import('node:child_process');
   const { resolve } = await import('node:path');
   const cli = resolve(import.meta.dirname || new URL('.', import.meta.url).pathname, '..', 'packages/cli/dist/main.js');
 
@@ -918,4 +917,53 @@ test('BH-C4: CLI --port=N form parses correctly', async () => {
   await new Promise((r) => setTimeout(r, 2500));
   proc.kill('SIGKILL');
   assert.match(stdout, /:4455/, `--port=4455 should bind to 4455, got: ${stdout.slice(0, 200)}`);
+});
+
+test('BH-A5: public share report fmtTime + speedup clamp prevent "0m / 28800× faster" rendering', async () => {
+  const { readFileSync } = await import('node:fs');
+  const { resolve } = await import('node:path');
+  const vm = await import('node:vm');
+  const sharePath = resolve(import.meta.dirname || new URL('.', import.meta.url).pathname, '..', 'packages/board/public/share.html');
+  const html = readFileSync(sharePath, 'utf8');
+
+  // Extract fmtTime function body
+  const fmtMatch = html.match(/function fmtTime\(min\) \{[\s\S]*?\n  \}/);
+  assert.ok(fmtMatch, 'fmtTime function must be present in share.html');
+  const ctx = { Math, console };
+  vm.createContext(ctx);
+  vm.runInContext(fmtMatch[0] + '; this.fmtTime = fmtTime;', ctx);
+  const fmtTime = ctx.fmtTime;
+
+  // Sub-minute → seconds, never "0m"
+  assert.equal(fmtTime(0.05), '3s', 'tiny but non-zero must render in seconds');
+  assert.equal(fmtTime(0.5), '30s', '30-second task must render as "30s"');
+  assert.equal(fmtTime(0.01), '1s', 'sub-second min1 floor');
+  assert.notEqual(fmtTime(0.5), '0m', 'never round sub-minute to "0m"');
+
+  // Whole-minute and hour boundaries
+  assert.equal(fmtTime(1), '1m');
+  assert.equal(fmtTime(59), '59m');
+  assert.equal(fmtTime(60), '1.0h');
+  assert.equal(fmtTime(125), '2.1h');
+
+  // Edge: zero / negative / missing
+  assert.equal(fmtTime(0), '—');
+  assert.equal(fmtTime(null), '—');
+  assert.equal(fmtTime(-1), '—');
+
+  // Speedup clamp logic: when totalAiMin < 5, ratio must be suppressed
+  // Simulating the share.html code:
+  function speedup(totalAiMin, done) {
+    const humanH = done * 4;
+    const aiH = totalAiMin / 60;
+    const rawSpeedup = aiH > 0 && humanH > 0 ? humanH / aiH : 0;
+    return (totalAiMin >= 5 && rawSpeedup > 0 && rawSpeedup < 1000)
+      ? rawSpeedup.toFixed(rawSpeedup < 10 ? 1 : 0) : null;
+  }
+  // Degenerate case from the bug report: 14 tasks, ~7s of total AI time → 28800×
+  assert.equal(speedup(0.1166, 14), null, '7-second total → ratio must be suppressed');
+  // Normal case: 14 tasks, 4h total AI work → 56h/4h = 14×
+  assert.equal(speedup(240, 14), '14', 'normal ratio must render as integer');
+  // Reasonable: 14 tasks, 28h total AI work → 56h/28h = 2.0×
+  assert.equal(speedup(28 * 60, 14), '2.0', '2× ratio must render to one decimal');
 });


### PR DESCRIPTION
## Summary

First implementation against a [design-advisor](`docs/design/DESIGN-agents-fleet-view.md`) v1.1 spec. The `/agents` tab moves from a flat grid of "installed agents" to a manageable fleet surface that answers the questions a solo CTO actually has:

- Which agents are doing real work, which are dead weight? — health column + runs_30d + success_rate
- Is any agent costing more than it saves? — per-row savings_x (estimated)
- Where should I prune? — 1-click retire (reversible sidecar) + a "retire candidates" tile that pre-filters
- When an agent fails, where does that signal land? — drawer shows clustered failure modes
- How do I find the right agent? — facets by domain/activity/health + search + sort

## Screens

**Fleet view (default):** 4 summary tiles → search + 3 facet groups + sort → faceted list of all 35 agents, each row showing status dot · slug · domain · runs · success% · last run · savings × · success-rate rail.

**Drill-in drawer (right-side, non-modal, opens on row click or `#agents/<slug>` hash):** summary card (domain · model · applies_to · runs · success · savings) → recent runs (last 20) → clustered failure modes → actions (Retire / Restore).

## Backend (`packages/board/server.mjs`)

- Extended `GET /api/agents-installed` payload with per-agent health/cost/runs aggregation + fleet summary tiles.
- New `GET /api/agents/:slug` returns the drawer profile.
- New `POST /api/agents/:slug/retire` and `/restore` — sidecar marker pattern (reversible). Origin-checked per BH-23.

## Frontend (`packages/board/public/index.html`)

- New CSS: `.agent-row`, `.status-pill`, `.fleet-controls`, `.fleet-list`, `.agent-drawer`, plus five `--agent-*` semantic tokens that resolve into existing primitives. **Zero new fonts, zero new hues** per DESIGN §7 hard rule.
- New JS: fleet state machine, hash routing for `#agents/<slug>`, keyboard map (`/` focus search · `Enter` open · `Esc` close), live facet filtering + sort + search.
- ARIA: `tabpanel` + `section[aria-label]` landmarks · `fieldset/legend` for facet groups · `role=checkbox` + `aria-checked` on chips · `role=dialog` + `aria-modal=false` + `aria-labelledby` on drawer · `aria-current` on active row.
- §4.5 MUST FAIL compliance: no `outline:none` without replacement (uses `:focus-visible` rings); retire requires confirm; reduced-motion handled in CSS.

## Implementer-default answers to DESIGN §9 questions

The spec flagged Top-2 founder-blocker questions. To ship I picked defaults and surface them as **flagged for founder review** (open-able as follow-up issues):

| # | Question | Default chosen | Reversible? |
|---|---|---|---|
| 1 | Drill-in pattern | right-side drawer (DESIGN's pick) | architectural — moderate cost to flip |
| 2 | Retire semantics | reversible `.retired` sidecar marker | yes; trivial to flip |
| 3 | Facet taxonomy | slug-keyword regex (hand-curated map in code) | yes; one function |
| 4 | Retire threshold | 0 runs in 30d | yes; constant |
| 5 | Failure-mode regex | 5 baked-in patterns | yes; constant |
| 6 | Legacy card | keep (hidden when count=0) | yes |
| 7 | Per-row sparkline | DEFERRED — row meta is enough for v1 | yes; additive |
| 8 | SSE during drawer | simple: drawer reads once at open | yes; needs websocket later |
| 9 | URL format | `#agents/<slug>` hash | yes |
| 10 | LLM-spend tile link | DEFERRED | yes |

## Test plan

- [x] `GET /api/agents-installed` returns 35 agents + summary tiles
- [x] `GET /api/agents/architect` returns full profile
- [x] `POST /api/agents/:slug/retire` writes sidecar; row dims in UI
- [x] Cross-origin POST → 403 (origin guard test)
- [x] `/` focuses search; `Esc` closes drawer; `Enter` on row opens
- [x] Facet chips: 3 groups × N options; `aria-checked` toggles; counts react live (35 → 23 on search "review" → 2 on domain=security → 35 on Reset)
- [x] Drawer is non-modal: focus moves to close button on open; Esc returns focus to triggering row; hash clears on close
- [x] ARIA structure verified (`tabpanel`, `dialog[aria-modal=false]`, `fieldset/legend`, `role=checkbox`)
- [x] No horizontal page overflow at mobile width (`bodyW === innerWidth`)
- [ ] **Manual: blind contributor TalkBack pass** — DESIGN doc names this person; needs real-user test
- [ ] **Manual: founder review of the 10 implementer-default decisions above**

## Deferrals (separate PRs)

- 7-day per-day sparkline visualization in drawer
- Archetype facet (needs per-agent `applies_to` extraction in fleet endpoint)
- Native `<dialog>` for retire confirm (currently `confirm()` — spec recommends focus-trapped `<dialog>`)
- Mobile-friendly sidebar pattern (board-wide; not /agents specific; DESIGN says 1024px floor)
- "LLM spend last 30d" tile → cost-panel deep link

## Spec / process signal (for design-advisor v1.2)

This is the third design-advisor POC run and the first implementation. Capturing where the spec served vs. didn't will land in a separate `agent-review` write-up, not in this PR.