### PR TITLE
feat(phase4): live FHIR connector + flow-runner — autopilots execute the flow (Wave 1)

### DIFF
--- a/scripts/lib/connectors.mjs
+++ b/scripts/lib/connectors.mjs
@@ -12,7 +12,7 @@
  */
 export const CONNECTORS = Object.freeze({
   // ── rcm ──
-  'ehr-fhir':        { label: 'EHR (FHIR)',            verticals: ['rcm'],         capabilities: ['fetch-note', 'fetch-patient'], realProviders: ['Epic', 'Cerner', 'athenahealth'], status: 'stub' },
+  'ehr-fhir':        { label: 'EHR (FHIR)',            verticals: ['rcm'],         capabilities: ['fetch-note', 'fetch-patient'], realProviders: ['Epic', 'Cerner', 'athenahealth'], status: 'live-ready' },
   'ocr':             { label: 'Document OCR',          verticals: ['rcm', 'tax', 'accounting'], capabilities: ['extract-text'], realProviders: ['AWS Textract', 'Google DocAI'], status: 'stub' },
   'code-sets':       { label: 'ICD-10 / CPT / HCPCS',  verticals: ['rcm'],         capabilities: ['lookup-code', 'validate-code'], realProviders: ['CMS', 'AMA CPT'], status: 'stub' },
   'ncci-mue':        { label: 'NCCI / MUE edits',      verticals: ['rcm'],         capabilities: ['check-ptp', 'check-mue'], realProviders: ['CMS quarterly tables'], status: 'stub' },
@@ -85,9 +85,62 @@ export function stubCall(connectorId, op, payload = {}) {
     ok: true,
     connector: connectorId,
     op,
-    mode: spec.status, // 'stub'
+    mode: 'stub',
     // A realistic, op-shaped placeholder. Deterministic (no randomness) for reproducible demos.
     data: { _stub: true, connector: connectorId, op, echo: payload },
     note: `STUB — ${spec.label}.${op}; wire ${spec.realProviders[0] || 'a real provider'} to go live`,
   };
+}
+
+// ── live adapters ────────────────────────────────────────────────────────────
+// Lazily-imported real adapters (the stub→live path). Importing connectors.mjs stays
+// side-effect-free + network-free; the adapter module loads only when a live call is made.
+const LIVE_ADAPTERS = {
+  'ehr-fhir': () => import('./connectors/fhir.mjs'),
+};
+
+/** Does this connector have a real (live) adapter wired? */
+export function hasLiveAdapter(id) {
+  return !!LIVE_ADAPTERS[id];
+}
+
+/**
+ * Execute a connector op. mode 'stub' (default) → deterministic mock; mode 'live' → the real
+ * adapter when one is registered (else falls back to stub with a note). Mode also reads from
+ * GREAT_CTO_CONNECTOR_MODE so a whole flow run can be flipped live at once.
+ * @returns {Promise<object>} { ok, mode, data|error, … }
+ */
+export async function call(connectorId, op, payload = {}, { mode } = {}) {
+  const m = mode || process.env.GREAT_CTO_CONNECTOR_MODE || 'stub';
+  if (m === 'live' && LIVE_ADAPTERS[connectorId]) {
+    try {
+      const adapter = await LIVE_ADAPTERS[connectorId]();
+      if (!adapter.capabilities.includes(op)) return { ok: false, error: `live ${connectorId} has no op '${op}'` };
+      return await adapter.call(op, payload);
+    } catch (e) {
+      return { ok: false, mode: 'live', connector: connectorId, op, error: `live adapter failed: ${e.message}` };
+    }
+  }
+  if (m === 'live') {
+    const r = stubCall(connectorId, op, payload);
+    return { ...r, mode: 'stub', note: `${r.note || ''} (no live adapter yet — still stub)`.trim() };
+  }
+  return stubCall(connectorId, op, payload);
+}
+
+// ── CLI ───────────────────────────────────────────────────────────────────────
+import { fileURLToPath } from 'node:url';
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const [cmd, id, op, payloadArg] = process.argv.slice(2);
+  const live = process.argv.includes('--live');
+  if (cmd !== 'call' || !id || !op) {
+    console.error('usage: connectors.mjs call <connector> <op> [json-payload] [--live]');
+    console.error(`live-ready: ${Object.keys(LIVE_ADAPTERS).join(', ')}`);
+    process.exit(2);
+  }
+  let payload = {};
+  if (payloadArg && !payloadArg.startsWith('--')) { try { payload = JSON.parse(payloadArg); } catch { console.error('payload must be JSON'); process.exit(2); } }
+  call(id, op, payload, { mode: live ? 'live' : 'stub' })
+    .then((r) => { console.log(JSON.stringify(r, null, 2)); process.exit(r.ok ? 0 : 1); })
+    .catch((e) => { console.error(e.message); process.exit(1); });
 }

--- a/scripts/lib/connectors/fhir.mjs
+++ b/scripts/lib/connectors/fhir.mjs
@@ -1,0 +1,89 @@
+// scripts/lib/connectors/fhir.mjs — LIVE adapter for the ehr-fhir connector (Phase 4 Wave 1).
+//
+// This is a real, working FHIR R4 client — the first stub→live connector. It defaults to the
+// public HAPI FHIR test server (no auth, free), so the rcm autopilot can read a real clinical
+// note end to end in a sandbox. Point GREAT_CTO_FHIR_BASE + GREAT_CTO_FHIR_TOKEN at a production
+// FHIR server (Epic / Cerner / athenahealth) to go live — same code, real data.
+//
+// Capabilities: fetch-note, fetch-patient (matches the ehr-fhir catalog entry).
+// No external deps — uses global fetch (Node 18+).
+
+const BASE = (process.env.GREAT_CTO_FHIR_BASE || 'https://hapi.fhir.org/baseR4').replace(/\/$/, '');
+const TOKEN = process.env.GREAT_CTO_FHIR_TOKEN || '';
+const TIMEOUT_MS = Number(process.env.GREAT_CTO_FHIR_TIMEOUT || 15000);
+
+async function fhirGet(path) {
+  const ctrl = new AbortController();
+  const t = setTimeout(() => ctrl.abort(), TIMEOUT_MS);
+  try {
+    const r = await fetch(`${BASE}${path}`, {
+      headers: { Accept: 'application/fhir+json', ...(TOKEN ? { Authorization: `Bearer ${TOKEN}` } : {}) },
+      signal: ctrl.signal,
+    });
+    if (!r.ok) throw new Error(`FHIR ${r.status} ${path}: ${(await r.text()).slice(0, 160)}`);
+    return await r.json();
+  } finally {
+    clearTimeout(t);
+  }
+}
+
+const decodeB64 = (s) => { try { return Buffer.from(s, 'base64').toString('utf8'); } catch { return ''; } };
+const stripTags = (s) => String(s).replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
+
+/** Extract readable text from a DocumentReference's attachment (inline base64 or a Binary/url). */
+async function noteTextFrom(docRef) {
+  for (const c of docRef.content || []) {
+    const att = c.attachment || {};
+    if (att.data) {
+      const txt = decodeB64(att.data);
+      return /text\/html/i.test(att.contentType || '') ? stripTags(txt) : txt;
+    }
+    if (att.url) {
+      // url may be absolute or a relative Binary reference (e.g. "Binary/123")
+      const path = att.url.startsWith('http') ? att.url.replace(BASE, '') : `/${att.url.replace(/^\//, '')}`;
+      try {
+        const bin = await fhirGet(path);
+        if (bin.data) {
+          const txt = decodeB64(bin.data);
+          return /text\/html/i.test(bin.contentType || att.contentType || '') ? stripTags(txt) : txt;
+        }
+      } catch { /* fall through */ }
+    }
+  }
+  return '';
+}
+
+export const capabilities = ['fetch-note', 'fetch-patient'];
+
+/**
+ * @param {string} op  one of capabilities
+ * @param {object} payload  { patient?: id, document?: id }
+ */
+export async function call(op, payload = {}) {
+  if (op === 'fetch-patient') {
+    if (!payload.patient) return { ok: false, error: 'fetch-patient needs { patient }' };
+    const p = await fhirGet(`/Patient/${encodeURIComponent(payload.patient)}`);
+    const name = (p.name && p.name[0]) ? [...(p.name[0].given || []), p.name[0].family].filter(Boolean).join(' ') : '(unnamed)';
+    return { ok: true, mode: 'live', source: BASE, data: { id: p.id, name, gender: p.gender, birthDate: p.birthDate } };
+  }
+
+  if (op === 'fetch-note') {
+    let bundle;
+    if (payload.document) {
+      const d = await fhirGet(`/DocumentReference/${encodeURIComponent(payload.document)}`);
+      bundle = { entry: [{ resource: d }] };
+    } else {
+      const q = payload.patient ? `?patient=${encodeURIComponent(payload.patient)}&_count=5` : '?_count=10&_sort=-_lastUpdated';
+      bundle = await fhirGet(`/DocumentReference${q}`);
+    }
+    for (const e of bundle.entry || []) {
+      const note = await noteTextFrom(e.resource || {});
+      if (note && note.length > 20) {
+        return { ok: true, mode: 'live', source: BASE, data: { documentId: e.resource.id, patient: e.resource.subject?.reference, note } };
+      }
+    }
+    return { ok: false, mode: 'live', source: BASE, error: 'no readable clinical note found in the FHIR server (try { patient } or { document })' };
+  }
+
+  return { ok: false, error: `ehr-fhir live adapter has no op '${op}'` };
+}

--- a/scripts/lib/flow-runner.mjs
+++ b/scripts/lib/flow-runner.mjs
@@ -1,0 +1,100 @@
+// scripts/lib/flow-runner.mjs — execute a vertical autopilot flow (Phase 4).
+//
+// This is the "doing" layer: it walks a flow's steps in order and actually runs each one.
+//   - an AGENT step (🤖 intake / process / deliver / monitor) invokes its connectors and records
+//     the result — in stub mode it returns deterministic mock data; in live mode it hits the real
+//     adapter (e.g. the FHIR connector reads a real clinical note).
+//   - a HUMAN step (🧑‍⚖️ a gate) PAUSES the run — the autopilot does the volume up to the judgment
+//     call, then stops and hands off to the named human. This is the assistant↔autopilot boundary,
+//     enforced at runtime, not just on the page.
+//
+// Returns a run trace (what ran, what each tool returned, where it paused). Stub mode is
+// deterministic + network-free, so the whole flow is unit-testable. Live mode proves the same
+// path against real systems one connector at a time.
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { call, getConnector } from './connectors.mjs';
+
+const FLOWS_DIR = join(dirname(fileURLToPath(import.meta.url)), '..', '..', 'flows');
+
+/** Load a flow by vertical slug from flows/<vertical>.flow.json. */
+export function loadFlow(vertical) {
+  return JSON.parse(readFileSync(join(FLOWS_DIR, `${vertical}.flow.json`), 'utf8'));
+}
+
+/** The op a runner invokes on a connector — its first declared capability (demo/representative). */
+function defaultOp(connectorId) {
+  const spec = getConnector(connectorId);
+  return spec && spec.capabilities[0];
+}
+
+/**
+ * Run a flow.
+ * @param {object} flow  a flow object (from loadFlow)
+ * @param {{ mode?: 'stub'|'live', payload?: object, stopAtGate?: boolean }} opts
+ *   - mode: connector execution mode (default 'stub').
+ *   - stopAtGate: if true (default), the run PAUSES at the first human checkpoint and returns;
+ *     if false, gate steps are recorded as 'awaiting-human' but the run continues past them
+ *     (useful to dry-run the whole flow).
+ * @returns {Promise<{vertical, mode, status, pausedAt, steps:[…]}>}
+ */
+export async function runFlow(flow, { mode = 'stub', payload = {}, stopAtGate = true } = {}) {
+  const trace = { vertical: flow.vertical, mode, status: 'completed', pausedAt: null, steps: [] };
+
+  for (let i = 0; i < (flow.steps || []).length; i++) {
+    const s = flow.steps[i];
+
+    if (s.gate) {
+      trace.steps.push({ i, does: s.does, human: s.human, gate: s.gate, status: 'awaiting-human' });
+      if (stopAtGate) { trace.status = 'paused-at-gate'; trace.pausedAt = s.gate; break; }
+      continue;
+    }
+
+    const toolCalls = [];
+    for (const t of s.tools || []) {
+      const op = defaultOp(t);
+      if (!op) { toolCalls.push({ connector: t, op: null, ok: false, error: 'unknown connector' }); continue; }
+      const r = await call(t, op, payload, { mode });
+      toolCalls.push({ connector: t, op, ok: !!r.ok, mode: r.mode, error: r.error });
+    }
+    trace.steps.push({ i, does: s.does, agent: s.agent, status: 'done', toolCalls });
+  }
+
+  return trace;
+}
+
+/** Compact summary of a run trace. */
+export function summarizeRun(trace) {
+  const done = trace.steps.filter((s) => s.status === 'done').length;
+  const calls = trace.steps.flatMap((s) => s.toolCalls || []);
+  const okCalls = calls.filter((c) => c.ok).length;
+  return {
+    vertical: trace.vertical, mode: trace.mode, status: trace.status,
+    stepsRun: done, toolCalls: calls.length, toolCallsOk: okCalls, pausedAt: trace.pausedAt,
+  };
+}
+
+/** Human-readable run report. */
+export function formatRun(trace) {
+  const out = [`=== Run: ${trace.vertical} autopilot (${trace.mode}) ===`];
+  for (const s of trace.steps) {
+    if (s.gate) { out.push(`  🧑‍⚖️ ${s.i + 1}. ${s.does}  → PAUSE · ${s.human} (${s.gate})`); continue; }
+    const tools = (s.toolCalls || []).map((c) => `${c.connector}:${c.op}${c.ok ? '✓' : '✗'}`).join(' ');
+    out.push(`  🤖 ${s.i + 1}. ${s.does}  [${s.agent}]${tools ? ' · ' + tools : ''}`);
+  }
+  out.push(`\n  status: ${trace.status}${trace.pausedAt ? ` (awaiting human at ${trace.pausedAt})` : ''}`);
+  return out.join('\n');
+}
+
+// ── CLI ──────────────────────────────────────────────────────────────────────
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const vertical = process.argv[2];
+  const live = process.argv.includes('--live');
+  const full = process.argv.includes('--full'); // don't stop at the gate
+  if (!vertical) { console.error('usage: flow-runner.mjs <vertical> [--live] [--full]'); process.exit(2); }
+  runFlow(loadFlow(vertical), { mode: live ? 'live' : 'stub', stopAtGate: !full })
+    .then((t) => { console.log(formatRun(t)); process.exit(0); })
+    .catch((e) => { console.error(e.message); process.exit(1); });
+}

--- a/tests/lib/flow-runner.test.mjs
+++ b/tests/lib/flow-runner.test.mjs
@@ -1,0 +1,113 @@
+// tests/lib/flow-runner.test.mjs — connector runtime + flow execution (Phase 4)
+//
+// Run: node --test tests/lib/flow-runner.test.mjs
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { call, hasLiveAdapter, stubCall } from '../../scripts/lib/connectors.mjs';
+import { loadFlow, runFlow, summarizeRun, formatRun } from '../../scripts/lib/flow-runner.mjs';
+
+// ── connector runtime (call dispatcher) ───────────────────────────────────────
+
+test('call: stub mode returns deterministic mock', async () => {
+  const r = await call('ehr-fhir', 'fetch-note', { id: 1 });
+  assert.equal(r.ok, true);
+  assert.equal(r.mode, 'stub');
+  assert.equal(r.data._stub, true);
+});
+
+test('call: stub is deterministic (same input → same output)', async () => {
+  const a = await call('code-sets', 'lookup-code', { q: 'x' });
+  const b = await call('code-sets', 'lookup-code', { q: 'x' });
+  assert.deepEqual(a.data, b.data);
+});
+
+test('hasLiveAdapter: ehr-fhir has one, code-sets does not', () => {
+  assert.equal(hasLiveAdapter('ehr-fhir'), true);
+  assert.equal(hasLiveAdapter('code-sets'), false);
+});
+
+test('call: live mode on a connector WITHOUT a live adapter falls back to stub', async () => {
+  const r = await call('code-sets', 'lookup-code', {}, { mode: 'live' });
+  assert.equal(r.mode, 'stub');
+  assert.match(r.note, /no live adapter/);
+});
+
+test('call: unknown op fails cleanly in stub', async () => {
+  const r = await call('ehr-fhir', 'no-such-op');
+  assert.equal(r.ok, false);
+});
+
+test('stubCall mode is always stub', () => {
+  assert.equal(stubCall('rmm', 'stage-change').mode, 'stub');
+});
+
+// ── flow execution (stub mode — deterministic, no network) ──────────────────────
+
+test('runFlow: rcm runs autonomous steps and PAUSES at the human gate', async () => {
+  const trace = await runFlow(loadFlow('rcm'), { mode: 'stub' });
+  assert.equal(trace.vertical, 'rcm');
+  assert.equal(trace.status, 'paused-at-gate');
+  assert.equal(trace.pausedAt, 'gate:coding-signoff');
+  // steps before the gate ran; the gate is the last recorded step
+  const last = trace.steps[trace.steps.length - 1];
+  assert.equal(last.gate, 'gate:coding-signoff');
+  assert.equal(last.status, 'awaiting-human');
+  // every prior step is a completed agent step with tool calls
+  for (const s of trace.steps.slice(0, -1)) {
+    assert.equal(s.status, 'done');
+    assert.ok(s.agent);
+  }
+});
+
+test('runFlow: tool calls succeed in stub mode', async () => {
+  const trace = await runFlow(loadFlow('rcm'), { mode: 'stub' });
+  const sum = summarizeRun(trace);
+  assert.ok(sum.toolCalls > 0);
+  assert.equal(sum.toolCallsOk, sum.toolCalls); // all stub calls ok
+});
+
+test('runFlow: stopAtGate=false runs the whole flow, recording gates as awaiting-human', async () => {
+  const trace = await runFlow(loadFlow('rcm'), { mode: 'stub', stopAtGate: false });
+  assert.equal(trace.status, 'completed');
+  assert.equal(trace.steps.length, loadFlow('rcm').steps.length);
+  assert.ok(trace.steps.some((s) => s.status === 'awaiting-human'));
+});
+
+test('runFlow: every shipped vertical flow runs in stub mode and pauses at its gate', async () => {
+  for (const v of ['rcm', 'legaltech', 'procurement', 'accounting', 'msp', 'tax']) {
+    const trace = await runFlow(loadFlow(v), { mode: 'stub' });
+    assert.equal(trace.status, 'paused-at-gate', `${v} should pause at a human gate`);
+    assert.ok(trace.pausedAt, `${v} should name the gate it paused at`);
+  }
+});
+
+test('runFlow: a gate-only flow pauses immediately', async () => {
+  const flow = { vertical: 'demo', steps: [{ does: 'sign', human: 'a person', gate: 'gate:demo' }] };
+  const trace = await runFlow(flow, { mode: 'stub' });
+  assert.equal(trace.status, 'paused-at-gate');
+  assert.equal(trace.steps.length, 1);
+});
+
+test('runFlow: a no-gate flow completes', async () => {
+  const flow = { vertical: 'demo', steps: [{ does: 'do', agent: 'x', tools: ['ocr'] }] };
+  const trace = await runFlow(flow, { mode: 'stub' });
+  assert.equal(trace.status, 'completed');
+});
+
+// ── reporting ──────────────────────────────────────────────────────────────────
+
+test('summarizeRun: counts steps + tool calls', async () => {
+  const sum = summarizeRun(await runFlow(loadFlow('rcm'), { mode: 'stub' }));
+  assert.equal(sum.vertical, 'rcm');
+  assert.equal(sum.status, 'paused-at-gate');
+  assert.ok(sum.stepsRun >= 1);
+});
+
+test('formatRun: shows the pause + the human role', async () => {
+  const s = formatRun(await runFlow(loadFlow('rcm'), { mode: 'stub' }));
+  assert.match(s, /PAUSE/);
+  assert.match(s, /coding-signoff/);
+  assert.match(s, /🤖/);
+});

--- a/tests/lib/flow.test.mjs
+++ b/tests/lib/flow.test.mjs
@@ -101,11 +101,15 @@ test('renderFlow: resolves connector ids to labels', () => {
 
 // ── connectors ──────────────────────────────────────────────────────────────────
 
-test('connectors: every catalog entry is a stub for now', () => {
+test('connectors: every catalog entry is stub or live-ready with capabilities', () => {
   for (const [id, spec] of Object.entries(CONNECTORS)) {
-    assert.equal(spec.status, 'stub', `${id} should be stub`);
+    assert.ok(['stub', 'live-ready'].includes(spec.status), `${id} status should be stub|live-ready`);
     assert.ok(spec.capabilities.length > 0, `${id} needs capabilities`);
   }
+});
+
+test('connectors: ehr-fhir is the first live-ready connector', () => {
+  assert.equal(CONNECTORS['ehr-fhir'].status, 'live-ready');
 });
 
 test('flowConnectors: dedupes across steps', () => {


### PR DESCRIPTION
## Summary

**Phase 4 Wave 1** (epic `great_cto-zgy`): the autopilots stop *describing* a flow and start **executing** it — with the **first live connector** (FHIR/EHR) reading real data.

## What

| What | Detail |
|---|---|
| `scripts/lib/connectors/fhir.mjs` | **real FHIR R4 client** — defaults to the public HAPI sandbox (no auth), `GREAT_CTO_FHIR_BASE`/`TOKEN` for Epic/Cerner/athenahealth. Caps: `fetch-note`, `fetch-patient` |
| `scripts/lib/connectors.mjs` | `call()` dispatcher (**stub \| live**), lazy live-adapter registry, `hasLiveAdapter`, CLI. `ehr-fhir` → `live-ready` |
| `scripts/lib/flow-runner.mjs` | the **doing layer**: `runFlow` walks the steps — 🤖 agent steps invoke their connectors, a 🧑‍⚖️ human step **pauses** the run and hands off to the named human (the assistant↔autopilot boundary, enforced at runtime). CLI: `flow-runner.mjs <vertical> [--live] [--full]` |

## Proven end-to-end

```
$ node scripts/lib/flow-runner.mjs rcm --live
=== Run: rcm autopilot (live) ===
  🤖 1. Pull the clinical note from the EHR  [intake] · ehr-fhir:fetch-note✓ ...   ← REAL note from hapi.fhir.org
  🤖 2. Assign ICD-10 / CPT codes ... [coder] · code-sets:lookup-code✓
  🤖 3. NCCI / MUE + necessity + upcoding guard [compliance] · ...✓
  🧑‍⚖️ 4. A certified coder signs off ... → PAUSE · CPC / CCS certified coder (gate:coding-signoff)
  status: paused-at-gate
```

Step 1 genuinely reads a real clinical note via FHIR; the rest stub-fallback; the human checkpoint halts the run. **The stub→live path is proven through the runner.**

## Test plan

- [x] 204 lib tests (+14 new): connector stub/live dispatch, `hasLiveAdapter`, live-fallback, and **all 6 flows run in stub mode and pause at their human gate**
- [x] structural green

## Beads

Closes `great_cto-60c` (Wave 1). Epic `great_cto-zgy`. Next waves: real connectors for the other steps (clearinghouse 837/835, code-sets) and per-vertical doing-agent prompts; then the other verticals (legaltech + DocuSign, …).