### PR TITLE
fix(plugin): replace null matcher/statusMessage values that fail manifest validation

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -52,7 +52,7 @@
   "hooks": {
     "SessionStart": [
       {
-        "matcher": null,
+        "matcher": "",
         "hooks": [
           {
             "type": "command",
@@ -65,7 +65,7 @@
     ],
     "PreCompact": [
       {
-        "matcher": null,
+        "matcher": "",
         "hooks": [
           {
             "type": "command",
@@ -78,7 +78,7 @@
     ],
     "SubagentStart": [
       {
-        "matcher": null,
+        "matcher": "",
         "hooks": [
           {
             "type": "command",
@@ -120,21 +120,19 @@
           {
             "type": "command",
             "command": "INPUT=$(cat 2>/dev/null); FILE=$(echo \"$INPUT\" | python3 -c \"import sys,json; d=json.load(sys.stdin); print(d.get('file_path',''))\" 2>/dev/null); TOOL=$(echo \"$INPUT\" | python3 -c \"import sys,json; d=json.load(sys.stdin); print(d.get('tool_name',''))\" 2>/dev/null); if [ -n \"$FILE\" ]; then mkdir -p .great_cto 2>/dev/null; printf '%s %s %s\\n' \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\" \"$TOOL\" \"$FILE\" >> .great_cto/agent-writes.log 2>/dev/null; fi; true",
-            "timeout": 3,
-            "statusMessage": null
+            "timeout": 3
           },
           {
             "type": "command",
             "command": "PLUGIN_DIR=$(ls -d ~/.claude/plugins/cache/local/great_cto/*/ 2>/dev/null | sort -V | tail -1 | sed 's|/$||'); node \"${PLUGIN_DIR}/scripts/hooks/format-check.mjs\" 2>/dev/null; true",
-            "timeout": 12,
-            "statusMessage": null
+            "timeout": 12
           }
         ]
       }
     ],
     "SessionEnd": [
       {
-        "matcher": null,
+        "matcher": "",
         "hooks": [
           {
             "type": "command",
@@ -147,32 +145,29 @@
     ],
     "UserPromptSubmit": [
       {
-        "matcher": null,
+        "matcher": "",
         "hooks": [
           {
             "type": "command",
             "command": "PLUGIN_DIR=$(ls -d ~/.claude/plugins/cache/local/great_cto/*/ 2>/dev/null | sort -V | tail -1 | sed 's|/$||'); python3 \"${PLUGIN_DIR}/scripts/hooks/user-prompt-submit.py\" 2>/dev/null; true",
-            "timeout": 3,
-            "statusMessage": null
+            "timeout": 3
           },
           {
             "type": "command",
             "command": "PLUGIN_DIR=$(ls -d ~/.claude/plugins/cache/local/great_cto/*/ 2>/dev/null | sort -V | tail -1 | sed 's|/$||'); node \"${PLUGIN_DIR}/scripts/hooks/cost-guard.mjs\" 2>&1 1>/dev/null; true",
-            "timeout": 3,
-            "statusMessage": null
+            "timeout": 3
           }
         ]
       }
     ],
     "PermissionDenied": [
       {
-        "matcher": null,
+        "matcher": "",
         "hooks": [
           {
             "type": "command",
             "command": "INPUT=$(cat 2>/dev/null); TOOL=$(echo \"$INPUT\" | python3 -c \"import sys,json; d=json.load(sys.stdin); print(d.get('tool_name','unknown'))\" 2>/dev/null); mkdir -p .great_cto 2>/dev/null; printf '%s PERMISSION_DENIED tool=%s\\n' \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\" \"$TOOL\" >> .great_cto/permission-denied.log 2>/dev/null; if [ \"$TOOL\" = \"Bash\" ] || [ \"$TOOL\" = \"Write\" ]; then printf '%s PERMISSION_DENIED %s \u2014 agent may be stuck. Run /inbox.\\n' \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\" \"$TOOL\" >> .great_cto/permission-denied.log 2>/dev/null; fi; true",
-            "timeout": 3,
-            "statusMessage": null
+            "timeout": 3
           }
         ]
       }


### PR DESCRIPTION
## Problem

`claude plugin validate` rejects the current manifest:

```
✘ Found 1 error:
  ❯ hooks: Invalid input
```

The plugin fails to load. The cause is JSON `null` values where the hook
schema expects a string (or the field omitted):

- **`matcher`** must be a string — `""`, `"*"`, or a pattern — or omitted
  entirely. Six hook blocks set it to `null`, which the schema rejects.
  Changed to `""` (match-all, the documented equivalent).
- **`statusMessage`** is an optional string (the custom spinner message
  shown while a hook runs). Five command objects set it to `null`. An
  absent field is the correct way to express "no message", so those five
  entries are removed.

## What this PR does NOT change

- **All hook events are kept** — including `SubagentStart` and
  `PermissionDenied`, which are both valid Claude Code hook events. Their
  blocks (and their context-injection / denial-logging behaviour) are
  untouched apart from the `matcher` null → `""` fix.
- The six real string `statusMessage` values are kept.
- No hook command string is modified.

## Verification

```
# before — upstream/main
$ claude plugin validate .
✘ hooks: Invalid input

# after — this PR
$ claude plugin validate .
✔ Validation passed with warnings
  (2 pre-existing, unrelated warnings remain)
```

The cause was isolated with `claude plugin validate`: fixing the `null`
matchers **and** removing the `null` `statusMessage` entries is both
necessary and sufficient — neither change alone passes validation, and
nothing else in the hooks block needs to change.

---

Independent companion to #61 (agent-model-override) — both touch
`plugin.json` in different regions; whichever merges second needs at most a
trivial rebase.
