### PR TITLE
feat: autopilot pivot — README rebrand + /start vertical detection (Phase 2b + 3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <img src="docs/screenshots/logo.svg" alt="great_cto" width="280" />
 
-**Your AI engineering team for ~$34/month.**
+**AI autopilots for business — get the work done, not just the software.**
 
 [![npm](https://img.shields.io/npm/v/great-cto?label=npx%20great-cto&color=cb3837)](https://www.npmjs.com/package/great-cto)
 [![npm downloads](https://img.shields.io/npm/dm/great-cto?color=cb3837&label=downloads)](https://www.npmjs.com/package/great-cto)
@@ -25,21 +25,40 @@ npx great-cto init
 
 ---
 
-## The problem
+## Services are the new software
 
-You're a solo CTO. You write the code, review the code, deploy the code. Nobody's catching:
+The next wave isn't tools for specialists — it's **autopilots that sell the outcome of a service**.
+An autopilot runs a whole business function end to end (intake → process → decide → deliver) and
+escalates only the judgment calls to a qualified human. Every model improvement makes the service
+faster and cheaper.
 
-- The GDPR clause you missed in the payment flow
-- The N+1 query that shows up in prod at 10× scale
-- The auth middleware hole you'll read about in a bug report
+GreatCTO ships those autopilots — each one a **flow of agents + tools with a human on the risky
+steps**, a built-in compliance reviewer, and a **measured quality score** behind it (not a claim).
 
-Hiring a senior engineer to review: **$15,000/month.** Doing it yourself: **risk.**
+## The autopilots
 
-## What you get
+| Autopilot | What it does | Market | Quality |
+|---|---|---|---|
+| 🩺 **[Medical-coding](https://greatcto.systems/autopilots/rcm.html)** | Clinical notes → clean, compliant claims; a certified coder signs the risky ones | $50–80B | **97.75/100** |
+| 🖥️ **[Managed-IT](https://greatcto.systems/autopilots/msp.html)** | Patches, configs & access across the fleet — staged, reversible, human on big changes | $100B+ | **98.5/100** |
+| ⚖️ **[Legal-document](https://greatcto.systems/autopilots/legaltech.html)** | Drafts & redlines contracts and NDAs; a licensed attorney signs anything that's advice | $20–25B | **94.75/100** |
+| 📒 **[Bookkeeping & close](https://greatcto.systems/autopilots/accounting.html)** | Books, reconciles & closes the month; a controller signs the close | $50–80B | **93.5/100** |
+| 🧾 **[Tax-prep](https://greatcto.systems/autopilots/tax.html)** | Prepares returns & classifies positions; a credentialed preparer signs before filing | $30–35B | **92.75/100** |
+| 🛒 **[Source-to-pay](https://greatcto.systems/autopilots/procurement.html)** | Onboards suppliers, matches invoices, releases payments — screened for sanctions & fraud | $200B+ | **89.42/100** |
 
-61 specialist agents — architect, 12-angle reviewer, QA, security officer, devops — wired into a gated pipeline tuned to your stack and jurisdiction.
+→ [All autopilots](https://greatcto.systems/autopilots.html) · run `/flow <vertical>` to see any flow in your terminal
 
-**You make two decisions per feature.** Everything else runs automatically.
+**Each autopilot keeps a human on the judgment calls** — a certified coder, a licensed attorney, a
+controller, a credentialed preparer. The autopilot does the volume; the human owns the call that
+carries liability. Connectors run as sandbox stubs today (flip to the real provider to go live).
+
+## Under the hood (for the CTO who runs it)
+
+Each autopilot is built and operated by a gated pipeline of specialist agents — architect, 12-angle
+reviewer, QA, security officer, devops — tuned to your stack and jurisdiction. **You make two
+decisions per feature; everything else runs automatically.** The compliance reviewer, signed human
+gates, audit trail, and the [measured scorecard](https://greatcto.systems/proof) are the trust
+layer that makes it safe to let the autopilot run.
 
 ## By the numbers
 

--- a/commands/start.md
+++ b/commands/start.md
@@ -160,6 +160,44 @@ Wait for CTO reply. If they say "I know what to build" or equivalent → proceed
 
 ---
 
+## Step 0.6: Autopilot vertical detection (business-function framing)
+
+Before generic type detection, check whether the CTO is automating a **known business function** —
+i.e. building one of our **autopilots**. If so, lead with the *flow* (business language), not
+"archetype + pack". This is the positioning surface (see `docs/positioning/vocabulary.md`).
+
+```bash
+PD=$(ls -d ~/.claude/plugins/cache/local/great_cto/*/ 2>/dev/null | sort -V | tail -1 | sed 's|/$||'); [ -z "$PD" ] && PD=.
+DESC=$(echo "$ARGUMENTS" | tr '[:upper:]' '[:lower:]')
+V=""
+echo "$DESC" | grep -qE "medical cod|icd-?10|\bcpt\b|claim|revenue cycle|\brcm\b|837|clearinghouse|denial|payer"      && V=rcm
+echo "$DESC" | grep -qE "contract|\bnda\b|redline|legal doc|attorney|law firm|e-?sign|clause|filing|paralegal"        && V=legaltech
+echo "$DESC" | grep -qE "procurement|source-to-pay|supplier|vendor onboard|purchase order|invoice|accounts payable|three-way" && V=procurement
+echo "$DESC" | grep -qE "bookkeep|accounting|journal entry|general ledger|reconcil|month-end|close the books|asc 606|gaap" && V=accounting
+echo "$DESC" | grep -qE "\bmsp\b|managed it|managed service|rmm|patch management|endpoint|provision access|help ?desk"  && V=msp
+echo "$DESC" | grep -qE "tax return|tax prep|\birs\b|form 1040|e-?file|preparer|1099|deduction"                       && V=tax
+
+if [ -n "$V" ] && [ -f "$PD/flows/${V}.flow.json" ]; then
+  echo "=== Looks like an autopilot: ${V} ==="
+  node -e "(async()=>{const m=await import('$PD/scripts/lib/flow.mjs');const fs=require('fs');console.log(m.renderFlow(JSON.parse(fs.readFileSync('$PD/flows/${V}.flow.json'))))})()" 2>/dev/null
+fi
+```
+
+**If a vertical matched** — present it to the CTO as the headline:
+
+> You're building the **{autopilot name}**. Here's the flow it runs — {N} automated steps and a
+> human checkpoint where a {role} signs the judgment calls. Connectors start as sandbox stubs.
+>
+> Want me to scaffold this autopilot? (the build runs under the hood; you approve the plan + the ship)
+
+Then set `archetype: {vertical}` in PROJECT.md, note `autopilot: {vertical}` and
+`connectors: stub`, and proceed to the normal pipeline (Step 2 onward) — the vertical's compliance
+reviewer + human gate are already wired. **Skip Step 1 type detection** (the vertical IS the type).
+
+**If no vertical matched** → proceed to Step 1 normally (generic software project).
+
+---
+
 ## Step 1: LLM-based Type Detection
 
 Read plugin files for type detection + archetype resolution:


### PR DESCRIPTION
## Summary

Finishes the positioning pivot (epic `great_cto-og7`): **README** and **`/start`** now speak *"AI autopilots for business,"* consistent with the rebranded landing.

## What changed

- **`README.md`** — leads with **"Services are the new software"** + an **autopilots table** (the 6 verticals: what it does · market size · measured quality, each linking its site page). The 61-agent SDLC pipeline is reframed as **"Under the hood (for the CTO who runs it)"** — the trust layer, not the headline.
- **`commands/start.md` Step 0.6** — detects whether the project description automates a **known business function** (rcm / legaltech / procurement / accounting / msp / tax via keywords) → renders the **flow** in business language (`/flow`) → frames the project as *building that autopilot* (sets `archetype = vertical`, `connectors: stub`, skips generic type detection). Falls back to normal `/start` for generic software.

## Verified

| Description | → detected |
|---|---|
| "automate medical coding from clinical notes" | rcm ✓ |
| "draft NDAs and contracts" | legaltech ✓ |
| "onboard suppliers and pay invoices" | procurement ✓ |
| "monthly bookkeeping and close" | accounting ✓ |
| "managed IT patch automation" | msp ✓ |
| "prepare tax returns and efile" | tax ✓ |

structural validation green.

## Pivot epic — complete

flows (Phase 1, merged) → landing rebrand (Phase 2, [great_cto-site#1](https://github.com/avelikiy/great_cto-site/pull/1), merged) → **README + `/start`** (this PR). Packs / reviewers / gates stay internal-only as the trust layer (`docs/positioning/vocabulary.md`).

Closes `great_cto-fe1`, `great_cto-7se`.