### PR TITLE
feat: impl-brief handoff bundle (NaCl governance Phase 3)

### DIFF
--- a/agents/architect.md
+++ b/agents/architect.md
@@ -832,6 +832,14 @@ Mark each item `- [ ]` so senior-dev and security-officer can tick off during re
 
    For `nano` projects: skip PM → go directly to senior-dev.
 
+   **Feeds the IMPL-BRIEF denylist (governance Phase 3):** pm Step 7b emits one
+   `docs/impl-briefs/IMPL-BRIEF-<task-id>.md` per task. Its **Files NOT to modify** list is
+   built from this ARCH's `## Non-goals` / `## Out of scope` and the `## Components` *Owner*
+   column. Write those precisely — a vague Non-goals section leaves the implementer's denylist
+   empty and scope creep un-catchable. For `regulated` / `large` features you may pre-emit the
+   briefs yourself (same template) so the boundary is fixed at architecture time; pm then
+   validates and extends rather than authoring from scratch.
+
 ## Cost Model — include in ARCH for qualifying projects
 
 Every ARCH-*.md for `project_size: medium` or larger, OR archetype `ai-system` / `commerce` / `regulated` (any size), includes a `## Cost Model` section. See `skills/great_cto/references/cost-model.md` for schema and data sources.

--- a/agents/pm.md
+++ b/agents/pm.md
@@ -394,6 +394,46 @@ echo "Plan written: $PLAN_FILE"
 
 ---
 
+## Step 7b — Emit one IMPL-BRIEF per implementation task (governance Phase 3)
+
+For every senior-dev task in the breakdown table, emit a per-task implementation brief.
+It pins what the implementer **may** touch, what they **must not**, and the
+API-CONTRACT / TEST-SPEC / ACCEPTANCE — so scope creep is caught mechanically, not in
+review. senior-dev reads it before coding (Step 4) and runs the scope check before commit.
+
+```bash
+mkdir -p docs/impl-briefs
+TMPL="$(ls -d ~/.claude/plugins/cache/local/great_cto/*/ 2>/dev/null | sort -V | tail -1 | sed 's|/$||')/skills/great_cto/templates/IMPL-BRIEF-template.md"
+[ -f "$TMPL" ] || TMPL="$(pwd)/skills/great_cto/templates/IMPL-BRIEF-template.md"
+```
+
+For each task `<id>` from the breakdown table:
+1. Copy the template to `docs/impl-briefs/IMPL-BRIEF-<id>.md`.
+2. Fill **Files to modify** (allowlist) and **Files NOT to modify** (denylist) by reading:
+   - the ARCH `## Components` owner column + `## Non-goals` / `## Out of scope` (off-limits),
+   - the parallelism analysis — any file owned by a *concurrent* task goes on the denylist
+     (this is the "no two parallel tasks own the same file" Proof-Check rule, made explicit
+     per implementer),
+   - `.great_cto/CODEBASE.md` god-nodes (touch only with a named reason).
+3. Copy the relevant slice of the ARCH `## API contracts` into **API-CONTRACT**, the task's
+   test cases into **TEST-SPEC**, and narrow the ARCH Definition of Done into **ACCEPTANCE**.
+4. Validate the brief is well-formed before moving on:
+   ```bash
+   node scripts/lib/impl-brief.mjs validate docs/impl-briefs/IMPL-BRIEF-<id>.md
+   ```
+   Exit 2 → fill the missing section (API-CONTRACT / TEST-SPEC / files / acceptance) and re-run.
+
+```bash
+echo "IMPL-BRIEFs written: docs/impl-briefs/IMPL-BRIEF-*.md (one per task)"
+```
+
+> Lean rule: for `poc`/`nano` modes, a single-file task may carry a 5-line brief — but the
+> **Files NOT to modify** list and ACCEPTANCE checklist are never skipped; they are the
+> guardrail. If architect already emitted briefs (large/regulated features), validate and
+> extend rather than overwrite.
+
+---
+
 ## Step 8 — Pre-plan Proof Check
 
 Before creating `gate:plan`, self-verify the plan:
@@ -404,6 +444,7 @@ PLAN PROOF CHECK:
   [ ] Critical path identified and duration stated in LLM wall-clock time? [Y/N]
   [ ] All gate points (gate:arch, gate:plan, gate:ship) in the graph? [Y/N]
   [ ] No two parallel tasks own the same file? [Y/N]
+  [ ] One IMPL-BRIEF per task emitted + `impl-brief.mjs validate` clean? [Y/N]
   [ ] Duration estimate has buffer applied? [Y/N]
   [ ] Minimum agent count stated? [Y/N]
   [ ] LLM cost estimate computed (per task + total)? [Y/N]

--- a/agents/senior-dev.md
+++ b/agents/senior-dev.md
@@ -335,6 +335,20 @@ Schema: `skills/great_cto/references/knowledge-extraction.md`
    git checkout -b feat/<beads-id>-<short-description>
    ```
 4. **Read context** (mandatory before writing a single line of code):
+   - **IMPL-BRIEF for this task** (governance Phase 3 — read FIRST, it scopes everything below):
+     ```bash
+     TASK_ID="<the bd id you claimed in step 2>"
+     BRIEF="docs/impl-briefs/IMPL-BRIEF-${TASK_ID}.md"
+     if [ -f "$BRIEF" ]; then
+       node scripts/lib/impl-brief.mjs validate "$BRIEF" || echo "WARN: brief malformed — ask pm to fix before coding"
+       cat "$BRIEF"
+     else
+       echo "NO_IMPL_BRIEF — task not scoped by pm. Proceed from ARCH, but treat ARCH Non-goals as the denylist and do not widen scope."
+     fi
+     ```
+     Honour it: implement **only** files under `## Files to modify`; never touch anything under
+     `## Files NOT to modify`. If the work genuinely needs an off-limits file, **stop** — go back
+     to pm/architect or open a signed exception (`/exception create`). Never silently widen scope.
    - Codebase map (if existing repo): `cat .great_cto/CODEBASE.md 2>/dev/null | head -40` — god nodes = highest-coupling modules, change carefully
    - Architecture doc: `ls docs/architecture/ARCH-*.md | sort -V | tail -1`
    - ADRs: `ls docs/decisions/ADR-*.md 2>/dev/null | sort | tail -3`
@@ -375,6 +389,19 @@ Schema: `skills/great_cto/references/knowledge-extraction.md`
      - **GREEN**: write minimal code to make test pass → re-run → confirm PASS
      - **REFACTOR**: clean up → confirm still PASS, no coverage regression
 6. **Quality check**: all tests pass, no lint errors, coverage ≥80%, no hardcoded secrets
+6b. **Scope check against the IMPL-BRIEF** (governance Phase 3 — before staging):
+   ```bash
+   BRIEF="docs/impl-briefs/IMPL-BRIEF-${TASK_ID}.md"
+   if [ -f "$BRIEF" ]; then
+     CHANGED=$(git diff --name-only HEAD; git diff --cached --name-only; git ls-files --others --exclude-standard)
+     node scripts/lib/impl-brief.mjs check "$BRIEF" $(echo "$CHANGED" | sort -u)
+   fi
+   ```
+   - **Exit 1 (denylist hit)** → a file you changed is on `## Files NOT to modify`. Do NOT commit.
+     Revert that file, or — if the change is genuinely required — open a signed exception
+     (`/exception create --gate gate:ship --scope "<task-id>" --reason "<why>"`) and note its id in the PR.
+   - **Warnings (off-allowlist files)** → either add the file to the brief's `## Files to modify`
+     (with a reason) or revert it. An unexplained out-of-scope file is scope creep.
 7. **Commit** with conventional commit format:
    ```bash
    git add -p  # stage intentionally, not git add .
@@ -418,6 +445,15 @@ Schema: `skills/great_cto/references/knowledge-extraction.md`
    ```
    - Any MISSING → do NOT close the task. Implement the missing item, run tests, then re-run Proof Loop.
    - All covered → proceed to close.
+
+   Then verify the IMPL-BRIEF **ACCEPTANCE** checklist (governance Phase 3) — every box must
+   hold before close, including the scope-clean line:
+   ```bash
+   BRIEF="docs/impl-briefs/IMPL-BRIEF-${TASK_ID}.md"
+   [ -f "$BRIEF" ] && sed -n '/## ACCEPTANCE/,/^## /p' "$BRIEF"
+   ```
+   Any unchecked acceptance item → not done. The scope-clean item is satisfied by the Step 6b
+   `impl-brief.mjs check` (clean, or covered by a signed exception).
 
    Also run a final test pass to confirm no regressions slipped in:
    ```bash

--- a/scripts/lib/impl-brief.mjs
+++ b/scripts/lib/impl-brief.mjs
@@ -1,0 +1,217 @@
+// scripts/lib/impl-brief.mjs — implementation-brief parser + scope check (governance Phase 3).
+//
+// An IMPL-BRIEF (skills/great_cto/templates/IMPL-BRIEF-template.md) pins, per task, the
+// files an implementer MAY touch (allowlist) and MUST NOT touch (denylist), plus an
+// API-CONTRACT / TEST-SPEC / ACCEPTANCE. This module makes the boundary machine-checkable
+// so scope creep is caught mechanically instead of in review prose:
+//
+//   - parseBrief(md)            → { filesToModify, filesNotToModify, hasApiContract,
+//                                   hasTestSpec, acceptance, taskId }
+//   - validateBrief(brief)      → { valid, errors }  (the brief is well-formed)
+//   - checkScope(changed, brief)→ { ok, violations, warnings }  (a diff respects the brief)
+//
+// CLI:
+//   node scripts/lib/impl-brief.mjs validate <brief.md>
+//   node scripts/lib/impl-brief.mjs check    <brief.md> <changed-file…>
+//       exit 0 = clean · 1 = denylist hit (hard) · 2 = malformed brief
+//   (allowlist misses are warnings, not failures — they print but keep exit 0.)
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+// Headings we recognise (matched case-insensitively, ignoring a trailing "(explicit)" etc).
+const SECTION = {
+  modify: /^#{1,4}\s+files\s+to\s+modify\b/i,
+  notModify: /^#{1,4}\s+files\s+not\s+to\s+modify\b/i,
+  api: /^#{1,4}\s+api[-\s]?contract\b/i,
+  test: /^#{1,4}\s+test[-\s]?spec\b/i,
+  acceptance: /^#{1,4}\s+acceptance\b/i,
+};
+
+const ANY_HEADING = /^#{1,4}\s+/;
+// A backtick-wrapped path, ignoring template placeholders like `{src/foo.ts}`.
+const PATH_IN_BACKTICKS = /`([^`]+)`/g;
+
+function isPlaceholder(s) {
+  // Template stubs are wrapped in {curly braces} or contain a spaceless {…}. Skip them.
+  return /[{}]/.test(s) || s.includes('…') || s.includes('...');
+}
+
+/** Split markdown into { headingKey → [lines] } buckets for the sections we care about. */
+function bucketSections(md) {
+  const lines = String(md).split(/\r?\n/);
+  const buckets = {};
+  let current = null;
+  for (const line of lines) {
+    if (ANY_HEADING.test(line)) {
+      current = null;
+      for (const [key, re] of Object.entries(SECTION)) {
+        if (re.test(line)) { current = key; buckets[key] = buckets[key] || []; break; }
+      }
+      continue;
+    }
+    if (current) buckets[current].push(line);
+  }
+  return buckets;
+}
+
+/** Extract real (non-placeholder) backtick paths from a block of lines. */
+function pathsFrom(lines) {
+  const out = [];
+  for (const line of lines || []) {
+    let m;
+    PATH_IN_BACKTICKS.lastIndex = 0;
+    while ((m = PATH_IN_BACKTICKS.exec(line)) !== null) {
+      const raw = m[1].trim();
+      if (!raw || isPlaceholder(raw)) continue;
+      // Skip inline-code that's plainly a command, not a path (heuristic: contains a space
+      // and no slash/dot — e.g. `npm test`). Keep things that look pathish or glob-ish.
+      if (/\s/.test(raw) && !/[\/.]/.test(raw)) continue;
+      out.push(raw);
+    }
+  }
+  // De-dupe, preserve order.
+  return [...new Set(out)];
+}
+
+/** Count checklist items (`- [ ]` / `- [x]`) in a block. */
+function checklistItems(lines) {
+  return (lines || []).filter((l) => /^\s*[-*]\s+\[[ xX]\]/.test(l)).map((l) => l.trim());
+}
+
+/** True if a section bucket has any non-placeholder, non-blank prose. */
+function hasContent(lines) {
+  return (lines || []).some((l) => {
+    const t = l.trim();
+    if (!t || t.startsWith('>')) return false;          // skip blockquote guidance
+    if (/^[-|]/.test(t) && /\{.*\}/.test(t)) return false; // skip placeholder table rows
+    return /[A-Za-z0-9`]/.test(t) && !isPlaceholder(t);
+  });
+}
+
+/**
+ * Parse an IMPL-BRIEF markdown string into a structured brief.
+ */
+export function parseBrief(md) {
+  const text = String(md);
+  const buckets = bucketSections(text);
+  const taskMatch = text.match(/\*\*bd task:\*\*\s*`([^`]+)`/i)
+    || text.match(/IMPL-BRIEF-([A-Za-z0-9_-]+)\.md/);
+  const taskId = taskMatch ? taskMatch[1].replace(/[{}]/g, '').trim() : null;
+  return {
+    taskId: taskId && !isPlaceholder(taskId) ? taskId : null,
+    filesToModify: pathsFrom(buckets.modify),
+    filesNotToModify: pathsFrom(buckets.notModify),
+    hasApiContract: hasContent(buckets.api),
+    hasTestSpec: hasContent(buckets.test),
+    acceptance: checklistItems(buckets.acceptance),
+    _sections: Object.keys(buckets),
+  };
+}
+
+/**
+ * Is the brief well-formed enough for an implementer to act on?
+ * Requires: ≥1 file to modify, a (possibly-empty but present) NOT-to-modify section,
+ * an API-CONTRACT, a TEST-SPEC, and ≥1 acceptance criterion.
+ */
+export function validateBrief(brief) {
+  const errors = [];
+  if (!brief.filesToModify.length) errors.push('no concrete `## Files to modify` entries');
+  if (!brief._sections.includes('notModify')) errors.push('missing `## Files NOT to modify` section');
+  if (!brief.hasApiContract) errors.push('empty or missing `## API-CONTRACT`');
+  if (!brief.hasTestSpec) errors.push('empty or missing `## TEST-SPEC`');
+  if (!brief.acceptance.length) errors.push('no `## ACCEPTANCE` checklist items');
+  return { valid: errors.length === 0, errors };
+}
+
+/**
+ * Convert a path/glob entry to a RegExp. Supports `**` (any depth, incl. slashes),
+ * `*` (anything but a slash), and `?`. A bare directory like `src/shared/` matches
+ * everything under it. Anchored at both ends.
+ */
+export function globToRegExp(glob) {
+  let g = String(glob).trim().replace(/\/+$/, (m) => m); // keep trailing slash for dir test
+  const dir = g.endsWith('/');
+  if (dir) g += '**';
+  let re = '';
+  for (let i = 0; i < g.length; i++) {
+    const c = g[i];
+    if (c === '*') {
+      if (g[i + 1] === '*') { re += '.*'; i++; if (g[i + 1] === '/') i++; }
+      else re += '[^/]*';
+    } else if (c === '?') re += '[^/]';
+    else if ('\\^$+.()|[]{}'.includes(c)) re += '\\' + c;
+    else re += c;
+  }
+  return new RegExp('^' + re + '$');
+}
+
+function matchesAny(file, globs) {
+  const f = String(file).replace(/^\.\//, '');
+  return globs.find((g) => globToRegExp(g).test(f) || globToRegExp(g).test('./' + f));
+}
+
+/**
+ * Check a list of changed files against a brief.
+ * @returns {{ ok: boolean, violations: string[], warnings: string[] }}
+ *   violations = files matching the denylist (hard fail).
+ *   warnings   = files matching neither list (possible scope creep, soft).
+ */
+export function checkScope(changedFiles, brief) {
+  const violations = [];
+  const warnings = [];
+  for (const file of changedFiles || []) {
+    if (!file) continue;
+    const denied = matchesAny(file, brief.filesNotToModify);
+    if (denied) { violations.push(`${file} → matches NOT-to-modify \`${denied}\``); continue; }
+    const allowed = matchesAny(file, brief.filesToModify);
+    if (!allowed) warnings.push(`${file} → not in \`## Files to modify\` allowlist`);
+  }
+  return { ok: violations.length === 0, violations, warnings };
+}
+
+// ── CLI ──────────────────────────────────────────────────────────────────────
+function main(argv) {
+  const [cmd, briefPath, ...rest] = argv;
+  if (!cmd || !briefPath) {
+    console.error('usage: impl-brief.mjs validate <brief.md>');
+    console.error('       impl-brief.mjs check    <brief.md> <changed-file…>');
+    process.exit(2);
+  }
+  let brief;
+  try {
+    brief = parseBrief(readFileSync(briefPath, 'utf8'));
+  } catch (e) {
+    console.error(`cannot read brief: ${e.message}`);
+    process.exit(2);
+  }
+
+  if (cmd === 'validate') {
+    const { valid, errors } = validateBrief(brief);
+    if (valid) { console.log(`IMPL-BRIEF OK — ${brief.filesToModify.length} file(s) in scope, ${brief.acceptance.length} acceptance item(s)`); process.exit(0); }
+    console.error('IMPL-BRIEF malformed:');
+    for (const e of errors) console.error(`  ✗ ${e}`);
+    process.exit(2);
+  }
+
+  if (cmd === 'check') {
+    const v = validateBrief(brief);
+    if (!v.valid) { console.error('IMPL-BRIEF malformed (run `validate`):'); for (const e of v.errors) console.error(`  ✗ ${e}`); process.exit(2); }
+    const { ok, violations, warnings } = checkScope(rest, brief);
+    for (const w of warnings) console.error(`  ⚠ ${w}`);
+    for (const v2 of violations) console.error(`  ✗ ${v2}`);
+    if (ok) {
+      console.log(`scope clean — ${rest.length} changed file(s) within brief${warnings.length ? ` (${warnings.length} warning${warnings.length > 1 ? 's' : ''})` : ''}`);
+      process.exit(0);
+    }
+    console.error(`SCOPE VIOLATION — ${violations.length} file(s) hit the NOT-to-modify denylist. Stop; return to pm/architect or open a signed exception.`);
+    process.exit(1);
+  }
+
+  console.error(`unknown command: ${cmd}`);
+  process.exit(2);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main(process.argv.slice(2));
+}

--- a/skills/great_cto/templates/IMPL-BRIEF-template.md
+++ b/skills/great_cto/templates/IMPL-BRIEF-template.md
@@ -1,0 +1,132 @@
+---
+name: IMPL-BRIEF-template
+description: Per-task implementation brief — files to modify / files NOT to modify (anti-scope-creep guardrail) / step-by-step + paired API-CONTRACT, TEST-SPEC, and ACCEPTANCE. Emitted per impl task by pm (or architect); read by senior-dev before writing code. Machine-checkable via scripts/lib/impl-brief.mjs.
+when_to_use: pm Step 7b emits one IMPL-BRIEF per senior-dev task into docs/impl-briefs/IMPL-BRIEF-<task-id>.md. senior-dev reads it before claiming the task and runs the scope check before commit. Cuts scope creep — a changed file outside the allow/deny lists is flagged.
+applies_to:
+  - ai-system
+  - agent-product
+  - commerce
+  - web3
+  - browser-extension
+  - game
+  - regulated
+  - fintech
+  - iot-embedded
+  - data-platform
+  - mobile-app
+  - library
+  - enterprise
+  - web-app
+  - devtools
+  - infra
+  - marketing-site
+---
+
+# IMPL-BRIEF-{task-id}.md — implementation brief for one task
+
+> **One brief per senior-dev task.** Emitted by `pm.md` Step 7b (derived from the ARCH
+> doc + the PLAN task row); read by `senior-dev.md` Step 4 before any code is written.
+> Source: `skills/great_cto/templates/IMPL-BRIEF-template.md`. Destination:
+> `docs/impl-briefs/IMPL-BRIEF-<bd-task-id>.md`.
+>
+> **Why this exists (governance Phase 3):** an unscoped task invites scope creep — the
+> implementer touches files nobody reviewed, or re-derives an API the ARCH already pinned.
+> This brief makes the boundary explicit and **machine-checkable**:
+> `node scripts/lib/impl-brief.mjs check <brief> <changed-files…>` flags any file that
+> falls outside `## Files to modify` or matches `## Files NOT to modify`.
+
+## Task
+
+- **bd task:** `{bd-task-id}` — `{task title from PLAN}`
+- **Feature:** `{feature-slug}` · PLAN: `docs/plans/PLAN-{feature-slug}.md`
+- **ARCH:** `docs/architecture/ARCH-{feature-slug}.md` · component: `{component this task builds}`
+- **Implements REQ / UC:** `{REQ-n, UC-n — or "none" if infra/chore}`
+
+## Files to modify
+
+> The allowlist. Every entry is a path or glob the implementer is expected to touch.
+> List the file **and the reason**, so review knows what each change is for.
+> `scripts/lib/impl-brief.mjs check` treats a changed file NOT matched here as a
+> scope-creep warning.
+
+| File / glob | Why it changes |
+|---|---|
+| `{src/feature/foo.ts}` | {add endpoint X handler} |
+| `{tests/feature/foo.test.ts}` | {RED tests for endpoint X} |
+| `{src/feature/index.ts}` | {wire the new handler into the router} |
+
+## Files NOT to modify
+
+> The denylist — the anti-scope-creep guardrail. These are tempting-but-out-of-bounds:
+> shared modules another task owns, generated files, config the ARCH froze, god-nodes
+> from `.great_cto/CODEBASE.md`. A changed file matching any entry is a **hard scope
+> violation** (`check` exits non-zero), not a warning. If you genuinely need to touch one,
+> stop and go back to pm/architect — don't silently widen scope.
+
+| File / glob | Why it's off-limits | Who owns it |
+|---|---|---|
+| `{src/shared/auth/**}` | {owned by WP-2, parallel task — would conflict} | {senior-dev #2} |
+| `{db/schema.sql}` | {ARCH froze the schema for this phase} | {architect} |
+| `{src/generated/**}` | {generated artefact — edit the source, not the output} | {build} |
+
+## Step-by-step
+
+> The implementation sequence. Keep steps to ~2–5 min of work each, RED→GREEN→REFACTOR.
+
+1. {Write failing test in `tests/feature/foo.test.ts` for the happy path of endpoint X.}
+2. {Implement `foo.ts` handler until the test passes.}
+3. {Add the error-path test (invalid input → 400) and make it pass.}
+4. {Wire the handler into `index.ts`; run the full suite.}
+
+## API-CONTRACT
+
+> The interface this task must honour — copied/narrowed from the ARCH `## API contracts`.
+> Pin it here so the implementer doesn't re-invent signatures or response shapes.
+
+- **Surface:** `{function signature / HTTP route + method / CLI subcommand}`
+- **Input:** `{params, types, required vs optional, validation rules}`
+- **Output (success):** `{return type / response body shape / exit code 0}`
+- **Errors:** `{error type / status code / message contract for each failure mode}`
+- **Invariants:** `{idempotency? auth required? rate limit? no breaking change in MINOR?}`
+
+## TEST-SPEC
+
+> The tests this task must add (the RED list). qa-engineer and the Proof Loop check these
+> exist and pass. Each row → at least one test case.
+
+| # | Case | Expected |
+|---|---|---|
+| 1 | {happy path — valid input} | {200 + body shape, or returns value V} |
+| 2 | {invalid input} | {400 + error contract from API-CONTRACT} |
+| 3 | {boundary / edge case} | {documented behaviour} |
+| 4 | {regression guard for a known postmortem, if any} | {no recurrence} |
+
+- Coverage target: `{from PROJECT.md, default ≥80%}`
+- Run: `{exact test command, e.g. npm test -- foo.test.ts}`
+
+## ACCEPTANCE
+
+> Done = all boxes checked. senior-dev verifies these in the Step 10 Proof Loop before
+> closing the bd task; mirrors the ARCH Definition of Done, narrowed to this task.
+
+- [ ] Every row in **TEST-SPEC** has a passing test
+- [ ] Every REQ/UC in **Task** is implemented and has a test that proves it
+- [ ] No file outside **Files to modify** was changed (`impl-brief.mjs check` clean), or a
+      signed exception covers the deviation
+- [ ] No file in **Files NOT to modify** was touched
+- [ ] API-CONTRACT honoured exactly (signatures + error contract)
+- [ ] Coverage ≥ target; lint clean; no hardcoded secrets
+
+## Out of scope / deferred
+
+> What this task explicitly does NOT do — pushed to a later task or phase. Prevents the
+> implementer from "while I'm here…" expansion.
+
+- {e.g. caching the endpoint response — deferred to WP-5}
+- {e.g. i18n of error messages — out of scope this phase}
+
+## Revision history
+
+| Date | Author | Change |
+|---|---|---|
+| {YYYY-MM-DD} | {pm / architect} | Initial brief |

--- a/skills/great_cto/templates/README.md
+++ b/skills/great_cto/templates/README.md
@@ -25,6 +25,7 @@
 | `compliance: [sox]` | `SOX-ITGC-checklist.md` | `docs/compliance/` |
 | `compliance: [pci-dss-saq-a]` | `PCI-DSS-SAQ-A.md` | `docs/compliance/` |
 | `compliance: [pci-dss]` (full scope) | `PCI-DSS-SAQ-D.md` | `docs/compliance/` |
+| every senior-dev task (pm Step 7b) | `IMPL-BRIEF-template.md` (×N, one per task) | `docs/impl-briefs/IMPL-BRIEF-{task-id}.md` |
 
 ## How agents use these
 
@@ -35,6 +36,8 @@
 `qa-engineer.md` Step 0b validates `tests/eval/EVAL-*.md` count against archetype thresholds — `EVAL-template.md` is what each scenario file looks like.
 
 `project-auditor.md` Phase 4 (planned v1.0.133) reads `monthly-budget-llm-usd` from PROJECT.md and the `## Cost Model` section of `ARCH-ai.md` to detect cost-cap violations.
+
+`pm.md` Step 7b emits one `IMPL-BRIEF-{task-id}.md` per task (governance Phase 3) — files-to-modify / files-NOT-to-modify / API-CONTRACT / TEST-SPEC / ACCEPTANCE. `senior-dev.md` Step 4 reads it before coding and Step 6b runs `node scripts/lib/impl-brief.mjs check <brief> <changed-files…>` to refuse a commit that touches a denylisted file. `validate` / `check` make the brief machine-enforceable, not just prose.
 
 ## What's NOT in this directory
 

--- a/tests/lib/impl-brief.test.mjs
+++ b/tests/lib/impl-brief.test.mjs
@@ -1,0 +1,186 @@
+// tests/lib/impl-brief.test.mjs — unit tests for impl-brief parser + scope check (governance Phase 3)
+//
+// Run: node --test tests/lib/impl-brief.test.mjs
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { parseBrief, validateBrief, checkScope, globToRegExp } from '../../scripts/lib/impl-brief.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const TEMPLATE = join(HERE, '../../skills/great_cto/templates/IMPL-BRIEF-template.md');
+
+// A concrete, well-formed brief (placeholders resolved) — what pm actually emits.
+const GOOD = `# IMPL-BRIEF-gc-123.md
+
+## Task
+- **bd task:** \`gc-123\` — add /healthz endpoint
+- Implements REQ / UC: REQ-2
+
+## Files to modify
+| File / glob | Why |
+|---|---|
+| \`src/api/healthz.ts\` | new handler |
+| \`tests/api/healthz.test.ts\` | RED tests |
+
+## Files NOT to modify
+| File / glob | Why | Owner |
+|---|---|---|
+| \`src/shared/auth/**\` | parallel task | dev2 |
+| \`db/schema.sql\` | frozen | architect |
+
+## Step-by-step
+1. write test
+2. implement
+
+## API-CONTRACT
+- Surface: \`GET /healthz\`
+- Output: 200 \`{status:"ok"}\`
+
+## TEST-SPEC
+| # | Case | Expected |
+|---|---|---|
+| 1 | hit /healthz | 200 |
+
+## ACCEPTANCE
+- [ ] test passes
+- [ ] no denylist file touched
+`;
+
+// ── parseBrief ────────────────────────────────────────────────────────────────
+
+test('parseBrief: extracts task id from **bd task** line', () => {
+  assert.equal(parseBrief(GOOD).taskId, 'gc-123');
+});
+
+test('parseBrief: extracts task id from filename header when no bd-task line', () => {
+  assert.equal(parseBrief('# IMPL-BRIEF-abc9.md\n## Files to modify\n`x.ts`').taskId, 'abc9');
+});
+
+test('parseBrief: collects only the modify allowlist paths', () => {
+  const b = parseBrief(GOOD);
+  assert.deepEqual(b.filesToModify, ['src/api/healthz.ts', 'tests/api/healthz.test.ts']);
+});
+
+test('parseBrief: collects the denylist separately', () => {
+  assert.deepEqual(parseBrief(GOOD).filesNotToModify, ['src/shared/auth/**', 'db/schema.sql']);
+});
+
+test('parseBrief: detects API-CONTRACT and TEST-SPEC content', () => {
+  const b = parseBrief(GOOD);
+  assert.equal(b.hasApiContract, true);
+  assert.equal(b.hasTestSpec, true);
+});
+
+test('parseBrief: counts acceptance checklist items', () => {
+  assert.equal(parseBrief(GOOD).acceptance.length, 2);
+});
+
+test('parseBrief: ignores placeholder paths and command-like inline code', () => {
+  const md = '## Files to modify\n| \`{src/foo.ts}\` | x |\n| \`npm test\` | y |\n| \`real/path.ts\` | z |';
+  assert.deepEqual(parseBrief(md).filesToModify, ['real/path.ts']);
+});
+
+// ── validateBrief ─────────────────────────────────────────────────────────────
+
+test('validateBrief: well-formed brief is valid', () => {
+  assert.equal(validateBrief(parseBrief(GOOD)).valid, true);
+});
+
+test('validateBrief: missing files-to-modify fails', () => {
+  const b = parseBrief('## Files NOT to modify\n## API-CONTRACT\n- x\n## TEST-SPEC\n- y\n## ACCEPTANCE\n- [ ] z');
+  const r = validateBrief(b);
+  assert.equal(r.valid, false);
+  assert.match(r.errors.join(' '), /Files to modify/);
+});
+
+test('validateBrief: missing NOT-to-modify section fails', () => {
+  const b = parseBrief('## Files to modify\n`a.ts`\n## API-CONTRACT\n- x\n## TEST-SPEC\n- y\n## ACCEPTANCE\n- [ ] z');
+  assert.equal(validateBrief(b).valid, false);
+});
+
+test('validateBrief: no acceptance items fails', () => {
+  const b = parseBrief('## Files to modify\n`a.ts`\n## Files NOT to modify\n`b.ts`\n## API-CONTRACT\n- x\n## TEST-SPEC\n- y\n## ACCEPTANCE\n');
+  assert.equal(validateBrief(b).valid, false);
+});
+
+// ── the shipped template itself must parse as a template (placeholders → invalid concrete) ──
+
+test('template file: parses, all five sections present', () => {
+  const b = parseBrief(readFileSync(TEMPLATE, 'utf8'));
+  for (const s of ['modify', 'notModify', 'api', 'test', 'acceptance']) {
+    assert.ok(b._sections.includes(s), `template missing section bucket: ${s}`);
+  }
+  // Template has acceptance items (real `- [ ]` lines, not placeholders).
+  assert.ok(b.acceptance.length >= 5, 'template should ship a real ACCEPTANCE checklist');
+});
+
+// ── globToRegExp ──────────────────────────────────────────────────────────────
+
+test('globToRegExp: * does not cross slash', () => {
+  assert.equal(globToRegExp('src/*.ts').test('src/a.ts'), true);
+  assert.equal(globToRegExp('src/*.ts').test('src/sub/a.ts'), false);
+});
+
+test('globToRegExp: ** crosses slashes', () => {
+  assert.equal(globToRegExp('src/shared/**').test('src/shared/auth/jwt.ts'), true);
+});
+
+test('globToRegExp: trailing-slash dir matches everything under it', () => {
+  assert.equal(globToRegExp('src/shared/').test('src/shared/x.ts'), true);
+});
+
+test('globToRegExp: dot is literal', () => {
+  assert.equal(globToRegExp('a.ts').test('axts'), false);
+  assert.equal(globToRegExp('a.ts').test('a.ts'), true);
+});
+
+// ── checkScope ────────────────────────────────────────────────────────────────
+
+test('checkScope: changed files within allowlist → clean', () => {
+  const r = checkScope(['src/api/healthz.ts', 'tests/api/healthz.test.ts'], parseBrief(GOOD));
+  assert.equal(r.ok, true);
+  assert.equal(r.violations.length, 0);
+  assert.equal(r.warnings.length, 0);
+});
+
+test('checkScope: denylist hit → hard violation', () => {
+  const r = checkScope(['src/shared/auth/jwt.ts'], parseBrief(GOOD));
+  assert.equal(r.ok, false);
+  assert.equal(r.violations.length, 1);
+  assert.match(r.violations[0], /NOT-to-modify/);
+});
+
+test('checkScope: frozen file (exact denylist) → violation', () => {
+  const r = checkScope(['db/schema.sql'], parseBrief(GOOD));
+  assert.equal(r.ok, false);
+});
+
+test('checkScope: off-allowlist file → warning, not violation', () => {
+  const r = checkScope(['src/api/other.ts'], parseBrief(GOOD));
+  assert.equal(r.ok, true);
+  assert.equal(r.warnings.length, 1);
+  assert.match(r.warnings[0], /allowlist/);
+});
+
+test('checkScope: denylist takes precedence over allowlist phrasing', () => {
+  // a file both not-in-allowlist AND in denylist is a violation, reported once
+  const r = checkScope(['src/shared/auth/x.ts'], parseBrief(GOOD));
+  assert.equal(r.violations.length, 1);
+  assert.equal(r.warnings.length, 0);
+});
+
+test('checkScope: leading ./ normalised', () => {
+  const r = checkScope(['./src/api/healthz.ts'], parseBrief(GOOD));
+  assert.equal(r.ok, true);
+  assert.equal(r.warnings.length, 0);
+});
+
+test('checkScope: empty / falsy entries skipped', () => {
+  const r = checkScope(['', null, 'src/api/healthz.ts'], parseBrief(GOOD));
+  assert.equal(r.ok, true);
+  assert.equal(r.warnings.length, 0);
+});


### PR DESCRIPTION
## Summary

Closes **Phase 3** of epic `great_cto-h4p` (NaCl-inspired governance). Every senior-dev task now ships with a per-task **implementation brief** that pins what the implementer may touch, must not touch, plus the contract/tests/acceptance — and the boundary is **machine-checkable**, not just review prose. Closes the "unscoped task → silent scope creep" gap.

This is the impl-brief layer the governance contour was missing: Phase 1 made bypasses auditable (signed exceptions), Phase 2 made gates refuse on missing evidence, Phase 3 makes the **task boundary itself** enforceable before code is written.

## What

| What | Detail |
|---|---|
| `skills/great_cto/templates/IMPL-BRIEF-template.md` | files-to-modify (allowlist) / **files NOT to modify** (denylist) / step-by-step + paired API-CONTRACT + TEST-SPEC + ACCEPTANCE |
| `scripts/lib/impl-brief.mjs` | `parseBrief` + `validateBrief` (well-formed) + `checkScope` (a diff respects the brief; glob/`**` aware, denylist = hard fail, off-allowlist = warn). CLI: `validate` (exit 2 malformed) / `check <brief> <changed-files…>` (exit 1 on denylist hit) |
| `pm.md` | Step 7b emits + validates one brief per task; new Proof-Check line |
| `senior-dev.md` | Step 4 reads brief before coding · Step 6b runs `impl-brief.mjs check` before staging, refuses a commit touching a denylisted file (override = signed exception from Phase 1) · Step 10 Proof Loop verifies ACCEPTANCE |
| `architect.md` | ARCH `## Non-goals` + `## Components` owner column feed the denylist; regulated/large features may pre-emit briefs |

## End-to-end

```
validate → IMPL-BRIEF OK — 2 file(s) in scope, 2 acceptance item(s)
before  → check src/mw/ratelimit.ts … src/shared/auth/jwt.ts
          ✗ src/shared/auth/jwt.ts → matches NOT-to-modify `src/shared/auth/**`
          SCOPE VIOLATION (exit 1)
after   → reverted off-limits file → scope clean (exit 0)
```

→ Scope creep is caught mechanically; the only sanctioned override is a Phase-1 signed exception.

## Test plan

- [x] 80/80 lib tests pass (57 existing + **23 new** in `tests/lib/impl-brief.test.mjs` — covers glob `**`, denylist-over-allowlist precedence, `./` normalisation, template parses with all five sections)
- [x] structural validation green
- [x] prompt-lint clean on all touched agents (pm / architect / senior-dev)
- [x] CLI smoke + end-to-end demo (above)
- [ ] reviewer: confirm IMPL-BRIEF template reads cleanly for a real task

## Beads

Closes `great_cto-atm` (Phase 3). Remaining in epic: Phase 4 (beads traceability), Phase 5 (gap-closure waves).