### PR TITLE
chore(release): v2.38.0 — context compression layer

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "great_cto",
   "id": "great_cto",
   "description": "Engineering process for solo founders and teams up to 50 engineers. Agents do architecture, code review, QA, and security. You make two decisions per feature.",
-  "version": "2.37.1",
+  "version": "2.38.0",
   "author": {
     "name": "Great CTO",
     "url": "https://github.com/avelikiy/great_cto"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,41 @@ All notable changes to great_cto are documented here.
 
 
 
+
+## v2.38.0 — 2026-06-06
+
+### Context compression layer (headroom-inspired, native)
+
+Cut the tokens agents read from logs / tool-outputs / JSON / memory — **without losing
+answers** — using deterministic, $0 compressors (no LLM, no native dependency). Concepts
+borrowed from [chopratejas/headroom](https://github.com/chopratejas/headroom), built native
+to keep great_cto lean and local-first.
+
+- **Compressors** (`scripts/lib/compress/`) — ContentRouter auto-detects type and applies:
+  `log-template` (collapse repeats to sample + count, keep FATAL/ERROR/stack verbatim),
+  `json-minify` (+ optional array crush, safe fallback on non-JSON), `line-importance`
+  (keep severity + stack, elide boilerplate to budget). `compress(text,{type,budget,crush})`
+  + CLI. Real numbers: CI log 31,475→155 chars (99.5%), JSON 43% minify / 98% crush, noisy
+  test run 86% with the FAIL preserved.
+- **CCR — Compressed Context with Retrieval** (`scripts/lib/ccr.mjs`, `/ccr`) — anything
+  dropped/compressed is stored locally (`.great_cto/ccr/`, content-addressed, ~500-item GC)
+  and recoverable on demand. `memory-filter` now registers what it filters out and appends a
+  recall footer → **lossless-on-demand**, so we compress aggressively without risk.
+- **Agent wiring** — `l3-support` (logs) and `qa-engineer` (test/build output) compress before
+  reasoning via the shared `agents/_shared/compress-prompt.md` contract.
+- **Fidelity gate** — `EVAL-compression-fidelity` (tuning+holdout) runs through the v2.37.0
+  eval loop: a compressor ships only if the key fact survives on the holdout split.
+- CI: evals-runner unit job now also runs `tests/lib`. 30 new unit tests.
+
+### Fixed
+- `ccr store` flag parsing (a `--source` value was mistaken for content); now reads stdin too.
+
+- _Add one bullet per shipped feature._
+- _Cite ADRs introduced (if any)._
+- _Mention test counts and opt-out flags._
+
+---
+
 ## v2.37.1 — 2026-06-05
 
 ### Fixed

--- a/packages/cli/CONTEXT.md
+++ b/packages/cli/CONTEXT.md
@@ -1,0 +1,25 @@
+# CONTEXT.md
+
+> AI session state for all agents. Updated at the end of each session.
+> All AI coding tools (Claude Code, Cursor, Copilot, Windsurf, Aider) read this
+> before starting work.
+
+## Resume block
+
+**Current task:** _(none — project just initialized)_
+**Last session:** 2026-05-28
+**Status:** 🟢 ready to start
+
+## Session log
+
+| Session | Date | Summary | Files changed |
+|---------|------|---------|---------------|
+| 1 | 2026-05-28 | Project initialized | CONTEXT.md, .great_cto/PROJECT.md |
+
+## Open questions
+
+_(none yet — add questions that need founder/team input before implementation can proceed)_
+
+## Divergences from spec
+
+_(none — record any deviations from design.md here with rationale)_

--- a/packages/cli/jsr.json
+++ b/packages/cli/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@avelikiy/great-cto",
-  "version": "2.37.1",
+  "version": "2.38.0",
   "description": "29 specialist Claude Code agents that ship from idea to production. Auto-detects archetype, attaches compliance, runs the full SDLC pipeline.",
   "license": "MIT",
   "exports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "great-cto",
-  "version": "2.37.1",
+  "version": "2.38.0",
   "description": "One command install for the great_cto Claude Code plugin. Auto-detects your stack, picks the right archetype, bootstraps PROJECT.md.",
   "keywords": [
     "claude-code",


### PR DESCRIPTION
Bump to 2.38.0 + CHANGELOG for the headroom-inspired native compression layer (compress + CCR + agent wiring, Phases 1-3). CLI 191/191.