### PR TITLE
feat: wire compressors into l3-support + qa-engineer (compression Phase 3)

### DIFF
--- a/agents/_shared/compress-prompt.md
+++ b/agents/_shared/compress-prompt.md
@@ -1,0 +1,54 @@
+# Compress-before-reasoning — shared agent contract
+
+> Used by `scripts/lib/compress/` (Phase 1) + `scripts/lib/ccr.mjs` (Phase 2) of the
+> context-compression initiative. Lets agents read large logs / tool-outputs / test
+> results at a fraction of the tokens — **without** losing the answer (CCR is the safety net).
+
+## When to use
+
+Before you reason on any **large** blob (> ~2k tokens): CI/runtime logs, `kubectl logs`,
+test output, a big JSON tool result, a long diff. Don't paste the raw blob into your context —
+compress it first, reason on the compressed view, and recall the original only if needed.
+
+## The pattern (deterministic, $0 — no LLM call)
+
+```bash
+# Locate the scripts (plugin install path or local dev)
+PD=$(ls -d ~/.claude/plugins/cache/local/great_cto/*/ 2>/dev/null | sort -V | tail -1 | sed 's|/$||'); [ -z "$PD" ] && PD=.
+_COMPRESS="$PD/scripts/lib/compress/index.mjs"; [ -f "$_COMPRESS" ] || _COMPRESS="scripts/lib/compress/index.mjs"
+_CCR="$PD/scripts/lib/ccr.mjs"; [ -f "$_CCR" ] || _CCR="scripts/lib/ccr.mjs"
+
+# 1. Store the raw original (recoverable) and 2. reason on the compressed view.
+RAW="$(kubectl logs deploy/api --since=1h)"            # or test output / tool result
+CCR_ID=$(printf '%s' "$RAW" | node "$_CCR" store --source l3-log)
+printf '%s' "$RAW" | node "$_COMPRESS" --budget 12000 --stats   # type auto-detected
+# stderr prints: # compress: type=log 240000→3100 chars (99% saved)
+```
+
+- **Auto-routing** — `index.mjs` detects type (json/log/diff/text) and applies the right
+  compressor: log-template (collapse repeats, keep FATAL/ERROR verbatim), json-minify,
+  importance-trim (keep severity + stack, elide boilerplate to `--budget`).
+- **`--budget N`** — target char cap for trimmable content. Omit for lossless minify/collapse only.
+- **`--crush`** — (JSON only) sample long homogeneous arrays. Lossy — only when item-level
+  completeness is not needed.
+
+## Recovering the original (lossless-on-demand)
+
+If the compressed view elided something you need (you'll see `… N lines elided …` markers, or a
+`<!-- ccr: … -->` footer from memory-filter), pull the full original back:
+
+```bash
+node "$_CCR" recall "$CCR_ID"     # or, interactively: /ccr <id>
+```
+
+This is the discipline that lets us compress **aggressively**: nothing is ever lost, only moved
+out of the hot context until asked for.
+
+## Rules
+
+- Never reason on a > 2k-token raw blob directly — compress first.
+- Always `ccr store` the raw before compressing a log/tool-output you might need verbatim
+  (errors, audit evidence). Re-queryable sources (live Loki) don't strictly need it.
+- The compressors are deterministic and `$0` — no LLM, no cost, safe to pipe everything through.
+- Compression must never be trusted blind — any new compressor ships only after passing
+  `tests/eval/EVAL-compression-fidelity.md` on the holdout split (`scripts/eval-gate.mjs`).

--- a/agents/l3-support.md
+++ b/agents/l3-support.md
@@ -54,6 +54,24 @@ Never let a Beads error block the actual phase work.
   move on — do not block the incident on missing config.
   See `skills/great_cto/references/llm-router.md` for when to use vs skip.
 
+- **Compress large logs before reasoning** (deterministic, $0): never paste a raw
+  multi-thousand-line log into your context. Store the raw (recoverable) and reason on the
+  compressed view — log-template collapses repeats but **keeps every FATAL/ERROR/stack line
+  verbatim**, so you don't miss the needle:
+
+  ```bash
+  PD=$(ls -d ~/.claude/plugins/cache/local/great_cto/*/ 2>/dev/null | sort -V | tail -1 | sed 's|/$||'); [ -z "$PD" ] && PD=.
+  _C="$PD/scripts/lib/compress/index.mjs"; [ -f "$_C" ] || _C="scripts/lib/compress/index.mjs"
+  _CCR="$PD/scripts/lib/ccr.mjs"; [ -f "$_CCR" ] || _CCR="scripts/lib/ccr.mjs"
+  RAW="$(kubectl logs deploy/api --since=1h)"      # or journalctl / docker logs / a log file
+  CCR_ID=$(printf '%s' "$RAW" | node "$_CCR" store --source l3-log)   # full original, recoverable
+  printf '%s' "$RAW" | node "$_C" --budget 12000 --stats              # compressed view to reason on
+  # need a detail the compressed view elided?  node "$_CCR" recall "$CCR_ID"   (or /ccr <id>)
+  ```
+
+  Full contract: `agents/_shared/compress-prompt.md`. This is what lets you triage a 200k-token
+  log on a tight budget without losing the FATAL.
+
 ## Environment Setup
 
 ```bash

--- a/agents/qa-engineer.md
+++ b/agents/qa-engineer.md
@@ -400,6 +400,23 @@ Threshold: p95 < 200ms, 0 PCI findings
 
 ### Step 3: Execute
 
+**Compress test/build output before reasoning** (deterministic, $0). Test runs and build
+logs are mostly passing-noise with a few failures buried in them. Pipe the output through the
+compressor so the `AssertionError` / `FAIL` / stack frames survive while thousands of passing
+lines collapse — then reason on the compressed view:
+
+```bash
+PD=$(ls -d ~/.claude/plugins/cache/local/great_cto/*/ 2>/dev/null | sort -V | tail -1 | sed 's|/$||'); [ -z "$PD" ] && PD=.
+_C="$PD/scripts/lib/compress/index.mjs"; [ -f "$_C" ] || _C="scripts/lib/compress/index.mjs"
+_CCR="$PD/scripts/lib/ccr.mjs"; [ -f "$_CCR" ] || _CCR="scripts/lib/ccr.mjs"
+RAW="$(npm test 2>&1)"                                  # or pytest / cargo test / go test
+CCR_ID=$(printf '%s' "$RAW" | node "$_CCR" store --source qa-output)   # full output, recoverable
+printf '%s' "$RAW" | node "$_C" --budget 10000 --stats                 # keeps FAIL + stack, elides passes
+# need the full run?  node "$_CCR" recall "$CCR_ID"   (or /ccr <id>)
+```
+
+Full contract: `agents/_shared/compress-prompt.md`. Use this for any large test/build/lint output.
+
 **Parallel groups** — run independent test types in parallel, dependent tests sequentially:
 
 **Group A (parallel — independent tests)** — spawn sub-agents via Agent tool:

--- a/scripts/lib/ccr.mjs
+++ b/scripts/lib/ccr.mjs
@@ -135,9 +135,16 @@ export function formatRecallFooter(stubs) {
 function main() {
   const [cmd, ...rest] = process.argv.slice(2);
   if (cmd === 'store') {
-    const content = rest.find((a) => !a.startsWith('--')) || '';
-    const si = rest.indexOf('--source');
-    const source = si >= 0 ? rest[si + 1] : 'cli';
+    // Content from the first positional arg, or stdin (so you can pipe a big blob).
+    // Parse flags first so a flag value (e.g. --source X) isn't mistaken for content.
+    let content, source = 'cli';
+    for (let i = 0; i < rest.length; i++) {
+      if (rest[i] === '--source') { source = rest[++i]; }
+      else if (!rest[i].startsWith('--') && content === undefined) { content = rest[i]; }
+    }
+    if (content === undefined) {
+      try { content = readFileSync(0, 'utf8'); } catch { content = ''; }
+    }
     const r = store(content, { source });
     process.stdout.write(`${r.id}\n`);
   } else if (cmd === 'recall') {

--- a/tests/lib/ccr.test.mjs
+++ b/tests/lib/ccr.test.mjs
@@ -131,3 +131,15 @@ test('CLI: recall unknown id exits 1', () => {
   });
   assert.equal(res.status, 1);
 });
+
+test('CLI: store reads stdin when no positional content (pipeable)', () => {
+  const root = tmp();
+  const env = { ...process.env, GREAT_CTO_CCR_ROOT: root };
+  const s = spawnSync(process.execPath, [SCRIPT, 'store', '--source', 'pipe'], {
+    env, encoding: 'utf8', input: 'piped log blob with FATAL inside',
+  });
+  assert.equal(s.status, 0);
+  const id = s.stdout.trim();
+  const r = spawnSync(process.execPath, [SCRIPT, 'recall', id], { env, encoding: 'utf8' });
+  assert.ok(r.stdout.includes('piped log blob with FATAL inside'));
+});


### PR DESCRIPTION
Compression epic Phase 3 — wire the compressors into the agents that read the biggest blobs.

- agents/_shared/compress-prompt.md: shared compress-before-reasoning contract (store raw to CCR -> compress -> reason -> /ccr recall).
- l3-support: compress large logs before triage (log-template keeps FATAL/ERROR/stack verbatim).
- qa-engineer: compress test/build output (keeps FAIL+stack, elides passing noise). Demo: 3100->439 chars (86%), FAIL preserved.
- ccr store reads stdin (pipeable) + flag-parse fix. 

structural green, prompt-lint clean, 30 lib tests, eval-suite 71/71.
