### PR TITLE
feat: strict-mode evidence-blocking gates (NaCl governance Phase 2)

### DIFF
--- a/agents/security-officer.md
+++ b/agents/security-officer.md
@@ -99,8 +99,24 @@ Read `approval-level` from PROJECT.md (default: `verbose`). Pause for CTO approv
 **Checkpoint A — BEFORE running audit** (after step 2-4 context reading, before step 5 compliance checklist):
 Show audit plan: compliance frameworks to check (from `compliance:` params + packs), secrets scan scope, dependency audit tools, high-priority targets from QA report. CTO approves or comments. Comments → adjust scope → re-checkpoint.
 
+**Strict-mode gate check (mandatory, before any gate:ship APPROVED)** — `gate:ship` refuses
+to pass while any task is in a terminal-fail state `{blocked, failed, unverified, not_run}`,
+unless a **valid signed exception** covers it. This is evidence-blocking, not "explained-away":
+
+```bash
+PD=$(ls -d ~/.claude/plugins/cache/local/great_cto/*/ 2>/dev/null | sort -V | tail -1 | sed 's|/$||'); [ -z "$PD" ] && PD=.
+node "$PD/scripts/lib/gate-check.mjs" gate:ship 2>/dev/null || node scripts/lib/gate-check.mjs gate:ship
+# exit 0 → may approve (any covered tasks are printed with their exception id)
+# exit 1 → DO NOT write APPROVED. Fix the task, or the CTO mints a signed exception:
+#          /exception create --gate gate:ship --scope "<task-id>" --reason "<why>" --days N
+```
+
+Never write `APPROVED` for `gate:ship` while `gate-check` exits 1 and no signed exception
+covers the blocking task. The only sanctioned overrides are signed exceptions (audited,
+expiring) — see `/exception`. (`bd` unavailable → gate-check is a no-op; fall back to manual.)
+
 **Checkpoint B — AFTER writing CSO report** (after step 6 report, before step 7 close/block gate:ship):
-Show decision: APPROVED/BLOCKED, findings by severity, compliance results. CTO approves → close or block gate:ship. Comments → re-scan specific area → re-checkpoint.
+Show decision: APPROVED/BLOCKED, findings by severity, compliance results, **strict-mode gate-check result + any sanctioning exceptions**. CTO approves → close or block gate:ship. Comments → re-scan specific area → re-checkpoint.
 
 Follow standard checkpoint pattern from SKILL.md § Interaction Mode (Checkpoints).
 

--- a/commands/inbox.md
+++ b/commands/inbox.md
@@ -37,6 +37,21 @@ Sections (only present when relevant, separated by blank lines):
 `## DORA_CFR`, `## GATE_DRIFT`, `## COST_ALERT`, `## ON_CALL`,
 `## RFC_OVERDUE`.
 
+## Step 2b — Strict-mode governance (signed exceptions)
+
+Surface the audited gate-bypass trail so nothing expires silently. Active exceptions are
+sanctioned overrides; expired/revoked ones are debt to remediate.
+
+```bash
+PD=$(ls -d ~/.claude/plugins/cache/local/great_cto/*/ 2>/dev/null | sort -V | tail -1 | sed 's|/$||'); [ -z "$PD" ] && PD=.
+node "$PD/scripts/lib/exceptions.mjs" list 2>/dev/null || node scripts/lib/exceptions.mjs list 2>/dev/null || true
+```
+
+Render any `✗` (expired/revoked/tampered) exceptions as **⚠️ High** ("signed exception
+EXC-… expired — remediate the work it covered or re-sign"). Active ones expiring within 7
+days → **🔔 Medium**. If a release is imminent, also run `gate-check.mjs gate:ship` and show
+any blocking tasks. See `/exception`.
+
 ## Step 3 — Render
 
 Priority-sorted list, one emoji prefix per row:

--- a/scripts/lib/gate-check.mjs
+++ b/scripts/lib/gate-check.mjs
@@ -1,0 +1,104 @@
+// scripts/lib/gate-check.mjs — strict-mode evidence-blocking gate check (governance Phase 2).
+//
+// NaCl strict-mode: a gate REFUSES to pass while any in-scope task is in a terminal-fail
+// state {BLOCKED, FAILED, UNVERIFIED, NOT_RUN} — instead of being downgraded to "explained".
+// The ONLY sanctioned override is a valid signed exception (Phase 1). Every covered task is
+// logged with the exception id, so a bypass is never silent.
+//
+// CLI:  node scripts/lib/gate-check.mjs <gate>   → exit 0 if the gate may pass, 1 if blocked
+//   (loads tasks from `bd list --json` and exceptions from the registry)
+
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { verify, list as listExceptions } from './exceptions.mjs';
+
+// Terminal-fail states that block a gate (normalized, lowercase).
+export const BLOCKING_STATES = new Set(['blocked', 'failed', 'unverified', 'not_run', 'not-run']);
+
+/**
+ * Normalize a beads task to { id, title, state }. A task's effective state is its
+ * blocking status, else the first blocking label, else its status.
+ */
+export function normalizeTask(task) {
+  const status = String(task.status || '').toLowerCase();
+  const labels = (task.labels || []).map((l) => String(l).toLowerCase().replace(/^state:/, ''));
+  let state = status;
+  if (!BLOCKING_STATES.has(status)) {
+    const bl = labels.find((l) => BLOCKING_STATES.has(l));
+    if (bl) state = bl;
+  }
+  return { id: task.id, title: task.title || '', state };
+}
+
+/**
+ * Does a signed exception cover this gate + task?
+ * - gate must match exactly or be '*'.
+ * - scope empty or '*' → gate-wide (covers every blocking task for that gate, e.g. a
+ *   "CI billing-locked" exception).
+ * - otherwise scope is a comma/space-separated list of task ids; coverage requires an
+ *   EXACT id match (no substring — "uncovered" must not be covered by scope "covered").
+ */
+export function covers(exc, gate, taskId, now) {
+  if (!verify(exc, { now }).valid) return false;
+  if (!(exc.gate === gate || exc.gate === '*')) return false;
+  const scope = String(exc.scope || '').trim();
+  if (!scope || scope === '*') return true;
+  return scope.split(/[\s,]+/).includes(String(taskId));
+}
+
+/**
+ * Evaluate a gate against a list of (already-normalized) tasks + exceptions.
+ * @returns {{ pass: boolean, blocking: Array, covered: Array }}
+ */
+export function evaluateGate(tasks, exceptions, { gate, now } = {}) {
+  const blocking = [];
+  const covered = [];
+  for (const t of tasks) {
+    if (!BLOCKING_STATES.has(String(t.state).toLowerCase())) continue;
+    const exc = (exceptions || []).find((e) => covers(e, gate, t.id, now));
+    if (exc) covered.push({ id: t.id, state: t.state, exception: exc.id });
+    else blocking.push({ id: t.id, state: t.state, title: t.title });
+  }
+  return { pass: blocking.length === 0, blocking, covered };
+}
+
+// ── CLI ──────────────────────────────────────────────────────────────────────
+
+function loadTasks() {
+  try {
+    const out = execFileSync('bd', ['list', '--json'], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] });
+    const data = JSON.parse(out);
+    const arr = Array.isArray(data) ? data : (data.issues || data.tasks || []);
+    return arr.map(normalizeTask);
+  } catch {
+    return null; // bd unavailable
+  }
+}
+
+function main() {
+  const gate = process.argv[2];
+  if (!gate) { process.stderr.write('Usage: gate-check.mjs <gate>\n'); process.exit(2); }
+
+  const tasks = loadTasks();
+  if (tasks === null) {
+    process.stdout.write('gate-check: beads (bd) unavailable — cannot evaluate; treat as a manual check.\n');
+    process.exit(0); // do not hard-fail when bd isn't present
+  }
+  const exceptions = listExceptions({});
+  const r = evaluateGate(tasks, exceptions, { gate });
+
+  for (const c of r.covered) {
+    process.stdout.write(`  ⚠ ${c.id} [${c.state}] — sanctioned by signed exception ${c.exception}\n`);
+  }
+  if (r.pass) {
+    process.stdout.write(`✓ ${gate}: no blocking tasks (${r.covered.length} covered by exception).\n`);
+    process.exit(0);
+  }
+  process.stdout.write(`✗ ${gate} BLOCKED — ${r.blocking.length} task(s) in a terminal-fail state with no signed exception:\n`);
+  for (const b of r.blocking) process.stdout.write(`    ${b.id} [${b.state}] ${b.title}\n`);
+  process.stdout.write(`  Fix the task, or create a signed exception: /exception create --gate ${gate} --reason "…"\n`);
+  process.exit(1);
+}
+
+const isMain = process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1];
+if (isMain) main();

--- a/tests/lib/gate-check.test.mjs
+++ b/tests/lib/gate-check.test.mjs
@@ -1,0 +1,99 @@
+// tests/lib/gate-check.test.mjs — unit tests for strict-mode gate check (governance Phase 2)
+//
+// Run: node --test tests/lib/gate-check.test.mjs
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { normalizeTask, covers, evaluateGate, BLOCKING_STATES } from '../../scripts/lib/gate-check.mjs';
+import { create } from '../../scripts/lib/exceptions.mjs';
+
+const NOW = '2026-06-06T00:00:00Z';
+
+// ── normalizeTask ─────────────────────────────────────────────────────────────
+
+test('normalizeTask: status blocked → state blocked', () => {
+  assert.equal(normalizeTask({ id: 'a', status: 'blocked' }).state, 'blocked');
+});
+
+test('normalizeTask: open status + failed label → state failed', () => {
+  assert.equal(normalizeTask({ id: 'a', status: 'open', labels: ['x', 'failed'] }).state, 'failed');
+});
+
+test('normalizeTask: state: label prefix stripped', () => {
+  assert.equal(normalizeTask({ id: 'a', status: 'open', labels: ['state:unverified'] }).state, 'unverified');
+});
+
+test('normalizeTask: clean open task → state open (not blocking)', () => {
+  const t = normalizeTask({ id: 'a', status: 'open', labels: ['feature'] });
+  assert.equal(t.state, 'open');
+  assert.equal(BLOCKING_STATES.has(t.state), false);
+});
+
+// ── covers ────────────────────────────────────────────────────────────────────
+
+test('covers: valid exception for exact gate + matching scope', () => {
+  const exc = create({ gate: 'gate:ship', scope: 'UC-003', reason: 'r', now: NOW });
+  assert.equal(covers(exc, 'gate:ship', 'UC-003', NOW), true);
+  assert.equal(covers(exc, 'gate:qa', 'UC-003', NOW), false);   // wrong gate
+  assert.equal(covers(exc, 'gate:ship', 'UC-999', NOW), false); // wrong scope
+});
+
+test('covers: wildcard gate + empty scope covers anything', () => {
+  const exc = create({ gate: '*', reason: 'blanket', now: NOW });
+  assert.equal(covers(exc, 'gate:ship', 'UC-1', NOW), true);
+});
+
+test('covers: expired exception does not cover', () => {
+  const exc = create({ gate: 'gate:ship', reason: 'r', expiresInDays: 1, now: NOW });
+  assert.equal(covers(exc, 'gate:ship', 'UC-1', '2026-07-01T00:00:00Z'), false);
+});
+
+// ── evaluateGate ──────────────────────────────────────────────────────────────
+
+const T = (id, state) => ({ id, title: id, state });
+
+test('evaluateGate: passes when no blocking tasks', () => {
+  const r = evaluateGate([T('a', 'open'), T('b', 'in_progress')], [], { gate: 'gate:ship' });
+  assert.equal(r.pass, true);
+  assert.equal(r.blocking.length, 0);
+});
+
+test('evaluateGate: a single BLOCKED task blocks the gate', () => {
+  const r = evaluateGate([T('a', 'open'), T('b', 'blocked')], [], { gate: 'gate:ship' });
+  assert.equal(r.pass, false);
+  assert.equal(r.blocking.length, 1);
+  assert.equal(r.blocking[0].id, 'b');
+});
+
+test('evaluateGate: terminal-fail states all block (failed/unverified/not_run)', () => {
+  const tasks = [T('a', 'failed'), T('b', 'unverified'), T('c', 'not_run')];
+  const r = evaluateGate(tasks, [], { gate: 'gate:ship' });
+  assert.equal(r.pass, false);
+  assert.equal(r.blocking.length, 3);
+});
+
+test('evaluateGate: a signed exception sanctions a blocked task (logged, not silent)', () => {
+  const exc = create({ gate: 'gate:ship', scope: 'b', reason: 'external blocker', now: NOW });
+  const r = evaluateGate([T('a', 'open'), T('b', 'blocked')], [exc], { gate: 'gate:ship', now: NOW });
+  assert.equal(r.pass, true);
+  assert.equal(r.blocking.length, 0);
+  assert.equal(r.covered.length, 1);
+  assert.equal(r.covered[0].exception, exc.id);
+});
+
+test('evaluateGate: exception for a different gate does not sanction', () => {
+  const exc = create({ gate: 'gate:qa', scope: 'b', reason: 'r', now: NOW });
+  const r = evaluateGate([T('b', 'blocked')], [exc], { gate: 'gate:ship', now: NOW });
+  assert.equal(r.pass, false);
+  assert.equal(r.blocking.length, 1);
+});
+
+test('evaluateGate: one blocked + one covered → still blocked by the uncovered one', () => {
+  const exc = create({ gate: 'gate:ship', scope: 'covered', reason: 'r', now: NOW });
+  const r = evaluateGate([T('covered', 'blocked'), T('uncovered', 'failed')], [exc], { gate: 'gate:ship', now: NOW });
+  assert.equal(r.pass, false);
+  assert.equal(r.blocking.length, 1);
+  assert.equal(r.blocking[0].id, 'uncovered');
+  assert.equal(r.covered.length, 1);
+});


### PR DESCRIPTION
Governance epic Phase 2 — strict-mode evidence-blocking gates.

gate:ship refuses to pass while any task is in a terminal-fail state {blocked, failed, unverified, not_run} unless a valid signed exception (Phase 1) covers it. Every covered task is logged with its exception id — no silent bypass.

- scripts/lib/gate-check.mjs: normalizeTask + covers (exact task-id token match) + evaluateGate. CLI reads bd list --json + exception registry.
- security-officer: mandatory gate-check before any gate:ship APPROVED.
- /inbox: surfaces signed exceptions (expired/expiring).
- 13 unit tests (caught a substring-coverage bug); 57 lib tests total; structural green.
