### PR TITLE
feat: vertical-reviewer regression gate (scorecard Phase 3)

### DIFF
--- a/agents/ai-eval-engineer.md
+++ b/agents/ai-eval-engineer.md
@@ -74,6 +74,33 @@ guarantee: **a learned prompt improvement cannot ship until re-run and measured 
 
 Plus a runner: `tests/eval/run.sh` or `tests/eval/test_evals.py` that executes all EVAL files and produces a single pass/fail summary for CI.
 
+## Vertical-reviewer regression gate (same pattern, for service-autopilot verticals)
+
+The service-autopilot vertical reviewers (legaltech / rcm / procurement / accounting / msp / tax)
+are themselves judgment products — their quality is a **measured** 0–100 score, not a declared one.
+When a reviewer prompt or its pack changes, re-score the affected vertical and block on regression,
+exactly like the prompt holdout gate above.
+
+```bash
+# Score one vertical against its golden set (tests/eval/verticals/<vertical>.json):
+OPENROUTER_API_KEY=... node scripts/eval/vertical-scorecard.mjs <vertical>
+
+# Regression gate on a reviewer/pack change (exit 0 = ok, 1 = regression):
+OPENROUTER_API_KEY=... node scripts/eval/vertical-scorecard.mjs <vertical> --gate
+
+# After a CONFIRMED improvement, re-baseline intentionally:
+OPENROUTER_API_KEY=... node scripts/eval/vertical-scorecard.mjs <vertical> --rebaseline
+```
+
+- The gate compares the **stable subscore** (recall + precision + gate = the deterministic,
+  verdict-based dims, max 60) to `tests/eval/verticals/baselines.json`, within a tolerance
+  (default ±5, to absorb borderline-case + actor variance). The LLM-judge dims (citation/coverage)
+  carry run-to-run noise and are **advisory, not gated**.
+- Holdout cases in each golden set are gate-only — never used to tune a reviewer prompt (SIA
+  discipline, same as the holdout split above). The pure engine + math live in
+  `scripts/lib/vertical-score.mjs` (`scoreVertical` / `stableSubscore` / `regressionGate`).
+- Run this when you (or a reviewer) touch `agents/<x>-reviewer.md` or `skills/great_cto/packs/<x>-pack.md`.
+
 ## Workflow
 
 ### Step 0: Read inputs and verify pre-conditions

--- a/scripts/eval/vertical-scorecard.mjs
+++ b/scripts/eval/vertical-scorecard.mjs
@@ -13,7 +13,8 @@
 import { readFileSync, existsSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
-import { scoreVertical, formatScorecard } from '../lib/vertical-score.mjs';
+import { writeFileSync } from 'node:fs';
+import { scoreVertical, formatScorecard, stableSubscore, regressionGate } from '../lib/vertical-score.mjs';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
 const MODEL = process.env.EVAL_ACTOR_MODEL || 'anthropic/claude-sonnet-4.5';
@@ -148,6 +149,31 @@ async function main(argv) {
   const result = scoreVertical({ ...t0, caseResults, judge: judgeScores });
   console.log(formatScorecard(vertical, result));
   if (totalCost) console.log(`\n  run cost: ~$${totalCost.toFixed(2)}`);
+
+  // --gate / --rebaseline operate on the deterministic stable subscore (recall+precision+gate).
+  const gate = argv.includes('--gate');
+  const rebaseline = argv.includes('--rebaseline');
+  if ((gate || rebaseline) && !caseResults) {
+    console.error('\n--gate / --rebaseline need a behavioural run (set OPENROUTER_API_KEY; not --dry-run).');
+    process.exit(2);
+  }
+  if (gate || rebaseline) {
+    const stable = stableSubscore(result);
+    const basePath = join(ROOT, 'tests', 'eval', 'verticals', 'baselines.json');
+    const baseDoc = JSON.parse(readFileSync(basePath, 'utf8'));
+    if (rebaseline) {
+      baseDoc.baselines[vertical] = { stable, score: result.complete ? result.score : null };
+      writeFileSync(basePath, JSON.stringify(baseDoc, null, 2) + '\n');
+      console.log(`\n  ✓ re-baselined ${vertical}: stable ${stable}/60` + (result.complete ? `, score ${result.score}` : ''));
+      process.exit(0);
+    }
+    const base = baseDoc.baselines[vertical];
+    if (!base) { console.error(`\n  no baseline for ${vertical} — run --rebaseline first.`); process.exit(2); }
+    const g = regressionGate(base.stable, stable, { tolerance: baseDoc.tolerance ?? 5 });
+    console.log(`\n  GATE: ${g.message}`);
+    process.exit(g.pass ? 0 : 1);
+  }
+
   process.exit(result.complete && result.band === 'do-not-ship' ? 1 : 0);
 }
 

--- a/scripts/lib/vertical-score.mjs
+++ b/scripts/lib/vertical-score.mjs
@@ -128,3 +128,32 @@ export function formatScorecard(vertical, result) {
   }
   return out.join('\n');
 }
+
+// Dimensions that are deterministic enough to gate on (verdict + keyword based). The LLM-judge
+// dims (citation/coverage) carry run-to-run variance and are advisory, not gating.
+export const STABLE_DIMS = Object.freeze(['recall', 'precision', 'gate']);
+
+/** Sum of points across the stable, gate-worthy dimensions (max 60). */
+export function stableSubscore(result) {
+  return +result.breakdown
+    .filter((d) => STABLE_DIMS.includes(d.dim) && d.measured)
+    .reduce((s, d) => s + d.points, 0)
+    .toFixed(2);
+}
+
+/**
+ * Regression gate: a prompt/pack change must not drop the stable subscore below its baseline by
+ * more than `tolerance` (absorbs borderline-case + actor variance). Judge dims are excluded.
+ * @returns {{ pass: boolean, drop: number, baseline: number, current: number, message: string }}
+ */
+export function regressionGate(baselineStable, currentStable, { tolerance = 5 } = {}) {
+  const drop = +(baselineStable - currentStable).toFixed(2);
+  const pass = drop <= tolerance;
+  const delta = (-drop >= 0 ? '+' : '') + (-drop).toFixed(2);
+  return {
+    pass, drop, baseline: baselineStable, current: currentStable,
+    message: pass
+      ? `OK — stable subscore ${currentStable}/60 (baseline ${baselineStable}, Δ ${delta}, tol ±${tolerance})`
+      : `REGRESSION — stable subscore ${currentStable}/60 dropped ${drop} below baseline ${baselineStable} (tol ±${tolerance}). A reviewer/pack change degraded detection, precision, or gating.`,
+  };
+}

--- a/tests/eval/verticals/baselines.json
+++ b/tests/eval/verticals/baselines.json
@@ -1,0 +1,13 @@
+{
+  "_comment": "Regression-gate baselines for vertical reviewers. `stable` = recall+precision+gate points (max 60), the deterministic, gate-worthy subscore. Judge dims (citation/coverage) are advisory and NOT gated (run-to-run LLM-judge variance). `score` is the full 0-100 headline at baseline time, informational. A reviewer/pack change must not drop `stable` below baseline by more than the tolerance (default 5). Re-baseline intentionally with `vertical-scorecard.mjs <v> --rebaseline` after a confirmed improvement.",
+  "_measured": "2026-06-07 via OpenRouter (anthropic/claude-sonnet-4.5 actor, opus-4.1 judge)",
+  "tolerance": 5,
+  "baselines": {
+    "msp":         { "stable": 60,    "score": 98.5 },
+    "rcm":         { "stable": 60,    "score": 97.75 },
+    "legaltech":   { "stable": 60,    "score": 94.75 },
+    "accounting":  { "stable": 55,    "score": 93.5 },
+    "tax":         { "stable": 55,    "score": 92.75 },
+    "procurement": { "stable": 51.67, "score": 89.42 }
+  }
+}

--- a/tests/lib/vertical-score.test.mjs
+++ b/tests/lib/vertical-score.test.mjs
@@ -5,7 +5,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { scoreVertical, band, WEIGHTS, formatScorecard } from '../../scripts/lib/vertical-score.mjs';
+import { scoreVertical, band, WEIGHTS, formatScorecard, stableSubscore, regressionGate, STABLE_DIMS } from '../../scripts/lib/vertical-score.mjs';
 
 // A complete, perfect input → 100.
 const PERFECT = {
@@ -149,4 +149,52 @@ test('formatScorecard: partial run prints PARTIAL + hint', () => {
   const s = formatScorecard('legaltech', scoreVertical({ structural: { wired: true } }));
   assert.match(s, /PARTIAL/);
   assert.match(s, /OPENROUTER_API_KEY/);
+});
+
+// ── stableSubscore + regressionGate ───────────────────────────────────────────────
+
+test('STABLE_DIMS is recall/precision/gate (the deterministic, gate-worthy dims)', () => {
+  assert.deepEqual([...STABLE_DIMS].sort(), ['gate', 'precision', 'recall']);
+});
+
+test('stableSubscore: sums recall+precision+gate only (max 60)', () => {
+  assert.equal(stableSubscore(scoreVertical(PERFECT)), 60); // 30+15+15
+});
+
+test('stableSubscore: excludes judge dims even when present', () => {
+  const r = scoreVertical({ caseResults: [
+    { id: 'p1', kind: 'planted', verdict: 'BLOCKED', matchedKeywords: ['x'], expectGate: true, gateEmitted: true },
+    { id: 'b1', kind: 'benign', verdict: 'APPROVED' },
+  ], judge: { citationAccuracy: 1, coverageCompleteness: 1 } });
+  // recall 30 + precision 15 + gate 15 = 60; citation/coverage excluded
+  assert.equal(stableSubscore(r), 60);
+});
+
+test('stableSubscore: only counts measured stable dims', () => {
+  const r = scoreVertical({ structural: { wired: true } }); // no behavioural
+  assert.equal(stableSubscore(r), 0);
+});
+
+test('regressionGate: equal score passes', () => {
+  const g = regressionGate(60, 60);
+  assert.equal(g.pass, true);
+  assert.equal(g.drop, 0);
+});
+
+test('regressionGate: small drop within tolerance passes', () => {
+  assert.equal(regressionGate(60, 56, { tolerance: 5 }).pass, true);
+});
+
+test('regressionGate: drop beyond tolerance fails with REGRESSION message', () => {
+  const g = regressionGate(60, 50, { tolerance: 5 });
+  assert.equal(g.pass, false);
+  assert.equal(g.drop, 10);
+  assert.match(g.message, /REGRESSION/);
+});
+
+test('regressionGate: improvement (negative drop) passes', () => {
+  const g = regressionGate(55, 60);
+  assert.equal(g.pass, true);
+  assert.equal(g.drop, -5);
+  assert.match(g.message, /OK/);
 });


### PR DESCRIPTION
## Summary

**Phase 3** — the final piece of the vertical-scorecard epic (`great_cto-h6n`). Closes the loop: a reviewer/pack change is now **gated on its measured score**, exactly like the AI-prompt holdout gate `ai-eval-engineer` already runs.

## What

| What | Detail |
|---|---|
| `scripts/lib/vertical-score.mjs` | `stableSubscore` (recall+precision+gate, max 60 — the deterministic, verdict-based dims) + `regressionGate` (blocks if the stable subscore drops > tolerance below baseline). The LLM-judge dims (citation/coverage) are **advisory, excluded from the gate** — they carry run-to-run variance. 8 new unit tests |
| `scripts/eval/vertical-scorecard.mjs` | `--gate` (exit 1 on regression) + `--rebaseline` (after a confirmed improvement). Both require a behavioural run |
| `tests/eval/verticals/baselines.json` | measured stable baselines: msp/rcm/legaltech **60**, accounting/tax **55**, procurement **51.67**; tolerance **5** |
| `agents/ai-eval-engineer.md` | documents the gate — run on any `agents/<x>-reviewer.md` / `skills/great_cto/packs/<x>-pack.md` change |

## Live gate verified (OpenRouter)

```
$ vertical-scorecard.mjs legaltech --gate
  SCORE: 93.42/100 → SHIP-READY
  GATE: OK — stable subscore 56.67/60 (baseline 60, Δ -3.33, tol ±5)   exit 0
```

The gate absorbs run-to-run noise (a 3.33 wobble passes) but a real **>5 regression blocks** — so a prompt edit that breaks detection / precision / gating can't ship silently.

## Test plan

- [x] 164 lib tests (156 + **8 new**) — stableSubscore excludes judge dims, regressionGate tolerance / pass / fail / improvement
- [x] structural green · `ai-eval-engineer.md` lints clean · `--gate` guards against no-key

## Epic `great_cto-h6n` — COMPLETE

Engine → 6 golden sets → **2 measure→improve→re-measure cycles** (legaltech 85.08→94.75, msp 78.08→98.5) → regression gate. **All 7 verticals ship-ready on a measured basis:**

| Vertical | Score |
|---|---:|
| msp | 98.5 |
| rcm | 97.75 |
| legaltech | 94.75 |
| accounting | 93.5 |
| tax | 92.75 |
| procurement | 89.42 |

Closes `great_cto-yl8`.