### PR TITLE
fix: wire db-migration-reviewer into qa-engineer (currently orphaned)

### DIFF
--- a/agents/qa-engineer.md
+++ b/agents/qa-engineer.md
@@ -360,6 +360,52 @@ From this, identify:
 - **Missing coverage**: what critical paths have no tests
 - **External deps**: what to mock vs hit with integration tests
 
+### Step 0e: Migration safety pre-check (MANDATORY)
+
+If the diff touches database migrations, **invoke `db-migration-reviewer`
+before continuing**. The db-migration-reviewer agent's own description
+declares qa-engineer as one of its triggers (*"You activate automatically
+when devops or qa-engineer detects `migrations/` files in the diff"*) but
+no agent actually spawned it — making the contract a no-op. This step
+honors the documented contract.
+
+Migrations are runtime risk (lock duration, irreversible drops, data loss,
+PII column additions) that functional tests miss by design — the
+specialist agent owns this.
+
+```bash
+BASE=$(git rev-parse --abbrev-ref --symbolic-full-name @{u} 2>/dev/null | sed 's|.*/||' || echo "main")
+MIGRATION_HIT=$(git diff "$BASE"...HEAD --name-only 2>/dev/null | \
+  grep -E '(^|/)(migrations|alembic/versions|db/migrate|prisma/migrations|flyway|knex/migrations)/.*\.(sql|py|ts|js|rb)$' | head -5)
+
+if [ -n "$MIGRATION_HIT" ]; then
+  echo "Migration files in diff — db-migration-reviewer required:"
+  echo "$MIGRATION_HIT"
+  echo ""
+  echo "ACTION: Spawn db-migration-reviewer subagent. Wait for its verdict."
+  echo "  - If PASS → continue to Step 1 of QA plan."
+  echo "  - If BLOCK → QA verdict is FAIL regardless of test outcomes."
+fi
+```
+
+The db-migration-reviewer writes `docs/migrations/MIGRATE-<slug>-<date>.md`.
+Surface its verdict in the Step 4 QA Report:
+
+```
+Migration safety: [PASS | BLOCK | N/A — no migrations in diff]
+  (see docs/migrations/MIGRATE-<slug>.md if applicable)
+```
+
+If migration review returns BLOCK, the overall QA verdict is FAIL and
+`gate:ship` must NOT be created — regardless of how clean the functional
+test results are.
+
+This wiring closes the gap where `db-migration-reviewer.applies_to`
+includes `web-service, commerce, enterprise, data-platform, fintech,
+regulated, web-app` but no archetype actually spawned the agent. After
+this change, any feature with a migration triggers the specialist,
+matching the agent's documented contract.
+
 ### Step 1: Build QA Plan from Archetype + Packs
 
 **Base QA** comes from ARCHETYPES.md → QA Strategy row for `$ARCHETYPE`:


### PR DESCRIPTION
## Summary

`db-migration-reviewer` is declared as an automatic specialist in its own description, but no agent in the pipeline actually spawns it. This PR wires it into `qa-engineer.md` so the documented contract becomes real behavior.

## The bug

`agents/db-migration-reviewer.md` declares:

> *"You activate automatically when devops or qa-engineer detects `migrations/` files in the diff."*
>
> `applies_to: [web-service, commerce, enterprise, data-platform, fintech, regulated, web-app]`

But grepping the pipeline:

```
$ grep -rn "db-migration-reviewer" agents/
agents/data-platform-reviewer.md:   "Hands off to: ... db-migration-reviewer (schema changes)"
agents/infra-reviewer.md:           "Hands off to: ... db-migration-reviewer (when DB schema changes)"
agents/enterprise-saas-reviewer.md: "Hands off to: ... db-migration-reviewer (RLS / tenant key migrations)"
agents/senior-dev.md:               # writes SECURITY_SIGNAL: pii-field-added breadcrumb only
agents/qa-engineer.md:              # mentions "db-migration" in archetype table
```

The hand-off mentions are passive — they document a relationship but don't spawn the agent. They also only fire for `data-platform` / `infra` / `enterprise-saas` archetypes, leaving the other archetypes in `applies_to` (`web-service`, `commerce`, `fintech`, `regulated`, `web-app`) with no invocation path. `senior-dev` writes an advisory breadcrumb that nothing reads. `qa-engineer` mentions the agent in a checklist table but never invokes it.

**Net effect**: dangerous migrations (table drops, lock-heavy index adds on large tables, PII column additions, irreversible schema changes) ship without the specialist review the contract promises.

## Real-world evidence

A fintech project (`archetype: fintech`, `project_size: medium`) using great_cto recently shipped 5 alembic migrations including:

- `drop_merchantresolution_add_source.py` — table drop, irreversible
- 3 composite-index additions on a 100K+ row transaction table — lock-duration risk

None went through `db-migration-reviewer`. The pipeline executed normally — code-reviewer passed, qa-engineer passed, security-officer passed, gate:ship was approved, deploy succeeded. The specialist agent that exists specifically to catch this class of risk was never asked.

This is exactly the silent-skip pattern the agent's `applies_to` list was supposed to prevent.

## Fix

Add a new **Step 0e** to `agents/qa-engineer.md` immediately after the existing **Step 0d: Read the Code** and before **Step 1: Build QA Plan**.

The step:
1. Detects migration files in the diff (`migrations/`, `alembic/versions/`, `db/migrate/`, `prisma/migrations/`, `flyway`, `knex/migrations/`).
2. Requires `db-migration-reviewer` to return PASS before qa-engineer continues.
3. Surfaces the verdict in the Step 4 QA report (`Migration safety: PASS | BLOCK | N/A`).
4. Forces QA verdict to FAIL (and prevents `gate:ship` creation) if migration review returns BLOCK.

This honors the agent's existing `applies_to` contract — no new field, no new agent, no new archetype semantics. The documented behavior just becomes actual behavior.

## Why qa-engineer (not code-reviewer / senior-dev / devops)

- The agent's own description names `devops or qa-engineer` as the triggers. devops runs after `gate:ship` — too late to block. qa-engineer is the right place.
- qa-engineer already runs after the diff is final (`Step 0d: Read the Code`) and before `gate:ship` is created. The natural pre-condition slot.
- senior-dev's existing PII breadcrumb stays in place as an advisory signal for downstream agents.

## Backwards compatibility

- No migrations in the diff → step is a one-line no-op. Same behavior as today.
- `nano` projects already skip qa-engineer entirely (Step 0).
- Existing test suites, archetypes, packs, gates: untouched.
- No new PROJECT.md fields, no new commands, no new agents.

## Diff stats

```
agents/qa-engineer.md | 46 ++++++++++++++++++++++++++++++++++++++++++++++
1 file changed, 46 insertions(+)
```

Verified locally: `python3 tests/structural/validate.py` → `OK`.

## Test plan

- [ ] Run a feature that adds a migration file → verify qa-engineer halts at Step 0e and reports `db-migration-reviewer` requirement.
- [ ] Have db-migration-reviewer return PASS → verify qa-engineer continues to Step 1 and the QA report Summary shows `Migration safety: PASS`.
- [ ] Have db-migration-reviewer return BLOCK → verify QA verdict is FAIL and gate:ship is NOT created.
- [ ] Run a feature with no migration files → verify Step 0e is a silent no-op.
- [ ] Verify for each archetype in `db-migration-reviewer.applies_to` (web-service, commerce, enterprise, data-platform, fintech, regulated, web-app) — the spawn now happens regardless of which other reviewers run.

## Note for the maintainer

No CHANGELOG entry added — slot under the next `## v<version>` section when releasing. Happy to add one in a specific format if preferred.