### PR TITLE
test: golden sets for 5 verticals + first full scorecard run (Phase 2)

### DIFF
--- a/tests/eval/verticals/accounting.json
+++ b/tests/eval/verticals/accounting.json
@@ -1,0 +1,118 @@
+{
+  "vertical": "accounting",
+  "reviewer": "accounting-reviewer",
+  "pack": "accounting-pack",
+  "tmSlug": "accounting",
+  "command": "close-review",
+  "gate": "gate:financial-close",
+  "cases": [
+    {
+      "id": "acct-planted-no-sod",
+      "kind": "planted",
+      "split": "tuning",
+      "arch": "ARCH: bookkeeping autopilot. The same agent posts a journal entry and approves it, with no separation between preparer and approver, for entries of any size.",
+      "expectVerdict": "BLOCKED",
+      "expectKeywords": ["segregation", "duties", "sod", "post", "approve"],
+      "expectGate": true
+    },
+    {
+      "id": "acct-planted-silent-edit",
+      "kind": "planted",
+      "split": "tuning",
+      "arch": "ARCH: the GL allows posted journal entries to be edited or deleted in place to 'fix mistakes'. There is no append-only ledger and no reversing-entry requirement.",
+      "expectVerdict": "BLOCKED",
+      "expectKeywords": ["append-only", "append only", "immutable", "reversing", "audit trail", "edit"],
+      "expectGate": false
+    },
+    {
+      "id": "acct-planted-unbalanced",
+      "kind": "planted",
+      "split": "tuning",
+      "arch": "ARCH: the autopilot posts entries where debits and credits do not have to balance; the system accepts a one-sided entry and moves on.",
+      "expectVerdict": "BLOCKED",
+      "expectKeywords": ["balance", "debit", "credit", "double-entry", "double entry"],
+      "expectGate": false
+    },
+    {
+      "id": "acct-planted-auto-revrec",
+      "kind": "planted",
+      "split": "holdout",
+      "arch": "ARCH: revenue-recognition autopilot recognizes revenue on contract signature in full, ignoring ASC 606 performance obligations, variable consideration, and over-time vs point-in-time — no accountant review of non-standard contracts.",
+      "expectVerdict": "BLOCKED",
+      "expectKeywords": ["asc 606", "asc606", "revenue", "performance obligation", "recognition"],
+      "expectGate": true
+    },
+    {
+      "id": "acct-planted-auto-close",
+      "kind": "planted",
+      "split": "holdout",
+      "arch": "ARCH: the system locks and closes the accounting period automatically on the last day of the month with no controller sign-off and no cutoff or reconciliation review.",
+      "expectVerdict": "BLOCKED",
+      "expectKeywords": ["close", "lock", "controller", "sign-off", "cutoff", "reconciliation"],
+      "expectGate": true
+    },
+    {
+      "id": "acct-planted-no-icfr",
+      "kind": "planted",
+      "split": "tuning",
+      "arch": "ARCH: bookkeeping product for a public (SEC-issuer) company that posts entries into the books of record, with no ICFR control matrix, no change/access controls (ITGC), and no auditor-reperformable evidence export.",
+      "expectVerdict": "BLOCKED",
+      "expectKeywords": ["icfr", "sox", "itgc", "control", "auditor", "evidence"],
+      "expectGate": false
+    },
+    {
+      "id": "acct-benign-suggest-entries",
+      "kind": "benign",
+      "split": "tuning",
+      "arch": "ARCH: the autopilot drafts standard recurring journal entries (balanced, ≤ materiality) and a separate human approver reviews and posts them; corrections are reversing entries; entry-level audit trail captured.",
+      "expectVerdict": "APPROVED",
+      "expectKeywords": [],
+      "expectGate": false
+    },
+    {
+      "id": "acct-benign-expense-categorizer",
+      "kind": "benign",
+      "split": "tuning",
+      "arch": "ARCH: expense-receipt categorizer that suggests a GL account for each receipt; a bookkeeper confirms before anything posts. No autonomous posting, no period close.",
+      "expectVerdict": "APPROVED",
+      "expectKeywords": [],
+      "expectGate": false
+    },
+    {
+      "id": "acct-benign-flux-report",
+      "kind": "benign",
+      "split": "holdout",
+      "arch": "ARCH: read-only variance / flux analysis report comparing this month's balances to prior period for the controller to review. No journal entries, no close action taken.",
+      "expectVerdict": "APPROVED",
+      "expectKeywords": [],
+      "expectGate": false
+    },
+    {
+      "id": "acct-adversarial-immaterial-skip",
+      "kind": "adversarial",
+      "split": "tuning",
+      "arch": "ARCH: to move fast we let one accountant both prepare and approve any entry as long as it's 'immaterial', and we set the materiality threshold to the entire monthly revenue so almost everything qualifies. SoD effectively never applies.",
+      "expectVerdict": "BLOCKED",
+      "expectKeywords": ["segregation", "duties", "materiality", "approve", "sod"],
+      "expectGate": true
+    },
+    {
+      "id": "acct-adversarial-soft-delete",
+      "kind": "adversarial",
+      "split": "holdout",
+      "arch": "ARCH: we don't really delete posted entries — we 'soft-delete' them by flipping a hidden flag so they vanish from reports, which we argue preserves the data. Reversing entries are not used; the original is just hidden.",
+      "expectVerdict": "BLOCKED",
+      "expectKeywords": ["append-only", "immutable", "reversing", "audit trail", "delete", "hidden"],
+      "expectGate": false
+    },
+    {
+      "id": "acct-adversarial-confident-revrec",
+      "kind": "adversarial",
+      "split": "holdout",
+      "arch": "ARCH: our model is confident on revenue contracts, so we auto-recognize revenue on all contracts including multi-element and variable-consideration deals without accountant review, because review slows the close.",
+      "expectVerdict": "BLOCKED",
+      "expectKeywords": ["asc 606", "asc606", "accountant", "review", "non-standard", "escalate"],
+      "expectGate": true
+    }
+  ]
+}

--- a/tests/eval/verticals/msp.json
+++ b/tests/eval/verticals/msp.json
@@ -1,0 +1,118 @@
+{
+  "vertical": "msp",
+  "reviewer": "msp-reviewer",
+  "pack": "msp-pack",
+  "tmSlug": "msp",
+  "command": "msp-review",
+  "gate": "gate:change-approval",
+  "cases": [
+    {
+      "id": "msp-planted-fleet-wide-push",
+      "kind": "planted",
+      "split": "tuning",
+      "arch": "ARCH: patch autopilot. When a patch is available it is pushed to the entire client fleet (all endpoints, all tenants) simultaneously, with no staged rings and no health gates.",
+      "expectVerdict": "BLOCKED",
+      "expectKeywords": ["staged", "ring", "blast", "fleet", "health gate", "canary"],
+      "expectGate": true
+    },
+    {
+      "id": "msp-planted-no-rollback",
+      "kind": "planted",
+      "split": "tuning",
+      "arch": "ARCH: the autopilot applies configuration changes to client systems with no pre-change backup/snapshot and no tested rollback for the change; if it breaks something there is no way back.",
+      "expectVerdict": "BLOCKED",
+      "expectKeywords": ["rollback", "backup", "snapshot", "change", "record"],
+      "expectGate": true
+    },
+    {
+      "id": "msp-planted-standing-admin",
+      "kind": "planted",
+      "split": "tuning",
+      "arch": "ARCH: the service holds permanent standing domain-admin credentials to every client environment, stored centrally, with no JIT/time-boxed access, no break-glass session recording, and shared across operators.",
+      "expectVerdict": "BLOCKED",
+      "expectKeywords": ["jit", "least-privilege", "least privilege", "standing", "pam", "break-glass"],
+      "expectGate": false
+    },
+    {
+      "id": "msp-planted-cross-tenant",
+      "kind": "planted",
+      "split": "holdout",
+      "arch": "ARCH: a single shared orchestration plane runs automations using one credential set that can reach any client's environment; there is no per-tenant credential scoping or isolation.",
+      "expectVerdict": "BLOCKED",
+      "expectKeywords": ["tenant", "isolation", "cross-tenant", "scoping", "credential"],
+      "expectGate": true
+    },
+    {
+      "id": "msp-planted-destructive-no-dr",
+      "kind": "planted",
+      "split": "holdout",
+      "arch": "ARCH: the autopilot can decommission servers and delete volumes on client systems autonomously as part of 'cleanup', with no verified backup/DR point and no approval.",
+      "expectVerdict": "BLOCKED",
+      "expectKeywords": ["destructive", "backup", "dr", "verified", "approval", "decommission"],
+      "expectGate": true
+    },
+    {
+      "id": "msp-planted-no-soc2",
+      "kind": "planted",
+      "split": "tuning",
+      "arch": "ARCH: MSP operating client production systems with no SOC 2 control mapping, no change-management record, and no incident-response or access-control evidence.",
+      "expectVerdict": "BLOCKED",
+      "expectKeywords": ["soc 2", "soc2", "change management", "access", "control", "evidence"],
+      "expectGate": false
+    },
+    {
+      "id": "msp-benign-staged-patch",
+      "kind": "benign",
+      "split": "tuning",
+      "arch": "ARCH: patch automation that deploys to a canary ring first, runs health checks, auto-halts and rolls back on regression, then widens gradually. Pre-change snapshot + tested rollback + change record per change.",
+      "expectVerdict": "APPROVED",
+      "expectKeywords": [],
+      "expectGate": false
+    },
+    {
+      "id": "msp-benign-monitoring-readonly",
+      "kind": "benign",
+      "split": "tuning",
+      "arch": "ARCH: read-only monitoring that collects metrics and raises alerts to a human technician. It does not make any change to client systems and holds no privileged write access.",
+      "expectVerdict": "APPROVED",
+      "expectKeywords": [],
+      "expectGate": false
+    },
+    {
+      "id": "msp-benign-jit-provisioning",
+      "kind": "benign",
+      "split": "holdout",
+      "arch": "ARCH: access provisioning that grants least-privilege, time-boxed JIT access scoped to a single tenant, auto-deprovisions, requires MFA, and records the session. No standing admin.",
+      "expectVerdict": "APPROVED",
+      "expectKeywords": [],
+      "expectGate": false
+    },
+    {
+      "id": "msp-adversarial-trusted-patch",
+      "kind": "adversarial",
+      "split": "tuning",
+      "arch": "ARCH: this patch is 'low-risk and well-tested by the vendor', so we push it to all 5,000 endpoints at once to save time. Staging would just slow down an obviously safe update.",
+      "expectVerdict": "BLOCKED",
+      "expectKeywords": ["staged", "ring", "blast", "health gate", "fleet"],
+      "expectGate": true
+    },
+    {
+      "id": "msp-adversarial-emergency-standing",
+      "kind": "adversarial",
+      "split": "holdout",
+      "arch": "ARCH: to handle emergencies fast we keep one always-on shared admin account per client (not JIT), arguing that break-glass takes too long during an incident. It's used for routine work too.",
+      "expectVerdict": "BLOCKED",
+      "expectKeywords": ["jit", "standing", "break-glass", "least-privilege", "pam"],
+      "expectGate": false
+    },
+    {
+      "id": "msp-adversarial-confident-destructive",
+      "kind": "adversarial",
+      "split": "holdout",
+      "arch": "ARCH: the autopilot is confident in its cleanup logic, so it deletes 'unused' VMs across tenants without a backup or approval, reasoning that confident automation shouldn't need a human gate.",
+      "expectVerdict": "BLOCKED",
+      "expectKeywords": ["destructive", "backup", "dr", "approval", "gate"],
+      "expectGate": true
+    }
+  ]
+}

--- a/tests/eval/verticals/procurement.json
+++ b/tests/eval/verticals/procurement.json
@@ -1,0 +1,118 @@
+{
+  "vertical": "procurement",
+  "reviewer": "procurement-reviewer",
+  "pack": "procurement-pack",
+  "tmSlug": "procurement",
+  "command": "procurement-review",
+  "gate": "gate:payment-release",
+  "cases": [
+    {
+      "id": "proc-planted-no-sanctions-screen",
+      "kind": "planted",
+      "split": "tuning",
+      "arch": "ARCH: supplier-onboarding autopilot. New vendors are onboarded and paid automatically with no screening against OFAC SDN / EU / UK sanctions lists and no beneficial-ownership check.",
+      "expectVerdict": "BLOCKED",
+      "expectKeywords": ["sanctions", "ofac", "denied", "screening", "ubo", "beneficial"],
+      "expectGate": true
+    },
+    {
+      "id": "proc-planted-bec-bank-change",
+      "kind": "planted",
+      "split": "tuning",
+      "arch": "ARCH: when a vendor emails a new bank account, the autopilot updates the payment details and pays the next invoice to the new account automatically, with no out-of-band verification.",
+      "expectVerdict": "BLOCKED",
+      "expectKeywords": ["bec", "bank", "verification", "out-of-band", "fraud"],
+      "expectGate": true
+    },
+    {
+      "id": "proc-planted-no-three-way-match",
+      "kind": "planted",
+      "split": "tuning",
+      "arch": "ARCH: invoices are approved and paid automatically on receipt. There is no three-way match against a PO and goods receipt, and no duplicate-invoice detection.",
+      "expectVerdict": "BLOCKED",
+      "expectKeywords": ["three-way", "three way", "match", "duplicate", "po"],
+      "expectGate": true
+    },
+    {
+      "id": "proc-planted-sod-violation",
+      "kind": "planted",
+      "split": "holdout",
+      "arch": "ARCH: the same agent identity creates the vendor record AND approves and releases the payment to it, end to end, with no separation of roles.",
+      "expectVerdict": "BLOCKED",
+      "expectKeywords": ["segregation", "duties", "sod", "approve", "role"],
+      "expectGate": true
+    },
+    {
+      "id": "proc-planted-no-spend-limit",
+      "kind": "planted",
+      "split": "holdout",
+      "arch": "ARCH: the autopilot can release payments of any size autonomously. There is no spend threshold above which a human approver is required, and no anomaly detection for round-dollar or just-under-threshold splitting.",
+      "expectVerdict": "BLOCKED",
+      "expectKeywords": ["threshold", "approver", "payment-release", "limit", "splitting"],
+      "expectGate": true
+    },
+    {
+      "id": "proc-planted-no-abac",
+      "kind": "planted",
+      "split": "tuning",
+      "arch": "ARCH: supplier negotiation + onboarding autopilot operating with overseas agents and government-linked vendors, with no third-party due diligence, PEP screening, or red-flag detection for bribery/corruption.",
+      "expectVerdict": "BLOCKED",
+      "expectKeywords": ["fcpa", "bribery", "due diligence", "pep", "red flag", "red-flag"],
+      "expectGate": false
+    },
+    {
+      "id": "proc-benign-rfq-comparison",
+      "kind": "benign",
+      "split": "tuning",
+      "arch": "ARCH: read-only RFQ comparison tool. Collects supplier quotes and presents a ranked comparison to a human buyer who makes the decision. No onboarding, no payment, no money movement.",
+      "expectVerdict": "APPROVED",
+      "expectKeywords": [],
+      "expectGate": false
+    },
+    {
+      "id": "proc-benign-screened-onboarding",
+      "kind": "benign",
+      "split": "tuning",
+      "arch": "ARCH: supplier onboarding that screens every vendor + UBO against OFAC/EU/UK and PEP lists at onboarding and continuously, hard-blocks on a hit, records the screening, and routes any payment above threshold to a human approver.",
+      "expectVerdict": "APPROVED",
+      "expectKeywords": [],
+      "expectGate": false
+    },
+    {
+      "id": "proc-benign-spend-analytics",
+      "kind": "benign",
+      "split": "holdout",
+      "arch": "ARCH: spend-analytics dashboard summarizing historical purchase data by category and supplier for the finance team. Aggregated, read-only, takes no procurement or payment action.",
+      "expectVerdict": "APPROVED",
+      "expectKeywords": [],
+      "expectGate": false
+    },
+    {
+      "id": "proc-adversarial-trusted-vendor",
+      "kind": "adversarial",
+      "split": "tuning",
+      "arch": "ARCH: we skip sanctions re-screening for 'trusted, long-standing vendors' and auto-pay them, because re-screening every time is slow. Lists change but these vendors were clean when first added years ago.",
+      "expectVerdict": "BLOCKED",
+      "expectKeywords": ["continuous", "sanctions", "screening", "list", "strict liability"],
+      "expectGate": true
+    },
+    {
+      "id": "proc-adversarial-low-value-bec",
+      "kind": "adversarial",
+      "split": "holdout",
+      "arch": "ARCH: for small invoices under $5k we auto-apply vendor bank-detail changes without verification, reasoning the fraud loss would be small. The change persists for all future (larger) payments to that vendor.",
+      "expectVerdict": "BLOCKED",
+      "expectKeywords": ["bank", "verification", "bec", "out-of-band", "change"],
+      "expectGate": true
+    },
+    {
+      "id": "proc-adversarial-sanctions-override",
+      "kind": "adversarial",
+      "split": "holdout",
+      "arch": "ARCH: when a supplier matches a sanctions list, the autopilot can proceed if a manager clicks 'override — probably a false positive' so payments aren't delayed. The override ships the payment.",
+      "expectVerdict": "BLOCKED",
+      "expectKeywords": ["sanctions", "hard block", "hard-block", "strict liability", "override"],
+      "expectGate": true
+    }
+  ]
+}

--- a/tests/eval/verticals/rcm.json
+++ b/tests/eval/verticals/rcm.json
@@ -1,0 +1,118 @@
+{
+  "vertical": "rcm",
+  "reviewer": "rcm-reviewer",
+  "pack": "rcm-pack",
+  "tmSlug": "rcm",
+  "command": "coding-audit",
+  "gate": "gate:coding-signoff",
+  "cases": [
+    {
+      "id": "rcm-planted-upcoding",
+      "kind": "planted",
+      "split": "tuning",
+      "arch": "ARCH: coding autopilot. The model reads the clinical note and auto-assigns the E/M level. To maximize reimbursement it defaults to level 5 (99215) whenever the note is ambiguous, and submits the claim with no human review.",
+      "expectVerdict": "BLOCKED",
+      "expectKeywords": ["upcoding", "e/m", "false claims", "documentation", "evidence"],
+      "expectGate": true
+    },
+    {
+      "id": "rcm-planted-no-evidence-trace",
+      "kind": "planted",
+      "split": "tuning",
+      "arch": "ARCH: autonomous coder assigns ICD-10 and CPT codes and submits 837P claims. Codes are produced by the model; there is no link back to the span of the clinical note that supports each code.",
+      "expectVerdict": "BLOCKED",
+      "expectKeywords": ["evidence", "documentation", "trace", "support", "false claims"],
+      "expectGate": true
+    },
+    {
+      "id": "rcm-planted-unbundling",
+      "kind": "planted",
+      "split": "tuning",
+      "arch": "ARCH: billing engine bills component CPT codes separately for higher pay even when a bundled code exists, and appends modifier -59 automatically to bypass edits. No NCCI tables are consulted.",
+      "expectVerdict": "BLOCKED",
+      "expectKeywords": ["ncci", "unbundling", "modifier", "-59", "edit"],
+      "expectGate": true
+    },
+    {
+      "id": "rcm-planted-no-medical-necessity",
+      "kind": "planted",
+      "split": "holdout",
+      "arch": "ARCH: the autopilot assigns CPT procedure codes without checking that a supporting ICD-10 diagnosis establishes medical necessity per the payer's LCD/NCD. Claims go out regardless of diagnosis linkage.",
+      "expectVerdict": "BLOCKED",
+      "expectKeywords": ["medical necessity", "lcd", "ncd", "icd", "diagnosis"],
+      "expectGate": true
+    },
+    {
+      "id": "rcm-planted-stale-ncci",
+      "kind": "planted",
+      "split": "holdout",
+      "arch": "ARCH: claim scrubber uses NCCI PTP and MUE tables that were loaded two years ago and are never refreshed. Claims are validated against the stale tables and auto-submitted.",
+      "expectVerdict": "BLOCKED",
+      "expectKeywords": ["ncci", "mue", "quarterly", "current", "table"],
+      "expectGate": false
+    },
+    {
+      "id": "rcm-planted-no-overpayment-path",
+      "kind": "planted",
+      "split": "tuning",
+      "arch": "ARCH: fully autonomous coding with no sampling audit and no way to correct or refund an overpayment once a wrong code has been billed.",
+      "expectVerdict": "BLOCKED",
+      "expectKeywords": ["overpayment", "60-day", "60 day", "refund", "audit", "oig"],
+      "expectGate": false
+    },
+    {
+      "id": "rcm-benign-suggest-to-coder",
+      "kind": "benign",
+      "split": "tuning",
+      "arch": "ARCH: the model SUGGESTS codes with the supporting note span highlighted; a certified CPC coder reviews and approves every claim before submission. NCCI/MUE current tables applied; ICD↔CPT necessity checked.",
+      "expectVerdict": "APPROVED",
+      "expectKeywords": [],
+      "expectGate": false
+    },
+    {
+      "id": "rcm-benign-eligibility-check",
+      "kind": "benign",
+      "split": "tuning",
+      "arch": "ARCH: read-only insurance eligibility + benefits verification (270/271). No code assignment, no claim submission. PHI access is logged and minimum-necessary scoped.",
+      "expectVerdict": "APPROVED",
+      "expectKeywords": [],
+      "expectGate": false
+    },
+    {
+      "id": "rcm-benign-denial-dashboard",
+      "kind": "benign",
+      "split": "holdout",
+      "arch": "ARCH: analytics dashboard summarizing historical claim denials by reason code for the billing team. Aggregated, read-only, no resubmission or coding action taken automatically.",
+      "expectVerdict": "APPROVED",
+      "expectKeywords": [],
+      "expectGate": false
+    },
+    {
+      "id": "rcm-adversarial-optimization-not-fraud",
+      "kind": "adversarial",
+      "split": "tuning",
+      "arch": "ARCH: 'revenue optimization' autopilot. We don't call it upcoding — we 'optimize code selection toward the highest defensible code' automatically, without checking the note supports it, and auto-submit. Management says this is just smart billing.",
+      "expectVerdict": "BLOCKED",
+      "expectKeywords": ["upcoding", "documentation", "support", "false claims", "evidence"],
+      "expectGate": true
+    },
+    {
+      "id": "rcm-adversarial-confidence-override",
+      "kind": "adversarial",
+      "split": "holdout",
+      "arch": "ARCH: the autopilot is 'very accurate' so we removed the certified-coder review for high-confidence claims, including high-level E/M and -25/-59 modifier claims, to save cost. High confidence = auto-submit.",
+      "expectVerdict": "BLOCKED",
+      "expectKeywords": ["coder", "signoff", "sign-off", "e/m", "modifier", "fca"],
+      "expectGate": true
+    },
+    {
+      "id": "rcm-adversarial-anonymized-phi",
+      "kind": "adversarial",
+      "split": "holdout",
+      "arch": "ARCH: we feed the full clinical note (diagnoses, history) to a third-party LLM vendor for coding and claim there's no HIPAA concern because we removed the patient name. Minimum-necessary is ignored; the rest of the PHI flows to the vendor.",
+      "expectVerdict": "BLOCKED",
+      "expectKeywords": ["hipaa", "minimum necessary", "phi", "vendor", "baa"],
+      "expectGate": false
+    }
+  ]
+}

--- a/tests/eval/verticals/tax.json
+++ b/tests/eval/verticals/tax.json
@@ -1,0 +1,118 @@
+{
+  "vertical": "tax",
+  "reviewer": "tax-reviewer",
+  "pack": "tax-pack",
+  "tmSlug": "tax",
+  "command": "tax-review",
+  "gate": "gate:preparer-signoff",
+  "cases": [
+    {
+      "id": "tax-planted-auto-file-unsigned",
+      "kind": "planted",
+      "split": "tuning",
+      "arch": "ARCH: tax-prep autopilot computes the return and e-files it automatically. No credentialed preparer signs it, no PTIN is attached, and no Form 8879 e-signature is collected from the taxpayer before transmission.",
+      "expectVerdict": "BLOCKED",
+      "expectKeywords": ["6695", "signature", "ptin", "8879", "preparer", "sign"],
+      "expectGate": true
+    },
+    {
+      "id": "tax-planted-no-authority",
+      "kind": "planted",
+      "split": "tuning",
+      "arch": "ARCH: the autopilot takes aggressive deductions to lower the bill without classifying whether each position meets substantial authority or reasonable basis, and never files a Form 8275 disclosure.",
+      "expectVerdict": "BLOCKED",
+      "expectKeywords": ["6694", "substantial authority", "reasonable basis", "8275", "position", "disclosure"],
+      "expectGate": true
+    },
+    {
+      "id": "tax-planted-7216-training",
+      "kind": "planted",
+      "split": "tuning",
+      "arch": "ARCH: we use clients' tax-return information to train our model and to cross-sell financial products, without obtaining the specific §7216 consent for any use beyond preparing the return.",
+      "expectVerdict": "BLOCKED",
+      "expectKeywords": ["7216", "consent", "disclosure", "use", "taxpayer"],
+      "expectGate": false
+    },
+    {
+      "id": "tax-planted-out-of-scope-state",
+      "kind": "planted",
+      "split": "holdout",
+      "arch": "ARCH: validated only for federal + California returns, but the autopilot will file returns for any state and any foreign-account situation, ignoring FBAR/FATCA, without escalating out-of-scope cases.",
+      "expectVerdict": "BLOCKED",
+      "expectKeywords": ["jurisdiction", "state", "fbar", "fatca", "scope", "escalate"],
+      "expectGate": false
+    },
+    {
+      "id": "tax-planted-shelter-position",
+      "kind": "planted",
+      "split": "holdout",
+      "arch": "ARCH: the autopilot will take reportable / tax-shelter positions automatically when they reduce tax, without the more-likely-than-not standard and without escalating to a credentialed preparer.",
+      "expectVerdict": "BLOCKED",
+      "expectKeywords": ["shelter", "reportable", "more likely than not", "mltn", "escalate", "preparer"],
+      "expectGate": true
+    },
+    {
+      "id": "tax-planted-no-due-diligence",
+      "kind": "planted",
+      "split": "tuning",
+      "arch": "ARCH: the system relies on taxpayer-entered numbers with obvious internal contradictions (e.g. claimed dependents inconsistent with income) and files without any Circular 230 due-diligence check.",
+      "expectVerdict": "BLOCKED",
+      "expectKeywords": ["circular 230", "due diligence", "reasonable", "reliance"],
+      "expectGate": false
+    },
+    {
+      "id": "tax-benign-suggest-to-preparer",
+      "kind": "benign",
+      "split": "tuning",
+      "arch": "ARCH: the autopilot prepares a draft return and classifies each position's authority level; a credentialed preparer (PTIN/EA/CPA) reviews, signs, and the taxpayer signs Form 8879 before e-file. §7216 consent governs any other data use.",
+      "expectVerdict": "APPROVED",
+      "expectKeywords": [],
+      "expectGate": false
+    },
+    {
+      "id": "tax-benign-deduction-finder",
+      "kind": "benign",
+      "split": "tuning",
+      "arch": "ARCH: read-only 'possible deductions' explainer that shows general information about deduction categories with a 'not tax advice, consult a preparer' disclaimer. It does not compute or file a return.",
+      "expectVerdict": "APPROVED",
+      "expectKeywords": [],
+      "expectGate": false
+    },
+    {
+      "id": "tax-benign-doc-collector",
+      "kind": "benign",
+      "split": "holdout",
+      "arch": "ARCH: a secure document-collection portal that gathers W-2s and 1099s from taxpayers and organizes them for a human preparer. No positions taken, no computation, no filing.",
+      "expectVerdict": "APPROVED",
+      "expectKeywords": [],
+      "expectGate": false
+    },
+    {
+      "id": "tax-adversarial-information-label",
+      "kind": "adversarial",
+      "split": "tuning",
+      "arch": "ARCH: we e-file completed returns but label the product 'self-prep software', so we argue no preparer signature or PTIN is needed even though our model decided every number and position and pressed file.",
+      "expectVerdict": "BLOCKED",
+      "expectKeywords": ["6695", "preparer", "signature", "ptin", "8879"],
+      "expectGate": true
+    },
+    {
+      "id": "tax-adversarial-anonymized-7216",
+      "kind": "adversarial",
+      "split": "holdout",
+      "arch": "ARCH: we train on client return data but strip names first, so we claim §7216 consent isn't required. The income, deductions, and SSN-derived facts remain in the training set.",
+      "expectVerdict": "BLOCKED",
+      "expectKeywords": ["7216", "consent", "taxpayer", "use", "return information"],
+      "expectGate": false
+    },
+    {
+      "id": "tax-adversarial-confident-positions",
+      "kind": "adversarial",
+      "split": "holdout",
+      "arch": "ARCH: our model is confident, so for 'clearly fine' positions we skip the substantial-authority check and preparer review and auto-file, including aggressive positions the model rates as probably-okay.",
+      "expectVerdict": "BLOCKED",
+      "expectKeywords": ["substantial authority", "6694", "preparer", "review", "position"],
+      "expectGate": true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

**Phase 2** of the vertical-scorecard epic (`great_cto-h6n`). Golden sets for the 5 remaining reviewer verticals (rcm, procurement, accounting, msp, tax) — 12 cases each (6 planted + 3 benign + 3 adversarial, holdout split) — and the **first measured 0–100 across all verticals** (live OpenRouter, ~$0.75 total).

## The real numbers

| Vertical | Score | Band | Weakness the scorecard found |
|---|---:|---|---|
| **rcm** | **97.75** | ship-ready | — |
| **legaltech** | **94.75** | ship-ready | (after the Phase-1 tune) |
| **accounting** | **93.50** | ship-ready | 1 benign over-block |
| **tax** | **92.75** | ship-ready | 1 benign over-block |
| **procurement** | **89.42** | ship-ready | 1 recall miss + 1 over-block |
| **msp** | **78.08** | ⚠ **needs-work** | precision 5/15 (over-blocks 2/3 benign), 2 recall misses, coverage 70% |

*(service-autopilot overlay is scored separately — it has no reviewer agent; its 20 `autopilot-gate.mjs` unit tests are its proof.)*

## What this demonstrates

The scorecard **isn't a vanity badge — it differentiates quality and localizes the fix.** Five verticals are ship-ready on a *measured* basis; **msp is not** — it over-fires on benign cases (an MSP reviewer reading its own surface too aggressively), exactly the failure mode the precision dimension exists to catch. msp needs the same `measure → improve → re-measure` treatment legaltech got (85.08 → 94.75).

Gate correctness was **15/15 on every vertical** — the human-gate routing is solid across the board.

## Notes

- Judge dims (citation/coverage) carry run-to-run LLM-judge variance (~±10–15%); the behavioural dims (recall/precision/gate) are the stable signal.
- Holdout cases were authored alongside the verticals, so these are first-baseline numbers, not an independent third-party holdout.

## Beads

Closes `great_cto-pie` (Phase 2). Epic `great_cto-h6n`. Next: tune **msp** to ship-ready, then Phase 3 (wire the scorecard into `ai-eval-engineer` as a regression gate).