### PR TITLE
Close #107 — mid-build spec-failure escape hatch

### DIFF
--- a/agents/senior-dev.md
+++ b/agents/senior-dev.md
@@ -37,6 +37,15 @@ edge case, a gate that can't be met, scope that crept. Silent compliance is a
 (ACCEPT-as-is / NEEDS-CHANGE + one line why) and proceed on the resolved spec.
 (Adapted from architect-loop R5, MIT.)
 
+**STRUCTURAL objection → STOP, don't absorb it (ADR-005).** Slice-level nits you
+resolve inline as above. But if you discover the **spec itself** is structurally
+wrong — wrong data model, wrong integration surface, an invalidated key assumption,
+or cost over headroom — do **not** "proceed on the resolved spec". Emit a
+`SPEC-OBJECTION` verdict (`scripts/log-verdict.sh senior-dev SPEC-OBJECTION auto
+feature=<slug> reason="<structural error>"`), which re-opens `gate:plan` for the
+CTO via HANDOFF → `/inbox`. This is the mid-build escape hatch — see
+`docs/strategy/MID-BUILD-RECOVERY.md`. The CTO decides; you only raise it.
+
 **Frozen gates are read-only.** Never edit, move, or delete any file under
 `docs/gates/` — those are the acceptance criteria, frozen before you started. A
 builder edit to a gate file is an automatic slice FAIL

--- a/commands/review.md
+++ b/commands/review.md
@@ -536,7 +536,22 @@ echo "P1 (post-triage): [sum]"
 echo "P2:              [sum]"
 ```
 
-**Gate:code decision:**
+**SPEC-OBJECTION decision (structural errors escalate to the CTO gate, ADR-005):**
+
+A code finding gets a `gate:code`. But if a P0 finding is **structural — the
+approved spec itself is wrong** (wrong data model, wrong integration surface, an
+invalidated assumption), `gate:code` is the wrong gate: the fix isn't in the code,
+it's in the spec. Raise a `SPEC-OBJECTION` instead, which re-opens `gate:plan` for
+the CTO (mid-build escape hatch — `docs/strategy/MID-BUILD-RECOVERY.md`):
+```bash
+# Only for STRUCTURAL P0s (spec/architecture/data-model/integration-surface):
+scripts/log-verdict.sh review SPEC-OBJECTION auto feature="<slug>" reason="<structural spec error>"
+bd create "gate:plan — SPEC-OBJECTION: structural spec error found mid-build, CTO decision needed" \
+  --type task --priority 0 --label gate 2>/dev/null
+echo "SPEC-OBJECTION raised — re-opens gate:plan. See /inbox. Do NOT keep building on the bad spec."
+```
+
+**Gate:code decision (code-level findings):**
 
 If P0 > 0 OR (approval-level = strict AND P1 > 0) **after triage**:
 ```bash

--- a/docs/adr/ADR-005-mid-build-spec-reentry.md
+++ b/docs/adr/ADR-005-mid-build-spec-reentry.md
@@ -1,0 +1,72 @@
+# ADR-005: Mid-build spec re-entry (the CTO gate is reversible-with-cost)
+
+**Status:** Accepted (v2.75.0)
+**Date:** 2026-06-28
+**Related:** ADR-003 (two-axis build-gate model)
+**Closes:** [#107](https://github.com/avelikiy/great_cto/issues/107)
+
+## Context
+
+The build flow documents exactly one human gate — the CTO approving the
+spec/architecture (`gate:plan`) — and `docs/strategy/BUILD-PIPELINES.md` states
+"everything after it is automated build." Issue #107 found the gap: there is no
+documented path for when the spec turns out to be structurally wrong *after*
+approval but *before* the build finishes (wrong data model, wrong integration
+surface, invalidated assumption).
+
+The code confirms the gap:
+
+- **No re-enter-from-spec protocol.** State that *would* enable cheap re-entry
+  already persists — `docs/architecture/ARCH-{slug}.md`, `.great_cto/HANDOFF.md`
+  (PreCompact hook), the Beads task graph, `.great_cto/PROJECT.md` — but nothing
+  wires it to a STOP. "Phases" (`references/phases.md`) are SessionStart context
+  filters, not checkpoints you can rewind to.
+- **No spec-level objection channel mid-build.** `/review` (`commands/review.md`)
+  is a *code* reviewer — it diffs vs `main` and creates `gate:code`; it cannot
+  re-open `gate:plan`. senior-dev's "Phase 0 — argue with the spec"
+  (`agents/senior-dev.md:31`) resolves disagreements **inline** and "proceeds on
+  the resolved spec" — it never halts or escalates a structural error.
+- **The gate reads as irreversible.** The CTO experiences approval as a
+  checkpoint; the system treats it as a commit. Nothing records "approved, then
+  reversed, here's why."
+
+The cost of the two ad-hoc options is real: finish on a bad spec (waste + rework)
+or abort and restart from scratch (the full $3+ build, as in the proof run).
+
+## Decision
+
+1. **`gate:plan` is reversible-with-cost, not a hard commit.** A mid-build
+   spec-level STOP is a first-class, documented operation — see
+   `docs/strategy/MID-BUILD-RECOVERY.md`.
+2. **The persisted state IS the checkpoint.** `ARCH-{slug}.md` + `HANDOFF.md` +
+   the Beads graph + `PROJECT.md` are sufficient to re-enter from the spec phase
+   without re-running the whole pipeline. We do not add a new snapshot store; we
+   document the re-entry that this existing state already permits.
+3. **`SPEC-OBJECTION` escalation.** Any agent that discovers a *structural* spec
+   error mid-build emits a `SPEC-OBJECTION` verdict that re-opens `gate:plan`
+   instead of absorbing it inline:
+   - senior-dev Phase 0: a *structural* disagreement (not a slice nit) → STOP +
+     `SPEC-OBJECTION`, surfaced in `/inbox` via HANDOFF.
+   - `/review`: a P0 finding on the *spec/architecture* angle → `SPEC-OBJECTION`,
+     not just a `gate:code` finding.
+   The CTO decides; agents only *raise* the objection.
+4. **Re-entry re-runs the delta, not the world.** Re-open `gate:plan`, architect
+   re-runs with the existing ARCH doc as input, only spec→scaffold-delta re-runs,
+   and Beads tasks downstream of the changed surface are re-opened — not the whole
+   graph.
+5. **Reversals are logged.** A Decision-Log entry with the existing
+   `Reversible:` field (`references/decision-log.md`) records the reversal + cost.
+
+## Consequences
+
+- **+** A long build is no longer a one-way door; a discovered spec error has a
+  bounded recovery instead of finish-bad or restart-from-zero.
+- **+** Zero new infrastructure — the escape hatch rides on state that already
+  persists.
+- **−** Re-entry is only *cheap*, not *free*: scaffold is not yet idempotent
+  (`agents/app-scaffolder.md` lacks the guarantee `infra-provisioner.md` has), so
+  scaffold-delta re-runs may need manual cleanup until that is hardened (deferred
+  to its own change — it touches build behavior).
+- **−** `SPEC-OBJECTION` adds a path agents can over-use; scoped to *structural*
+  errors (data model / integration surface / invalidated assumption / cost
+  overrun), not slice-level nits, which Phase 0 still resolves inline.

--- a/docs/strategy/BUILD-PIPELINES.md
+++ b/docs/strategy/BUILD-PIPELINES.md
@@ -39,6 +39,9 @@ the pipeline composes them.)
    ║  approve spec + architecture (is this right?) ║
    ╚══════════════════════════════════════════════╝
         │  (approved → everything below is automated)
+        │  ⓘ Approval is reversible-with-cost, not a one-way door. If a structural
+        │    spec error surfaces mid-build, any agent can raise SPEC-OBJECTION to
+        │    re-open this gate — see docs/strategy/MID-BUILD-RECOVERY.md (ADR-005).
    S2. Scaffold        ──────── instantiate the archetype's stack template
    S3. Backend         ──────── data model → API + auth + CRUD + roles
    S4. Frontend        ──────── senior-dev + ui-ux-pro-max build to design-advisor's DESIGN-{slug}.md

--- a/docs/strategy/MID-BUILD-RECOVERY.md
+++ b/docs/strategy/MID-BUILD-RECOVERY.md
@@ -1,0 +1,91 @@
+# Mid-build recovery — the spec-level escape hatch
+
+> Status: active · Created 2026-06-28 · Decision: [ADR-005](../adr/ADR-005-mid-build-spec-reentry.md) · Closes [#107](https://github.com/avelikiy/great_cto/issues/107)
+
+The build flow has one human gate: the CTO approves the spec, then the build runs
+automated to `gate:ship`. **This doc is the missing path** for when the spec turns
+out to be structurally wrong *after* approval but *before* the build finishes.
+
+It exists because the two ad-hoc options are both bad: **finish on the bad spec**
+(waste + rework) or **abort and restart from scratch** (the whole $3+ build). The
+escape hatch makes a discovered spec error a bounded recovery instead.
+
+## When to pull it — triggers (structural only)
+
+A mid-build STOP is for **structural** spec errors, not slice-level nits (those
+are still resolved inline by senior-dev Phase 0):
+
+- wrong **data model** (entities/relations that won't support the requirements)
+- wrong **integration surface** (the API/contract/3rd-party shape is mismatched)
+- an **invalidated key assumption** the spec was built on
+- **cost** projected to exceed the run's headroom
+
+## Who can raise it
+
+| Role | Authority |
+|------|-----------|
+| **CTO** | Raises and decides — authoritative. |
+| **architect / senior-dev / `/review`** | **Recommend** via a `SPEC-OBJECTION` verdict. They never silently abort; they surface it (HANDOFF → `/inbox`) and the CTO decides. |
+
+`SPEC-OBJECTION` re-opens `gate:plan` instead of being absorbed:
+- **senior-dev Phase 0** — a *structural* disagreement (vs a slice nit) emits
+  `SPEC-OBJECTION` and STOPs, rather than "proceed on the resolved spec".
+- **`/review`** — a P0 finding on the *spec / architecture* angle writes
+  `SPEC-OBJECTION`, not just a `gate:code` finding.
+
+## The checkpoint already exists
+
+No new snapshot store is added — re-entry rides on state that already persists:
+
+| State | Written by | Enables |
+|-------|-----------|---------|
+| `docs/architecture/ARCH-{slug}.md` | architect | re-run spec with the prior design as input |
+| `.great_cto/HANDOFF.md` | PreCompact hook | open gates / tasks / last verdict |
+| Beads task graph (`.beads/`) | all agents | which tasks/phases completed |
+| `.great_cto/PROJECT.md` | start/audit | archetype, phase, compliance |
+
+## Re-entry — re-run the delta, not the world
+
+```
+SPEC-OBJECTION raised
+        │
+   👤 CTO reviews (/inbox)
+        ├── reject objection → resume build unchanged
+        └── accept → STOP build, re-open gate:plan
+                 │
+        architect re-runs WITH existing ARCH-{slug}.md as input
+                 │
+        diff the new spec vs old → changed surface only
+                 │
+        re-open ONLY Beads tasks downstream of the changed surface
+                 │
+        re-run spec → scaffold-delta → affected backend/frontend
+                 │
+        log a Decision-Log entry (Reversible: field) — what changed + cost
+```
+
+### Phase re-entry — honest cost table
+
+| Phase | Re-enter without redoing earlier? | Cost |
+|-------|-----------------------------------|------|
+| Spec (`gate:plan`) | Yes — ARCH doc persists | low |
+| Scaffold (S2) | Yes, but **not yet idempotent** — may need manual cleanup of duplicate resources (hardening deferred, ADR-005 §Consequences) | medium |
+| Backend (S3) | Only tasks downstream of the changed surface re-open; merged PRs need new tasks | medium–high |
+| Frontend (S4) | In-progress only; merged = fresh feature request | medium |
+
+## Default behaviour (no founder round-trip needed)
+
+Per great_cto's implementer-defaults rule, the escape hatch has safe defaults so it
+never blocks waiting on the founder:
+
+- **Default on objection:** STOP and surface (don't auto-resume, don't auto-abort).
+  Reversible: yes (CTO can reject the objection and resume).
+- **Default re-entry scope:** delta only (downstream-of-changed-surface tasks).
+  Reversible: yes (CTO can widen to full re-plan).
+- **Default logging:** every accepted objection writes a Decision-Log entry.
+
+## Approval-gate clarity
+
+The `gate:plan` approval is **hard-but-not-impossible to undo**: approving starts
+an automated build, and reversing it costs the delta above. It is not a one-way
+door — but it is not free. See ADR-005.


### PR DESCRIPTION
Closes #107.

## Problem (verified in code)
One human gate (`gate:plan`); everything after is automated to `gate:ship` with no
documented path when a structural spec error is found mid-build. `/review` is a code
reviewer (→ `gate:code`), cannot re-open `gate:plan`. senior-dev Phase 0 resolves
spec disagreements inline and proceeds. State for cheap re-entry (ARCH/HANDOFF/Beads)
persists but is wired to nothing.

## Fix
- **ADR-005** — `gate:plan` is reversible-with-cost; persisted state IS the checkpoint; `SPEC-OBJECTION` escalation contract.
- **docs/strategy/MID-BUILD-RECOVERY.md** — triggers, who-raises, per-phase cost table, delta re-entry, safe defaults.
- **senior-dev Phase 0** — a STRUCTURAL spec error emits `SPEC-OBJECTION` + STOP (vs resolving inline).
- **/review** — a structural P0 raises `SPEC-OBJECTION` (re-opens `gate:plan`) instead of `gate:code`.
- **BUILD-PIPELINES.md** — notes approval is reversible-with-cost, not a one-way door.

Scaffold idempotency hardening (needed for fully clean re-entry) is tracked separately.

## Test plan
- [x] structural validator + docs-reference sync pass
- [ ] CI green (see note: Actions currently failing account-wide — separate billing issue, not this PR)