### PR TITLE
feat(phase4): live code-sets connector (ICD-10-CM / HCPCS via NLM) — Wave 2

### DIFF
--- a/scripts/lib/connectors.mjs
+++ b/scripts/lib/connectors.mjs
@@ -14,7 +14,7 @@ export const CONNECTORS = Object.freeze({
   // ── rcm ──
   'ehr-fhir':        { label: 'EHR (FHIR)',            verticals: ['rcm'],         capabilities: ['fetch-note', 'fetch-patient'], realProviders: ['Epic', 'Cerner', 'athenahealth'], status: 'live-ready' },
   'ocr':             { label: 'Document OCR',          verticals: ['rcm', 'tax', 'accounting'], capabilities: ['extract-text'], realProviders: ['AWS Textract', 'Google DocAI'], status: 'stub' },
-  'code-sets':       { label: 'ICD-10 / CPT / HCPCS',  verticals: ['rcm'],         capabilities: ['lookup-code', 'validate-code'], realProviders: ['CMS', 'AMA CPT'], status: 'stub' },
+  'code-sets':       { label: 'ICD-10 / CPT / HCPCS',  verticals: ['rcm'],         capabilities: ['lookup-code', 'validate-code'], realProviders: ['NLM Clinical Tables', 'CMS', 'AMA CPT'], status: 'live-ready' },
   'ncci-mue':        { label: 'NCCI / MUE edits',      verticals: ['rcm'],         capabilities: ['check-ptp', 'check-mue'], realProviders: ['CMS quarterly tables'], status: 'stub' },
   'clearinghouse':   { label: 'Claims clearinghouse',  verticals: ['rcm'],         capabilities: ['submit-837', 'fetch-835'], realProviders: ['Change Healthcare', 'Availity'], status: 'stub' },
   'payer-rules':     { label: 'Payer rules / LCD-NCD', verticals: ['rcm'],         capabilities: ['check-necessity'], realProviders: ['CMS coverage DB'], status: 'stub' },
@@ -97,6 +97,7 @@ export function stubCall(connectorId, op, payload = {}) {
 // side-effect-free + network-free; the adapter module loads only when a live call is made.
 const LIVE_ADAPTERS = {
   'ehr-fhir': () => import('./connectors/fhir.mjs'),
+  'code-sets': () => import('./connectors/codesets.mjs'),
 };
 
 /** Does this connector have a real (live) adapter wired? */

--- a/scripts/lib/connectors/codesets.mjs
+++ b/scripts/lib/connectors/codesets.mjs
@@ -1,0 +1,68 @@
+// scripts/lib/connectors/codesets.mjs — LIVE adapter for the code-sets connector (Phase 4 Wave 2).
+//
+// Real medical code lookup against the NLM Clinical Table Search Service — a free, no-auth public
+// API over the official ICD-10-CM and HCPCS code sets. This makes the rcm autopilot's "assign
+// codes" step genuinely live: it looks up and validates real diagnosis/procedure codes, not mocks.
+//
+// CPT is proprietary (AMA) and has no free API — `lookup-code`/`validate-code` default to ICD-10-CM
+// and also support HCPCS; pass { system:'cpt' } and the adapter returns a clear "needs AMA license"
+// note rather than a wrong answer. Point GREAT_CTO_CODESETS_BASE at a licensed CPT service to extend.
+//
+// No external deps — global fetch (Node 18+).
+
+const BASE = (process.env.GREAT_CTO_CODESETS_BASE || 'https://clinicaltables.nlm.nih.gov/api').replace(/\/$/, '');
+const TIMEOUT_MS = Number(process.env.GREAT_CTO_CODESETS_TIMEOUT || 12000);
+
+const SYSTEMS = { icd10cm: 'icd10cm/v3', 'icd10-cm': 'icd10cm/v3', icd10: 'icd10cm/v3', hcpcs: 'hcpcs/v3' };
+
+async function nlm(systemPath, params) {
+  const ctrl = new AbortController();
+  const t = setTimeout(() => ctrl.abort(), TIMEOUT_MS);
+  try {
+    const qs = new URLSearchParams({ sf: 'code,name', df: 'code,name', ...params }).toString();
+    const r = await fetch(`${BASE}/${systemPath}/search?${qs}`, { signal: ctrl.signal });
+    if (!r.ok) throw new Error(`NLM ${r.status}: ${(await r.text()).slice(0, 120)}`);
+    return await r.json(); // [count, [codes], extra, [[code,name],...]]
+  } finally {
+    clearTimeout(t);
+  }
+}
+
+function resolveSystem(system) {
+  const key = String(system || 'icd10cm').toLowerCase();
+  return SYSTEMS[key] || null;
+}
+
+export const capabilities = ['lookup-code', 'validate-code'];
+
+/**
+ * @param {string} op  'lookup-code' | 'validate-code'
+ * @param {object} payload  { q?, code?, system? }   system: icd10cm (default) | hcpcs | cpt
+ */
+export async function call(op, payload = {}) {
+  const system = String(payload.system || 'icd10cm').toLowerCase();
+  if (system === 'cpt') {
+    return { ok: false, mode: 'live', system: 'cpt',
+      error: 'CPT is AMA-licensed — no free API. Set GREAT_CTO_CODESETS_BASE to a licensed CPT service.' };
+  }
+  const systemPath = resolveSystem(system);
+  if (!systemPath) return { ok: false, error: `unknown code system: ${system}` };
+
+  if (op === 'lookup-code') {
+    const term = payload.q || payload.term;
+    if (!term) return { ok: false, error: 'lookup-code needs { q }' };
+    const [count, , , pairs] = await nlm(systemPath, { terms: term, maxList: payload.limit || 7 });
+    return { ok: true, mode: 'live', source: BASE, system,
+      data: { query: term, total: count, matches: (pairs || []).map(([code, name]) => ({ code, name })) } };
+  }
+
+  if (op === 'validate-code') {
+    if (!payload.code) return { ok: false, error: 'validate-code needs { code }' };
+    const [, codes, , pairs] = await nlm(systemPath, { terms: payload.code, maxList: 5 });
+    const hit = (pairs || []).find(([c]) => c.toUpperCase() === String(payload.code).toUpperCase());
+    return { ok: true, mode: 'live', source: BASE, system,
+      data: { code: payload.code, valid: !!hit, name: hit ? hit[1] : null, candidates: (codes || []).slice(0, 5) } };
+  }
+
+  return { ok: false, error: `code-sets live adapter has no op '${op}'` };
+}

--- a/scripts/lib/flow-runner.mjs
+++ b/scripts/lib/flow-runner.mjs
@@ -30,6 +30,14 @@ function defaultOp(connectorId) {
   return spec && spec.capabilities[0];
 }
 
+// Representative demo inputs per connector:op, so a live run can actually exercise an adapter that
+// requires inputs (in production the orchestrator threads these from prior steps). The caller's
+// `payload` always overrides these.
+const DEMO_INPUTS = {
+  'code-sets:lookup-code': { q: 'type 2 diabetes' },
+  'code-sets:validate-code': { code: 'E11.9' },
+};
+
 /**
  * Run a flow.
  * @param {object} flow  a flow object (from loadFlow)
@@ -56,7 +64,7 @@ export async function runFlow(flow, { mode = 'stub', payload = {}, stopAtGate = 
     for (const t of s.tools || []) {
       const op = defaultOp(t);
       if (!op) { toolCalls.push({ connector: t, op: null, ok: false, error: 'unknown connector' }); continue; }
-      const r = await call(t, op, payload, { mode });
+      const r = await call(t, op, { ...DEMO_INPUTS[`${t}:${op}`], ...payload }, { mode });
       toolCalls.push({ connector: t, op, ok: !!r.ok, mode: r.mode, error: r.error });
     }
     trace.steps.push({ i, does: s.does, agent: s.agent, status: 'done', toolCalls });

--- a/tests/lib/flow-runner.test.mjs
+++ b/tests/lib/flow-runner.test.mjs
@@ -23,15 +23,24 @@ test('call: stub is deterministic (same input → same output)', async () => {
   assert.deepEqual(a.data, b.data);
 });
 
-test('hasLiveAdapter: ehr-fhir has one, code-sets does not', () => {
+test('hasLiveAdapter: ehr-fhir and code-sets have one, ncci-mue does not', () => {
   assert.equal(hasLiveAdapter('ehr-fhir'), true);
-  assert.equal(hasLiveAdapter('code-sets'), false);
+  assert.equal(hasLiveAdapter('code-sets'), true);
+  assert.equal(hasLiveAdapter('ncci-mue'), false);
 });
 
 test('call: live mode on a connector WITHOUT a live adapter falls back to stub', async () => {
-  const r = await call('code-sets', 'lookup-code', {}, { mode: 'live' });
+  const r = await call('ncci-mue', 'check-ptp', {}, { mode: 'live' });
   assert.equal(r.mode, 'stub');
   assert.match(r.note, /no live adapter/);
+});
+
+test('code-sets live adapter: capabilities + cpt is gracefully unsupported', async () => {
+  const m = await import('../../scripts/lib/connectors/codesets.mjs');
+  assert.deepEqual(m.capabilities, ['lookup-code', 'validate-code']);
+  const cpt = await m.call('lookup-code', { q: 'x', system: 'cpt' });
+  assert.equal(cpt.ok, false);
+  assert.match(cpt.error, /AMA-licensed/);
 });
 
 test('call: unknown op fails cleanly in stub', async () => {


### PR DESCRIPTION
## Summary

**Phase 4 Wave 2** — the **second live connector**. The rcm autopilot's "assign codes" step is now genuinely live: it looks up and validates **real ICD-10-CM / HCPCS codes** against the **NLM Clinical Table Search Service** (free, no auth), the same way the FHIR connector reads real notes.

## What

| What | Detail |
|---|---|
| `scripts/lib/connectors/codesets.mjs` | real ICD-10-CM + HCPCS client (NLM). `lookup-code` → real diagnosis codes; `validate-code` → verifies a code; **CPT** (AMA-licensed, no free API) returns a clear "needs a licensed service" note, never a wrong answer |
| `connectors.mjs` | `code-sets` → `LIVE_ADAPTERS` + `status: live-ready` |
| `flow-runner.mjs` | `DEMO_INPUTS` thread representative inputs so a live run exercises input-requiring adapters (the orchestrator threads these from prior steps in production) |

## Proven live (free public API, no keys)

```
$ connectors.mjs call code-sets lookup-code '{"q":"type 2 diabetes"}' --live
  E11.65  Type 2 diabetes mellitus with hyperglycemia
  E11.9   Type 2 diabetes mellitus without complications
$ connectors.mjs call code-sets validate-code '{"code":"E11.9"}' --live
  valid: true · Type 2 diabetes mellitus without complications

$ flow-runner.mjs rcm --live
  🤖 1. Pull the clinical note from the EHR  · ehr-fhir:fetch-note✓ ...   ← real note (HAPI FHIR)
  🤖 2. Assign ICD-10 / CPT codes ...        · code-sets:lookup-code✓     ← real ICD-10 (NLM)
  🧑‍⚖️ 4. A certified coder signs off ...      → PAUSE (gate:coding-signoff)
```

**rcm now runs two live connectors end-to-end**, both on free public APIs, then halts at the human checkpoint.

## Test plan
- [x] 205 lib tests (+ updated live-ready set, code-sets capabilities + CPT-graceful, runner demo green)
- [x] structural green

## Beads
Closes `great_cto-7jp`. Next: clearinghouse (837/835) + NCCI/MUE, or the legaltech vertical (DocuSign).