### PR TITLE
Reposition to AI business autopilots for regulated companies + crypto / fintech / support autopilots

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ steps**, a built-in compliance reviewer, and **live connectors** that run each f
 | 🛡️ **[KYC/AML](https://greatcto.systems/autopilots/aml.html)** | Onboards, screens & monitors customers; a BSA Officer signs every SAR | $61B | Diligent AI · Alloy · Sardine |
 | 🪙 **[Crypto compliance](https://greatcto.systems/autopilots/crypto.html)** | Onboards VASPs, screens wallets on-chain & runs Travel Rule; an MLRO signs every SAR & address block | $1.5B | Chainalysis · TRM Labs · Elliptic |
 | 💳 **[Card-dispute & chargeback](https://greatcto.systems/autopilots/disputes.html)** | Intakes disputes, builds the representment & decides provisional credit (Reg E/Z); an analyst signs before money moves | $1B | Chargeflow · Quavo · Galileo |
+| 🎧 **[Customer-support](https://greatcto.systems/autopilots/support.html)** | Resolves tier-1 tickets & drafts the rest; a lead signs refunds, account changes & regulated complaints | $10B+ | Sierra · Decagon · Gorgias |
 | 🔐 **[Managed-SOC](https://greatcto.systems/autopilots/soc.html)** | Triages & investigates every alert 24/7; a SOC analyst signs any containment | $4–6B | 7AI · Dropzone · Prophet Security |
 | ☂️ **[Claims & underwriting](https://greatcto.systems/autopilots/insurance.html)** | Adjudicates claims & prices risk; a licensed adjuster/underwriter signs the call | $36–38B | Shift · Akur8 · Avallon |
 | 🏠 **[Mortgage-underwriting](https://greatcto.systems/autopilots/mortgage.html)** | Processes & underwrites to clear-to-close; a DE underwriter signs | $40B+ | Tidalwave · Zest AI · Blend |
@@ -69,7 +70,7 @@ steps**, a built-in compliance reviewer, and **live connectors** that run each f
 
 **Each autopilot keeps a human on the judgment calls** — a certified coder, a licensed attorney, a
 controller, a credentialed preparer. The autopilot does the volume; the human owns the call that
-carries liability. **17 live connectors run on real data across the 27 verticals** — FHIR, ICD-10
+carries liability. **17 live connectors run on real data across the 28 verticals** — FHIR, ICD-10
 (NLM), NCCI/MUE, X12 837P, DocuSign, Plaid, OFAC, staged-rollout, a US federal tax engine, plus
 medical-necessity criteria, claims fraud-scoring, mortgage AUS (DU/LPA), OIG/SAM exclusion screening,
 FMCSA carrier-vetting, Reg-F/TCPA outreach guardrails, IOC threat-intel, and FinCEN SAR generation.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <img src="docs/screenshots/logo.svg" alt="great_cto" width="280" />
 
-**AI autopilots for business — get the work done, not just the software.**
+**AI business autopilots for regulated and operationally complex companies — fintech, crypto, compliance, back office, support, security and engineering. Get the work done, not just the software.**
 
 [![npm](https://img.shields.io/npm/v/great-cto?label=npx%20great-cto&color=cb3837)](https://www.npmjs.com/package/great-cto)
 [![npm downloads](https://img.shields.io/npm/dm/great-cto?color=cb3837&label=downloads)](https://www.npmjs.com/package/great-cto)
@@ -45,6 +45,8 @@ steps**, a built-in compliance reviewer, and **live connectors** that run each f
 | 🛒 **[Source-to-pay](https://greatcto.systems/autopilots/procurement.html)** | Onboards suppliers, matches invoices, releases payments — screened for sanctions & fraud | $200B+ | Tacto · Zip · AskLio |
 | ✅ **[Prior-authorization](https://greatcto.systems/autopilots/prior-auth.html)** | Auth request + chart → approval or a clean determination; a medical director signs every denial | $35–56B | Cohere Health · Anterior · Develop Health |
 | 🛡️ **[KYC/AML](https://greatcto.systems/autopilots/aml.html)** | Onboards, screens & monitors customers; a BSA Officer signs every SAR | $61B | Diligent AI · Alloy · Sardine |
+| 🪙 **[Crypto compliance](https://greatcto.systems/autopilots/crypto.html)** | Onboards VASPs, screens wallets on-chain & runs Travel Rule; an MLRO signs every SAR & address block | $1.5B | Chainalysis · TRM Labs · Elliptic |
+| 💳 **[Card-dispute & chargeback](https://greatcto.systems/autopilots/disputes.html)** | Intakes disputes, builds the representment & decides provisional credit (Reg E/Z); an analyst signs before money moves | $1B | Chargeflow · Quavo · Galileo |
 | 🔐 **[Managed-SOC](https://greatcto.systems/autopilots/soc.html)** | Triages & investigates every alert 24/7; a SOC analyst signs any containment | $4–6B | 7AI · Dropzone · Prophet Security |
 | ☂️ **[Claims & underwriting](https://greatcto.systems/autopilots/insurance.html)** | Adjudicates claims & prices risk; a licensed adjuster/underwriter signs the call | $36–38B | Shift · Akur8 · Avallon |
 | 🏠 **[Mortgage-underwriting](https://greatcto.systems/autopilots/mortgage.html)** | Processes & underwrites to clear-to-close; a DE underwriter signs | $40B+ | Tidalwave · Zest AI · Blend |
@@ -67,7 +69,7 @@ steps**, a built-in compliance reviewer, and **live connectors** that run each f
 
 **Each autopilot keeps a human on the judgment calls** — a certified coder, a licensed attorney, a
 controller, a credentialed preparer. The autopilot does the volume; the human owns the call that
-carries liability. **17 live connectors run on real data across the 25 verticals** — FHIR, ICD-10
+carries liability. **17 live connectors run on real data across the 27 verticals** — FHIR, ICD-10
 (NLM), NCCI/MUE, X12 837P, DocuSign, Plaid, OFAC, staged-rollout, a US federal tax engine, plus
 medical-necessity criteria, claims fraud-scoring, mortgage AUS (DU/LPA), OIG/SAM exclusion screening,
 FMCSA carrier-vetting, Reg-F/TCPA outreach guardrails, IOC threat-intel, and FinCEN SAR generation.

--- a/docs/positioning/vocabulary.md
+++ b/docs/positioning/vocabulary.md
@@ -1,8 +1,25 @@
 # Positioning vocabulary — business language, not engineering
 
 > **Single source of truth for all outward copy** (landing, README, CLI onboarding, decks).
-> great_cto is positioned as **"AI autopilots for business."** When we talk about a vertical we
-> talk about its **flow** and **automation**, not pipelines and packs.
+> great_cto is positioned as **"AI business autopilots for regulated and operationally complex
+> companies."** When we talk about a vertical we talk about its **flow** and **automation**, not
+> pipelines and packs.
+
+## The positioning line (use verbatim where space allows)
+
+> **GreatCTO builds AI business autopilots for regulated and operationally complex companies —
+> fintech, crypto, compliance, back office, support, security and engineering.**
+
+Canonical forms (pick by space):
+- **Full**: "GreatCTO builds AI business autopilots for regulated and operationally complex companies — fintech, crypto, compliance, back office, support, security and engineering."
+- **Short tagline** (titles, OG): "AI business autopilots for regulated companies"
+- **Micro** (eyebrow, badge): "AI business autopilots"
+
+### Who we're for
+Companies where the work is **regulated or operationally complex** — every flow keeps a **named,
+qualified human on the judgment calls** (BSA/AML officer, MLRO, controller, SOC analyst, CPA). That
+human checkpoint is the product, not a footnote. The autopilots are **grouped by domain**
+(see `flows/_domains.json`); ICP domains lead, other industries follow.
 
 ## The reframe
 

--- a/flows/_domains.json
+++ b/flows/_domains.json
@@ -9,7 +9,7 @@
     "back-office": { "label": "Back office",  "blurb": "Bookkeeping, procurement, billing and managed IT — high-volume operations run straight-through.", "icp": true },
     "security":    { "label": "Security",     "blurb": "SecOps and IT-controls audit — triage and testing at machine speed, a human on containment and the opinion.", "icp": true },
     "engineering": { "label": "Engineering",  "blurb": "The original GreatCTO SDLC pipeline — architect → dev → QA → security → ship, with human gates.", "icp": true },
-    "support":     { "label": "Support",      "blurb": "Operational support workflows — direction on the roadmap.", "icp": true },
+    "support":     { "label": "Support",      "blurb": "Customer support & complaints — tier-1 resolved straight-through; a lead signs refunds, account changes and regulated complaints.", "icp": true },
     "healthcare":  { "label": "Healthcare",   "blurb": "Prior-auth, pharmacovigilance and clinical-trial ops — a clinician signs the medical judgment.", "icp": false },
     "legal":       { "label": "Legal",        "blurb": "Contracts, estate, patent and immigration — a licensed attorney signs anything that is advice (UPL).", "icp": false },
     "real-estate": { "label": "Real estate",  "blurb": "Title, escrow and appraisal — a licensed officer signs the insurable title and the report of record.", "icp": false },

--- a/flows/_domains.json
+++ b/flows/_domains.json
@@ -1,0 +1,18 @@
+{
+  "_comment": "Domain registry for the autopilot showcase. ICP domains lead; out-of-ICP industries follow. Each flows/<v>.flow.json carries a matching \"domain\". Generators group + order by this file. Not a flow file (no .flow.json suffix) so flow scanners ignore it.",
+  "icpOrder": ["fintech", "crypto", "compliance", "back-office", "security", "engineering", "support"],
+  "outOfIcpOrder": ["healthcare", "legal", "real-estate", "logistics"],
+  "domains": {
+    "fintech":     { "label": "Fintech",      "blurb": "Lending, payments, payroll, claims and tax — regulated money movement with a human on the call that carries liability.", "icp": true },
+    "crypto":      { "label": "Crypto",       "blurb": "VASP onboarding, on-chain screening and Travel Rule — an MLRO signs every SAR and block.", "icp": true },
+    "compliance":  { "label": "Compliance",   "blurb": "KYC/AML, trade and credentialing — screening and filings with a named officer on every decision.", "icp": true },
+    "back-office": { "label": "Back office",  "blurb": "Bookkeeping, procurement, billing and managed IT — high-volume operations run straight-through.", "icp": true },
+    "security":    { "label": "Security",     "blurb": "SecOps and IT-controls audit — triage and testing at machine speed, a human on containment and the opinion.", "icp": true },
+    "engineering": { "label": "Engineering",  "blurb": "The original GreatCTO SDLC pipeline — architect → dev → QA → security → ship, with human gates.", "icp": true },
+    "support":     { "label": "Support",      "blurb": "Operational support workflows — direction on the roadmap.", "icp": true },
+    "healthcare":  { "label": "Healthcare",   "blurb": "Prior-auth, pharmacovigilance and clinical-trial ops — a clinician signs the medical judgment.", "icp": false },
+    "legal":       { "label": "Legal",        "blurb": "Contracts, estate, patent and immigration — a licensed attorney signs anything that is advice (UPL).", "icp": false },
+    "real-estate": { "label": "Real estate",  "blurb": "Title, escrow and appraisal — a licensed officer signs the insurable title and the report of record.", "icp": false },
+    "logistics":   { "label": "Logistics",    "blurb": "Freight brokerage — a licensed broker signs binding rates and claims.", "icp": false }
+  }
+}

--- a/flows/accounting.flow.json
+++ b/flows/accounting.flow.json
@@ -1,5 +1,6 @@
 {
   "vertical": "accounting",
+  "domain": "back-office",
   "autopilot": "Bookkeeping & close autopilot",
   "tagline": "Books entries, reconciles and closes the month — segregation of duties enforced, a controller signs the close.",
   "audience": "CFO / Controller",

--- a/flows/aml.flow.json
+++ b/flows/aml.flow.json
@@ -1,5 +1,6 @@
 {
   "vertical": "aml",
+  "domain": "compliance",
   "autopilot": "KYC/AML compliance autopilot",
   "tagline": "Onboards, screens and monitors customers — a BSA Officer signs every SAR and high-risk approval.",
   "audience": "BSA/AML Officer / Head of Compliance",

--- a/flows/appraisal.flow.json
+++ b/flows/appraisal.flow.json
@@ -1,5 +1,6 @@
 {
   "vertical": "appraisal",
+  "domain": "real-estate",
   "autopilot": "Real-estate appraisal autopilot",
   "tagline": "Intakes the order, pulls comps and cross-checks an AVM — a state-certified appraiser signs the report of record.",
   "audience": "Valuation / appraisal operations lead",

--- a/flows/audit.flow.json
+++ b/flows/audit.flow.json
@@ -1,5 +1,6 @@
 {
   "vertical": "audit",
+  "domain": "security",
   "autopilot": "SOX ITGC audit autopilot",
   "tagline": "Tests IT general controls and drafts workpapers — a licensed CPA signs the opinion.",
   "audience": "Audit partner / SOX lead",

--- a/flows/collections.flow.json
+++ b/flows/collections.flow.json
@@ -1,5 +1,6 @@
 {
   "vertical": "collections",
+  "domain": "fintech",
   "autopilot": "Debt-collection / AR autopilot",
   "tagline": "Runs compliant outreach and negotiates plans — a manager signs legal escalation and settlements.",
   "audience": "Head of collections / AR",

--- a/flows/credentialing.flow.json
+++ b/flows/credentialing.flow.json
@@ -1,5 +1,6 @@
 {
   "vertical": "credentialing",
+  "domain": "compliance",
   "autopilot": "Provider-credentialing autopilot",
   "tagline": "Verifies a provider against primary sources and enrolls them — the committee signs the privileging decision.",
   "audience": "Medical staff office / CVO lead",

--- a/flows/cro.flow.json
+++ b/flows/cro.flow.json
@@ -1,5 +1,6 @@
 {
   "vertical": "cro",
+  "domain": "healthcare",
   "autopilot": "Clinical-trial-ops autopilot",
   "tagline": "Screens patients and runs monitoring — the PI / medical monitor signs eligibility and safety calls.",
   "audience": "Sponsor / CRO operations lead",

--- a/flows/crypto.flow.json
+++ b/flows/crypto.flow.json
@@ -1,0 +1,84 @@
+{
+  "vertical": "crypto",
+  "domain": "crypto",
+  "autopilot": "Crypto compliance & Travel Rule autopilot",
+  "tagline": "Onboards, screens and monitors crypto customers and wallets — an MLRO signs every SAR, block and high-risk approval.",
+  "audience": "MLRO / Head of Compliance (VASP / exchange)",
+  "owner": "Designated MLRO (Money Laundering Reporting Officer)",
+  "marketSizeUsd": "1.5B",
+  "problem": "Crypto compliance is a fast-growing labor sink — VASPs must KYC customers, screen wallets on-chain, exchange Travel Rule data with counterparty VASPs, and triage on-chain alerts. A missed sanctioned address or unfiled SAR is personal liability for the MLRO and an enforcement risk for the exchange.",
+  "outcome": "Onboarding, wallet screening, Travel Rule exchange and on-chain monitoring run straight-through with a documented rationale; only genuine risk reaches the MLRO, who signs every SAR, address block and high-risk approval before anything is filed or funds are frozen.",
+  "qualityScore": 89,
+  "steps": [
+    {
+      "does": "Onboard the customer / counterparty VASP: verify identity and beneficial ownership",
+      "reversible": true,
+      "blastRadius": "low",
+      "agent": "intake",
+      "tools": [
+        "id-verify",
+        "kyb"
+      ]
+    },
+    {
+      "does": "Screen deposit/withdrawal wallets and counterparties on-chain (sanctions, mixers, illicit exposure)",
+      "reversible": true,
+      "blastRadius": "low",
+      "agent": "screen",
+      "tools": [
+        "chain-analytics",
+        "sanctions-screen"
+      ]
+    },
+    {
+      "does": "Exchange Travel Rule originator/beneficiary data (IVMS101) with the counterparty VASP",
+      "reversible": true,
+      "blastRadius": "low",
+      "agent": "travel-rule",
+      "tools": [
+        "travel-rule"
+      ]
+    },
+    {
+      "does": "Monitor on-chain + fiat flows, triage alerts, and draft the SAR narrative",
+      "reversible": true,
+      "blastRadius": "low",
+      "agent": "compliance",
+      "tools": [
+        "chain-analytics",
+        "txn-monitor"
+      ]
+    },
+    {
+      "does": "The MLRO signs the SAR filing, any address block, and high-risk onboarding",
+      "human": "Designated MLRO",
+      "gate": "gate:mlro-signoff"
+    },
+    {
+      "does": "File the SAR with FinCEN, apply the block, and record the onboarding decision",
+      "reversible": false,
+      "blastRadius": "high",
+      "agent": "file",
+      "tools": [
+        "sar-filing"
+      ]
+    },
+    {
+      "does": "Maintain continuous wallet monitoring and document dispositions for exam",
+      "reversible": true,
+      "blastRadius": "low",
+      "agent": "monitor",
+      "tools": [
+        "chain-analytics"
+      ]
+    }
+  ],
+  "reviewer": "crypto-mlro-reviewer",
+  "manifest": "docs/autopilot/autopilot.json",
+  "startups": [
+    "Chainalysis",
+    "TRM Labs",
+    "Elliptic",
+    "Notabene"
+  ]
+}

--- a/flows/customs.flow.json
+++ b/flows/customs.flow.json
@@ -1,5 +1,6 @@
 {
   "vertical": "customs",
+  "domain": "compliance",
   "autopilot": "Customs-clearance autopilot",
   "tagline": "Classifies, screens and clears imports — a licensed customs broker signs the entry of record.",
   "audience": "Trade-compliance / import lead",

--- a/flows/disputes.flow.json
+++ b/flows/disputes.flow.json
@@ -1,0 +1,84 @@
+{
+  "vertical": "disputes",
+  "domain": "fintech",
+  "autopilot": "Card-dispute & chargeback autopilot",
+  "tagline": "Intakes cardholder disputes, builds the representment, and decides provisional credit — a dispute analyst signs before money moves or a case is sent to the network.",
+  "audience": "Disputes / Chargeback Manager (Reg E / Reg Z officer)",
+  "owner": "Designated Reg E / disputes officer",
+  "marketSizeUsd": "1B",
+  "problem": "Card disputes are a regulated, deadline-driven labor sink — Reg E (debit) and Reg Z (credit) impose strict provisional-credit and investigation timelines, and every chargeback is evidence assembly across the processor and the card network. Miss a clock or mis-handle a claim and the issuer eats the loss and the regulatory exposure.",
+  "outcome": "Intake, evidence-gathering, Reg E/Z classification and representment assembly run straight-through within the clock; only the provisional-credit and representment decisions reach the analyst, who signs before any credit is issued or a case is filed with Visa/Mastercard.",
+  "qualityScore": 88,
+  "steps": [
+    {
+      "does": "Intake the cardholder dispute and verify the claimant against the account",
+      "reversible": true,
+      "blastRadius": "low",
+      "agent": "intake",
+      "tools": [
+        "card-processor",
+        "id-verify"
+      ]
+    },
+    {
+      "does": "Pull the transaction, prior history and fraud signals; gather merchant/processor evidence",
+      "reversible": true,
+      "blastRadius": "low",
+      "agent": "evidence",
+      "tools": [
+        "card-processor",
+        "fraud-score"
+      ]
+    },
+    {
+      "does": "Classify the dispute (Reg E vs Reg Z, fraud vs service) and compute the regulatory clock",
+      "reversible": true,
+      "blastRadius": "low",
+      "agent": "classify",
+      "tools": [
+        "dispute-network"
+      ]
+    },
+    {
+      "does": "Assemble the representment packet and the provisional-credit recommendation",
+      "reversible": true,
+      "blastRadius": "low",
+      "agent": "build",
+      "tools": [
+        "dispute-network"
+      ]
+    },
+    {
+      "does": "The disputes analyst signs the provisional-credit decision and the representment",
+      "human": "Designated Reg E / disputes officer",
+      "gate": "gate:disputes-signoff"
+    },
+    {
+      "does": "Issue provisional credit and submit the representment to the card network",
+      "reversible": false,
+      "blastRadius": "high",
+      "agent": "submit",
+      "tools": [
+        "card-processor",
+        "dispute-network"
+      ]
+    },
+    {
+      "does": "Track the network outcome, post final adjustment, and document for audit",
+      "reversible": true,
+      "blastRadius": "low",
+      "agent": "monitor",
+      "tools": [
+        "dispute-network"
+      ]
+    }
+  ],
+  "reviewer": "disputes-rege-reviewer",
+  "manifest": "docs/autopilot/autopilot.json",
+  "startups": [
+    "Chargeflow",
+    "Quavo",
+    "Pinwheel",
+    "Galileo"
+  ]
+}

--- a/flows/estate.flow.json
+++ b/flows/estate.flow.json
@@ -1,5 +1,6 @@
 {
   "vertical": "estate",
+  "domain": "legal",
   "autopilot": "Estate-planning + probate autopilot",
   "tagline": "Intakes assets, assesses the plan and screens execution — a licensed estate-planning attorney signs the instrument.",
   "audience": "Estate-planning / probate lead",

--- a/flows/freight.flow.json
+++ b/flows/freight.flow.json
@@ -1,5 +1,6 @@
 {
   "vertical": "freight",
+  "domain": "logistics",
   "autopilot": "Freight-brokerage autopilot",
   "tagline": "Matches loads to vetted carriers and books them — a licensed broker signs binding rates and claims.",
   "audience": "Brokerage operations lead",

--- a/flows/immigration.flow.json
+++ b/flows/immigration.flow.json
@@ -1,5 +1,6 @@
 {
   "vertical": "immigration",
+  "domain": "legal",
   "autopilot": "Immigration-petition autopilot",
   "tagline": "Intakes, checks eligibility and prepares petitions — a licensed immigration attorney of record signs before filing.",
   "audience": "Immigration / mobility lead",

--- a/flows/insurance.flow.json
+++ b/flows/insurance.flow.json
@@ -1,5 +1,6 @@
 {
   "vertical": "insurance",
+  "domain": "fintech",
   "autopilot": "Claims & underwriting autopilot",
   "tagline": "Adjudicates claims and prices risk — a licensed adjuster/underwriter signs the call that carries bad-faith exposure.",
   "audience": "Claims VP / Chief Underwriter",

--- a/flows/legaltech.flow.json
+++ b/flows/legaltech.flow.json
@@ -1,5 +1,6 @@
 {
   "vertical": "legaltech",
+  "domain": "legal",
   "autopilot": "Legal-document autopilot",
   "tagline": "Drafts and redlines contracts, NDAs and filings — a licensed attorney signs anything that's advice.",
   "audience": "CEO / General Counsel",

--- a/flows/mortgage.flow.json
+++ b/flows/mortgage.flow.json
@@ -1,5 +1,6 @@
 {
   "vertical": "mortgage",
+  "domain": "fintech",
   "autopilot": "Mortgage-underwriting autopilot",
   "tagline": "Processes and underwrites the loan to a clear-to-close — a DE underwriter signs the decision.",
   "audience": "Head of mortgage lending",

--- a/flows/msp.flow.json
+++ b/flows/msp.flow.json
@@ -1,5 +1,6 @@
 {
   "vertical": "msp",
+  "domain": "back-office",
   "autopilot": "Managed-IT autopilot",
   "tagline": "Patches, configures and provisions across the client fleet — staged and reversible, with a human on high-blast-radius changes.",
   "audience": "CEO / Head of IT Services",

--- a/flows/patent.flow.json
+++ b/flows/patent.flow.json
@@ -1,5 +1,6 @@
 {
   "vertical": "patent",
+  "domain": "legal",
   "autopilot": "Patent-prosecution autopilot",
   "tagline": "Searches prior art, screens bars and drafts the filing — a USPTO-registered patent practitioner signs before it is filed with the USPTO.",
   "audience": "IP counsel / patent-prosecution lead",

--- a/flows/payroll.flow.json
+++ b/flows/payroll.flow.json
@@ -1,5 +1,6 @@
 {
   "vertical": "payroll",
+  "domain": "fintech",
   "autopilot": "Payroll-processing autopilot",
   "tagline": "Runs gross-to-net, withholds and funds pay — a payroll manager (CPP) signs the run before money moves.",
   "audience": "Payroll / people-ops lead",

--- a/flows/pharma.flow.json
+++ b/flows/pharma.flow.json
@@ -1,5 +1,6 @@
 {
   "vertical": "pharma",
+  "domain": "healthcare",
   "autopilot": "Pharmacovigilance autopilot",
   "tagline": "Processes adverse-event cases — a QPPV / drug-safety physician signs before reporting.",
   "audience": "Drug-safety / PV lead",

--- a/flows/prior-auth.flow.json
+++ b/flows/prior-auth.flow.json
@@ -1,5 +1,6 @@
 {
   "vertical": "prior-auth",
+  "domain": "healthcare",
   "autopilot": "Prior-authorization autopilot",
   "tagline": "Turns a prior-auth request + chart into an approval or a clean determination — a medical director signs every denial.",
   "audience": "Payer UM lead / provider revenue lead",

--- a/flows/procurement.flow.json
+++ b/flows/procurement.flow.json
@@ -1,5 +1,6 @@
 {
   "vertical": "procurement",
+  "domain": "back-office",
   "autopilot": "Source-to-pay autopilot",
   "tagline": "Onboards suppliers, matches invoices and releases payments — screened for sanctions and fraud, with a human on the big ones.",
   "audience": "CFO / Head of Procurement",

--- a/flows/rcm.flow.json
+++ b/flows/rcm.flow.json
@@ -1,5 +1,6 @@
 {
   "vertical": "rcm",
+  "domain": "back-office",
   "autopilot": "Medical-coding autopilot",
   "tagline": "Turns clinical notes into clean, compliant claims — a certified coder signs only the risky ones.",
   "audience": "CFO / revenue-cycle lead",

--- a/flows/soc.flow.json
+++ b/flows/soc.flow.json
@@ -1,5 +1,6 @@
 {
   "vertical": "soc",
+  "domain": "security",
   "autopilot": "Managed-SOC / MDR autopilot",
   "tagline": "Triages and investigates every security alert 24/7 — a SOC analyst signs any containment.",
   "audience": "CISO / MSSP lead",

--- a/flows/support.flow.json
+++ b/flows/support.flow.json
@@ -1,0 +1,83 @@
+{
+  "vertical": "support",
+  "domain": "support",
+  "autopilot": "Customer-support autopilot",
+  "tagline": "Resolves tier-1 tickets end to end and drafts the rest — a support lead signs refunds, account changes and regulated-complaint responses before they go out.",
+  "audience": "Head of Support / CX lead",
+  "owner": "Designated support team lead",
+  "marketSizeUsd": "10B+",
+  "problem": "Support is a high-volume, deadline-bound operation — most tickets are repetitive, but a wrong refund, an account change on the wrong person, or a mishandled regulated complaint (CFPB, GDPR, chargeback) is real money and real liability. Scaling headcount linearly with ticket volume doesn't work.",
+  "outcome": "Intake, context-gathering, resolution drafting and safe actions run straight-through within SLA; only refunds, account changes and regulated-complaint responses above policy thresholds reach the support lead, who signs before any irreversible action or money movement.",
+  "qualityScore": 86,
+  "steps": [
+    {
+      "does": "Intake and classify the ticket: channel, intent, sentiment, priority and SLA clock",
+      "reversible": true,
+      "blastRadius": "low",
+      "agent": "intake",
+      "tools": [
+        "helpdesk"
+      ]
+    },
+    {
+      "does": "Pull account/order context and retrieve the relevant KB articles and policy",
+      "reversible": true,
+      "blastRadius": "low",
+      "agent": "retrieve",
+      "tools": [
+        "helpdesk",
+        "kb-search"
+      ]
+    },
+    {
+      "does": "Draft the resolution and propose any action (refund, replacement, account change)",
+      "reversible": true,
+      "blastRadius": "low",
+      "agent": "resolve",
+      "tools": [
+        "kb-search"
+      ]
+    },
+    {
+      "does": "Guardrail check: policy/refund thresholds, PII, and regulated-complaint detection (CFPB/GDPR)",
+      "reversible": true,
+      "blastRadius": "low",
+      "agent": "compliance",
+      "tools": [
+        "helpdesk"
+      ]
+    },
+    {
+      "does": "The support lead signs refunds, account changes and regulated-complaint responses above threshold",
+      "human": "Designated support team lead",
+      "gate": "gate:support-lead-signoff"
+    },
+    {
+      "does": "Apply the approved action and send the response to the customer",
+      "reversible": false,
+      "blastRadius": "high",
+      "agent": "act",
+      "tools": [
+        "helpdesk",
+        "payment-rails"
+      ]
+    },
+    {
+      "does": "Track CSAT, tag the resolution, and log regulated complaints for audit",
+      "reversible": true,
+      "blastRadius": "low",
+      "agent": "monitor",
+      "tools": [
+        "helpdesk"
+      ]
+    }
+  ],
+  "reviewer": "support-cx-reviewer",
+  "manifest": "docs/autopilot/autopilot.json",
+  "startups": [
+    "Sierra",
+    "Decagon",
+    "Intercom (Fin)",
+    "Gorgias"
+  ]
+}

--- a/flows/tax.flow.json
+++ b/flows/tax.flow.json
@@ -1,5 +1,6 @@
 {
   "vertical": "tax",
+  "domain": "fintech",
   "autopilot": "Tax-prep autopilot",
   "tagline": "Prepares returns and classifies positions — a credentialed preparer signs before anything is filed.",
   "audience": "CFO / Tax lead",

--- a/flows/title.flow.json
+++ b/flows/title.flow.json
@@ -1,5 +1,6 @@
 {
   "vertical": "title",
+  "domain": "real-estate",
   "autopilot": "Title & escrow autopilot",
   "tagline": "Runs title search, escrow and closing — a licensed officer signs the insurable title and authorizes the wire.",
   "audience": "Title agency / escrow operations lead",

--- a/flows/workers-comp.flow.json
+++ b/flows/workers-comp.flow.json
@@ -1,5 +1,6 @@
 {
   "vertical": "workers-comp",
+  "domain": "fintech",
   "autopilot": "Workers'-comp claims autopilot",
   "tagline": "Determines compensability, computes benefits and files the EDI claim — a licensed claims adjuster signs the determination.",
   "audience": "Workers'-comp claims / TPA lead",

--- a/scripts/lib/connectors.mjs
+++ b/scripts/lib/connectors.mjs
@@ -150,6 +150,14 @@ export const CONNECTORS = Object.freeze({
   // ── patent ──
   'prior-art':       { label: 'Prior-art / patentability', verticals: ['patent'],      capabilities: ['search-prior-art'], realProviders: ['USPTO PatFT', 'Google Patents', 'EPO'], status: 'stub' },
   'uspto-filing':    { label: 'USPTO filing (Patent Center)', verticals: ['patent'],   capabilities: ['file-application', 'check-status'], realProviders: ['USPTO Patent Center', 'EFS-Web'], status: 'stub' },
+
+  // ── crypto ──
+  'chain-analytics': { label: 'Blockchain analytics',    verticals: ['crypto'],        capabilities: ['screen-wallet', 'trace-funds'], realProviders: ['Chainalysis', 'TRM Labs', 'Elliptic'], status: 'live-ready' },
+  'travel-rule':     { label: 'Travel Rule messaging',   verticals: ['crypto'],        capabilities: ['exchange-vasp-info'], realProviders: ['Notabene', 'Sygna', 'TRP'], status: 'stub' },
+
+  // ── disputes (fintech) ──
+  'card-processor':  { label: 'Card processor / issuer', verticals: ['disputes'],      capabilities: ['get-transaction', 'issue-provisional-credit'], realProviders: ['Stripe', 'Adyen', 'Marqeta'], status: 'stub' },
+  'dispute-network': { label: 'Card-network disputes',   verticals: ['disputes'],      capabilities: ['submit-representment', 'check-status'], realProviders: ['Visa VROL', 'Mastercom'], status: 'stub' },
 });
 
 /** Look up a connector spec by id. */

--- a/scripts/lib/connectors.mjs
+++ b/scripts/lib/connectors.mjs
@@ -158,6 +158,10 @@ export const CONNECTORS = Object.freeze({
   // ── disputes (fintech) ──
   'card-processor':  { label: 'Card processor / issuer', verticals: ['disputes'],      capabilities: ['get-transaction', 'issue-provisional-credit'], realProviders: ['Stripe', 'Adyen', 'Marqeta'], status: 'stub' },
   'dispute-network': { label: 'Card-network disputes',   verticals: ['disputes'],      capabilities: ['submit-representment', 'check-status'], realProviders: ['Visa VROL', 'Mastercom'], status: 'stub' },
+
+  // ── support ──
+  'helpdesk':        { label: 'Help desk / ticketing',   verticals: ['support'],       capabilities: ['get-ticket', 'send-reply', 'apply-action'], realProviders: ['Zendesk', 'Intercom', 'Freshdesk'], status: 'stub' },
+  'kb-search':       { label: 'Knowledge base search',   verticals: ['support'],       capabilities: ['search-kb'], realProviders: ['Zendesk Guide', 'Confluence', 'Notion'], status: 'stub' },
 });
 
 /** Look up a connector spec by id. */

--- a/tests/lib/flow.test.mjs
+++ b/tests/lib/flow.test.mjs
@@ -26,8 +26,8 @@ const GOOD = {
 
 // ── shipped flow files all validate ──────────────────────────────────────────────
 
-test('there are 25 vertical flow files', () => {
-  assert.equal(flowFiles.length, 25);
+test('there are 27 vertical flow files', () => {
+  assert.equal(flowFiles.length, 27);
 });
 
 for (const f of readdirSync(FLOWS_DIR).filter((x) => x.endsWith('.flow.json'))) {

--- a/tests/lib/flow.test.mjs
+++ b/tests/lib/flow.test.mjs
@@ -26,8 +26,8 @@ const GOOD = {
 
 // ── shipped flow files all validate ──────────────────────────────────────────────
 
-test('there are 27 vertical flow files', () => {
-  assert.equal(flowFiles.length, 27);
+test('there are 28 vertical flow files', () => {
+  assert.equal(flowFiles.length, 28);
 });
 
 for (const f of readdirSync(FLOWS_DIR).filter((x) => x.endsWith('.flow.json'))) {


### PR DESCRIPTION
## Repositioning

New ICP positioning: **AI business autopilots for regulated and operationally complex companies — fintech, crypto, compliance, back office, support, security and engineering.** Source of truth: `docs/positioning/vocabulary.md` (new line + canonical forms). Hero framing ("get the work done", "Services are the new software") kept.

## New autopilots (each with a mandatory human gate before the irreversible step)

| Vertical | Domain | Human signs |
|---|---|---|
| 🪙 crypto — Crypto compliance & Travel Rule | crypto | MLRO signs SAR / address block / high-risk onboarding |
| 💳 disputes — Card-dispute & chargeback (Reg E/Z) | fintech | analyst signs provisional credit + representment before money moves |
| 🎧 support — Customer-support | support | lead signs refunds, account changes, regulated complaints |

New connectors: `chain-analytics`, `travel-rule`, `card-processor`, `dispute-network`, `helpdesk`, `kb-search`.

## Domain taxonomy (net-new)

Every flow now carries a `domain`; `flows/_domains.json` is the registry. ICP domains lead, other regulated industries follow. **28 verticals total.**

- **fintech**: disputes, mortgage, collections, payroll, insurance, tax, workers-comp
- **crypto**: crypto
- **compliance**: aml, customs, credentialing
- **back-office**: accounting, procurement, rcm, msp
- **security**: soc, audit
- **support**: support
- *out-of-ICP (shown under "More regulated verticals")*: healthcare, legal, real-estate, logistics

## Tests
- [x] `node --test tests/lib/flow.test.mjs` → 100/100 (validate, connectors-in-catalog, human-gate present; count 25 → 28)

Paired with the site PR (avelikiy/great_cto-site#reposition-icp-autopilots) which regenerates the landing + domain-grouped showcase from these flows.