### PR TITLE
Adopt 3 AgentSpace ideas — grant audit, knowledge versioning, harness router

### DIFF
--- a/commands/crystallize.md
+++ b/commands/crystallize.md
@@ -170,6 +170,19 @@ ls "$KE_DIR"/KE-*.yaml 2>/dev/null | while read ke_file; do
     sed -i.bak "s/^hits: ${CURRENT_HITS}/hits: $((CURRENT_HITS+1))/" "$EXISTING_GP" 2>/dev/null
     sed -i.bak "s/^confidence: .*/confidence: validated/" "$EXISTING_GP" 2>/dev/null
     rm -f "${EXISTING_GP}.bak"
+    # Knowledge versioning (AgentSpace #4): a re-occurrence means the pattern
+    # evolved — version it + record history, don't silently overwrite.
+    GPS="$PLUGIN_DIR/shared/gp-schema.mjs"; [ -f "$GPS" ] || GPS="$(pwd)/shared/gp-schema.mjs"
+    GPS_ABS="$(cd "$(dirname "$GPS")" 2>/dev/null && pwd)/$(basename "$GPS")"
+    GP_FILE="$EXISTING_GP" GP_DATE="$TODAY" GP_KE="$KE_ID" GPS_ABS="$GPS_ABS" node -e '
+      import("file://" + process.env.GPS_ABS).then(async (m) => {
+        const fs = await import("node:fs");
+        const f = process.env.GP_FILE;
+        const r = m.bumpGpVersion(fs.readFileSync(f, "utf8"), { date: process.env.GP_DATE, source_ke: process.env.GP_KE, reason: "re-occurred (hits incremented)" });
+        fs.writeFileSync(f, r.text);
+        console.log("  VERSIONED " + f + " v" + r.from + " -> v" + r.to);
+      }).catch(() => {});
+    ' 2>/dev/null || true
     printf "promoted_to: %s\n" "$EXISTING_ID" >> "$ke_file"
     echo "  MERGED into $EXISTING_ID (hits now $((CURRENT_HITS+1)))"
     continue

--- a/commands/doctor.md
+++ b/commands/doctor.md
@@ -505,6 +505,20 @@ fi
 - `/doctor --packs` → expand pack detection with signal-by-signal trace (verbose)
 - (default) → show summary
 
+## Check 8e — Grants & credentials (v2.75+)
+
+Audit the credentials the project actually needs (AgentSpace-inspired): LLM provider
+key, npm auth (local publish), gh auth (PRs/release), and provider↔key orphans (a
+provider configured in PROJECT.md with no matching key). A `critical` here means the
+LLM-calling parts of the pipeline cannot run.
+
+```bash
+PLUGIN_DIR=$(ls -d ~/.claude/plugins/cache/local/great_cto/*/ 2>/dev/null | sort -V | tail -1 | sed 's|/$||')
+GA="$PLUGIN_DIR/scripts/lib/grant-audit.mjs"; [ -f "$GA" ] || GA="scripts/lib/grant-audit.mjs"
+echo "## Check 8e — Grants & credentials"
+node "$GA" 2>/dev/null || echo "  (grant-audit unavailable)"
+```
+
 ## Check 9 — Auto-remediation (--fix mode)
 
 If `FIX_MODE=true`, perform safe, non-destructive fixes. Skip silently otherwise.

--- a/docs/adr/ADR-006-harness-router.md
+++ b/docs/adr/ADR-006-harness-router.md
@@ -1,0 +1,51 @@
+# ADR-006: Harness router — agent identity decoupled from harness binding
+
+**Status:** Accepted (v2.75.0)
+**Date:** 2026-06-28
+**Source:** adoption of one idea from HKUDS/AgentSpace (its AgentRouter)
+
+## Context
+
+great_cto runs as a plugin **inside** a coding harness — Claude Code today, with
+Codex listed as supported. Its agents are portable markdown, but the surrounding
+machinery is Claude-Code-specific: hooks (SessionStart / SubagentStart / PreToolUse)
+inject context and enforce gates; subagents are spawned via the Task tool. On a
+harness without those (Codex, OpenCode), that machinery silently does nothing, and
+nothing in the codebase knows it.
+
+AgentSpace's **AgentRouter** frames this well: an agent's *identity and instructions*
+are stable; only the *runtime/harness binding* changes, and a normalization layer
+reconciles harness differences (events, sessions, tool approval).
+
+## Decision
+
+Adopt the **idea**, not the stack. Introduce `scripts/lib/harness-router.mjs`:
+
+1. A **capability registry** (`HARNESSES`) — for each harness (claude-code, codex,
+   opencode): cli name, env signals, and capability flags (hooks, mcp, subagents,
+   slashCommands, toolApproval, streamJson).
+2. **`detectHarness(env)`** — which harness we're under (env signals;
+   `GREAT_CTO_HARNESS` overrides), falling back to `unknown`.
+3. **`hasCapability(id, cap)`** — degrade-safe (unknown harness/cap → false), so
+   great_cto code can branch instead of assuming Claude Code.
+
+This is the **first slice**: detection + a single source of truth great_cto can
+reason about (e.g. "no hooks here → agents must self-load context instead of relying
+on SessionStart injection").
+
+## Scope / deferred
+
+- **Deferred:** full cross-harness EXECUTION — launching codex/opencode CLIs and
+  normalizing their stream-json events / sessions / tool-approval into one stream
+  (AgentRouter's heavy part). That's a large effort and only pays off once we
+  actually run agents off Claude Code.
+- **Not adopted:** AgentSpace's monorepo / Postgres / daemon — contrary to
+  great_cto's lightweight, markdown-in-git design.
+
+## Consequences
+
+- **+** One place to ask "what can this harness do" — lets hooks/agents degrade
+  gracefully rather than silently no-op off Claude Code.
+- **+** Cheap, testable, zero new deps.
+- **−** Capability flags are best-effort and must be kept current as harnesses
+  evolve; they are conservative (unknown → false) to avoid over-promising.

--- a/docs/strategy/AGENTSPACE-ADOPT.md
+++ b/docs/strategy/AGENTSPACE-ADOPT.md
@@ -1,0 +1,27 @@
+# Adopting ideas from HKUDS/AgentSpace (ideas, not the stack)
+
+> Status: active · Created 2026-06-28 · Source: analysis of github.com/HKUDS/AgentSpace
+
+AgentSpace is a heavy team workspace (TS monorepo + Postgres + web/daemon). great_cto
+is a lightweight Claude-Code plugin (markdown agents in git, zero-dep board). We take
+**three ideas**, scoped to great_cto's design — not the stack.
+
+## What we adopt
+
+| # | AgentSpace idea | great_cto form | Effort |
+|---|-----------------|----------------|--------|
+| **#2** | Audit of grants/credentials (missing / revoked / orphaned / unavailable provider) | `scripts/lib/grant-audit.mjs` + a `/doctor` check: OpenRouter/Anthropic keys, npm auth, gh auth, provider↔key orphans | S |
+| **#4** | Knowledge as owned + **versioned** + approval-queued | `bumpGpVersion()` in `shared/gp-schema.mjs` + crystallize bumps version + appends a Version-history block when a pattern is re-crystallized (instead of skip/duplicate) | S–M |
+| **#1** | **AgentRouter** — agent identity stable across harnesses; normalize harness capabilities | `scripts/lib/harness-router.mjs` — detect the current harness (Claude Code / Codex / OpenCode) + a capability registry; first slice (detect + registry), full multi-harness execution deferred (ADR-006) | L |
+
+## What we explicitly do NOT adopt
+
+- The monorepo + PostgreSQL + web + daemon + sandbox — kills great_cto's lightweight edge.
+- Agents in a DB — our markdown-in-git agents are a feature (portable, versioned, coverage-gate ratchet).
+- Team features (channels, document permissions, Google Workspace delegation) — out of scope for solo/small-team.
+
+## Sequence
+
+1. **#2 grant-audit** (cheap, concrete) — extends `/doctor` (which already pings the OpenRouter key).
+2. **#4 knowledge-versioning** (cheap) — extends the GP schema + crystallize the loop already has.
+3. **#1 harness-router** (strategic, large) — ADR-006 + a first slice (detect + capability registry). Full cross-harness execution is a follow-up; the one genuinely new capability for us.

--- a/scripts/lib/grant-audit.mjs
+++ b/scripts/lib/grant-audit.mjs
@@ -1,0 +1,106 @@
+// scripts/lib/grant-audit.mjs — audit grants & credentials (DEEPEN / AgentSpace #2).
+//
+// Inspired by AgentSpace's permission control plane ("missing grants, revoked
+// credentials, orphaned grants, unavailable providers"). great_cto form: one place
+// that answers "do I actually have the credentials this project needs, and are any
+// configured-but-broken (orphaned)?" — surfaced in /doctor.
+//
+// Pure core (classifyGrants) is unit-tested with injected inputs; the CLI gathers
+// the live inputs (env, secrets files, npm whoami, gh auth) and prints the table.
+//
+// Usage:
+//   node scripts/lib/grant-audit.mjs            # human table
+//   node scripts/lib/grant-audit.mjs --json     # machine-readable
+// Exit 0 always (advisory); /doctor surfaces the findings.
+
+import { readFileSync, existsSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { execSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Pure classification. `i` = gathered inputs (all optional).
+ * @param {{openrouterKey?:boolean, anthropicKey?:boolean, npmUser?:string|null,
+ *          ghUser?:string|null, providerConfigured?:string|null}} i
+ * @returns {Array<{grant,status,severity,detail}>}  status: ok|missing|orphan
+ */
+export function classifyGrants(i = {}) {
+  const out = [];
+
+  // LLM provider credential — at least one must exist or the pipeline can't run.
+  if (i.openrouterKey) out.push({ grant: 'llm: OpenRouter', status: 'ok', severity: 'info', detail: 'OPENROUTER_API_KEY present' });
+  else if (i.anthropicKey) out.push({ grant: 'llm: Anthropic', status: 'ok', severity: 'info', detail: 'ANTHROPIC_API_KEY present (fallback)' });
+  else out.push({ grant: 'llm provider key', status: 'missing', severity: 'critical', detail: 'no OPENROUTER_API_KEY or ANTHROPIC_API_KEY — evals/agents that call the LLM cannot run' });
+
+  // Orphan: PROJECT.md names a provider but its key is absent.
+  if (i.providerConfigured === 'openrouter' && !i.openrouterKey)
+    out.push({ grant: 'orphan: openrouter configured', status: 'orphan', severity: 'high', detail: 'PROJECT.md routes to OpenRouter but OPENROUTER_API_KEY is missing' });
+  if (i.providerConfigured === 'anthropic' && !i.anthropicKey)
+    out.push({ grant: 'orphan: anthropic configured', status: 'orphan', severity: 'high', detail: 'PROJECT.md routes to Anthropic but ANTHROPIC_API_KEY is missing' });
+
+  // npm — needed for local publish (cd-local --publish).
+  if (i.npmUser) out.push({ grant: 'npm auth', status: 'ok', severity: 'info', detail: `logged in as ${i.npmUser}` });
+  else out.push({ grant: 'npm auth', status: 'missing', severity: 'med', detail: 'not logged in (npm login) — local publish via cd-local --publish will refuse' });
+
+  // GitHub — needed for PRs / pushing releases.
+  if (i.ghUser) out.push({ grant: 'github auth', status: 'ok', severity: 'info', detail: `gh active account: ${i.ghUser}` });
+  else out.push({ grant: 'github auth', status: 'missing', severity: 'med', detail: 'gh not authenticated — PRs / release pushes need it' });
+
+  return out;
+}
+
+export function summarize(rows) {
+  return {
+    ok: rows.filter(r => r.status === 'ok').length,
+    missing: rows.filter(r => r.status === 'missing').length,
+    orphan: rows.filter(r => r.status === 'orphan').length,
+    critical: rows.filter(r => r.severity === 'critical').length,
+  };
+}
+
+// ── CLI: gather live inputs, classify, print ──────────────────────────────────
+
+function envOrFile(name) {
+  if (process.env[name]) return true;
+  for (const p of [join(homedir(), '.great_cto', 'secrets.env'), '.env.local']) {
+    try { if (new RegExp(`^${name}=`, 'm').test(readFileSync(p, 'utf8'))) return true; } catch { /* ignore */ }
+  }
+  return false;
+}
+
+function tryCmd(cmd) {
+  try { return execSync(cmd, { stdio: ['ignore', 'pipe', 'ignore'], timeout: 8000 }).toString().trim() || null; } catch { return null; }
+}
+
+function readProvider() {
+  try {
+    const t = readFileSync('.great_cto/PROJECT.md', 'utf8');
+    if (/openrouter/i.test(t)) return 'openrouter';
+    if (/anthropic/i.test(t)) return 'anthropic';
+  } catch { /* ignore */ }
+  return null;
+}
+
+function main(argv) {
+  const inputs = {
+    openrouterKey: envOrFile('OPENROUTER_API_KEY'),
+    anthropicKey: envOrFile('ANTHROPIC_API_KEY'),
+    npmUser: tryCmd('npm whoami'),
+    ghUser: (tryCmd('gh auth status --active 2>&1 | grep -oE "account [A-Za-z0-9-]+" | head -1') || '').replace('account ', '') || null,
+    providerConfigured: readProvider(),
+  };
+  const rows = classifyGrants(inputs);
+  if (argv.includes('--json')) { process.stdout.write(JSON.stringify({ rows, summary: summarize(rows) }, null, 2)); return; }
+
+  console.log('Grant & credential audit');
+  for (const r of rows) {
+    const icon = r.status === 'ok' ? '✓' : r.status === 'orphan' ? '⚠' : '✗';
+    console.log(`  ${icon} ${r.grant.padEnd(28)} ${r.status.padEnd(8)} ${r.detail}`);
+  }
+  const s = summarize(rows);
+  console.log(`\n  ${s.ok} ok · ${s.missing} missing · ${s.orphan} orphan${s.critical ? `  (⛔ ${s.critical} critical)` : ''}`);
+}
+
+const isMain = process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1];
+if (isMain) main(process.argv.slice(2));

--- a/scripts/lib/harness-router.mjs
+++ b/scripts/lib/harness-router.mjs
@@ -1,0 +1,84 @@
+// scripts/lib/harness-router.mjs — harness detection + capability registry
+// (AgentSpace #1, first slice). Inspired by AgentSpace's AgentRouter: an agent's
+// identity is stable; only the *harness binding* changes. great_cto agents are
+// already portable markdown — what's missing is one place to reason about which
+// harness we're running under and what it can do, so behaviour degrades gracefully
+// off Claude Code (e.g. our hooks/subagents are Claude-Code-specific).
+//
+// SCOPE: this slice is detect + capability registry. Full cross-harness EXECUTION
+// (launching codex/opencode CLIs, normalizing their stream-json events) is deferred
+// — see ADR-006.
+//
+// Usage:
+//   node scripts/lib/harness-router.mjs detect      # current harness + capabilities
+//   node scripts/lib/harness-router.mjs harnesses   # list the registry
+
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Capability flags are best-effort (mark unknowns conservatively false). The value
+ * is a single source of truth great_cto code can branch on instead of scattered
+ * env sniffing. Override detection with GREAT_CTO_HARNESS=<id>.
+ */
+export const HARNESSES = Object.freeze({
+  'claude-code': {
+    name: 'Claude Code', cli: 'claude',
+    envSignals: ['CLAUDECODE', 'CLAUDE_CODE_ENTRYPOINT'],
+    capabilities: { hooks: true, mcp: true, subagents: true, slashCommands: true, toolApproval: true, streamJson: true },
+  },
+  'codex': {
+    name: 'OpenAI Codex', cli: 'codex',
+    envSignals: ['CODEX', 'CODEX_SANDBOX', 'CODEX_HOME'],
+    capabilities: { hooks: false, mcp: true, subagents: false, slashCommands: true, toolApproval: true, streamJson: true },
+  },
+  'opencode': {
+    name: 'OpenCode', cli: 'opencode',
+    envSignals: ['OPENCODE', 'OPENCODE_BIN'],
+    capabilities: { hooks: false, mcp: true, subagents: false, slashCommands: false, toolApproval: true, streamJson: true },
+  },
+});
+
+/** Detect the current harness from env signals (GREAT_CTO_HARNESS overrides). */
+export function detectHarness(env = process.env) {
+  if (env.GREAT_CTO_HARNESS && HARNESSES[env.GREAT_CTO_HARNESS]) return env.GREAT_CTO_HARNESS;
+  for (const [id, h] of Object.entries(HARNESSES)) {
+    if (h.envSignals.some(s => env[s])) return id;
+  }
+  return 'unknown';
+}
+
+/** Capability map for a harness id, or null if unknown. */
+export function capabilities(id) {
+  return HARNESSES[id]?.capabilities ?? null;
+}
+
+/** Does `id` support `cap`? Unknown harness / unknown cap → false (degrade safe). */
+export function hasCapability(id, cap) {
+  return capabilities(id)?.[cap] === true;
+}
+
+// ── CLI ───────────────────────────────────────────────────────────────────────
+
+function main(argv) {
+  const cmd = argv[0] || 'detect';
+  if (cmd === 'harnesses') {
+    for (const [id, h] of Object.entries(HARNESSES)) {
+      const caps = Object.entries(h.capabilities).filter(([, v]) => v).map(([k]) => k).join(', ');
+      console.log(`${id.padEnd(14)} ${h.name.padEnd(16)} caps: ${caps}`);
+    }
+    return;
+  }
+  // detect
+  const id = detectHarness();
+  console.log(`harness: ${id}${HARNESSES[id] ? ` (${HARNESSES[id].name})` : ''}`);
+  const caps = capabilities(id);
+  if (caps) {
+    for (const [k, v] of Object.entries(caps)) console.log(`  ${v ? '✓' : '✗'} ${k}`);
+    if (!caps.hooks) console.log('  ⓘ no hooks on this harness — great_cto SessionStart/PreToolUse context injection won\'t fire; agents must self-load context.');
+  } else {
+    console.log('  unknown harness — assuming no Claude-Code-specific capabilities (hooks/subagents). Set GREAT_CTO_HARNESS to override.');
+  }
+}
+
+const isMain = process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1];
+if (isMain) main(process.argv.slice(2));

--- a/shared/gp-schema.mjs
+++ b/shared/gp-schema.mjs
@@ -92,3 +92,36 @@ export function validateGpFrontmatter(text) {
   const missing = RECALL_REQUIRED_KEYS.filter(k => !new RegExp(`^${k}:`, 'm').test(String(text)));
   return { ok: missing.length === 0, missing };
 }
+
+/**
+ * Bump a GP's version when a pattern is re-crystallized or amended (AgentSpace #4:
+ * knowledge is owned + versioned, not overwritten). Increments the `version:`
+ * frontmatter, refreshes `last_validated:`, and appends a line to a
+ * `## Version history` section (created if absent) — append-only audit of how the
+ * pattern evolved. Pure: returns the new text; never throws on a missing version.
+ *
+ * @param {string} text  full GP file text
+ * @param {{reason?:string, date:string, source_ke?:string}} meta  date is required (caller supplies the clock)
+ * @returns {{text:string, from:number, to:number}}
+ */
+export function bumpGpVersion(text, meta = {}) {
+  let t = String(text);
+  const m = t.match(/^version:\s*(\d+)\s*$/m);
+  const from = m ? parseInt(m[1], 10) : 1;
+  const to = from + 1;
+
+  if (m) t = t.replace(/^version:\s*\d+\s*$/m, `version: ${to}`);
+  else t = t.replace(/^(---\n)/, `$1version: ${to}\n`); // insert if absent
+
+  if (meta.date) {
+    if (/^last_validated:/m.test(t)) t = t.replace(/^last_validated:.*$/m, `last_validated: ${meta.date}`);
+  }
+
+  const entry = `- v${to} (${meta.date ?? '?'})${meta.source_ke ? ` · ${meta.source_ke}` : ''} — ${meta.reason ?? 're-crystallized'}`;
+  if (/^##\s+Version history/m.test(t)) {
+    t = t.replace(/(^##\s+Version history\s*\n)/m, `$1${entry}\n`);
+  } else {
+    t = t.replace(/\s*$/, `\n\n## Version history\n${entry}\n`);
+  }
+  return { text: t, from, to };
+}

--- a/tests/eval/gp-schema.test.mjs
+++ b/tests/eval/gp-schema.test.mjs
@@ -18,6 +18,7 @@ import {
   RECALL_REQUIRED_KEYS,
   renderGpFrontmatter,
   validateGpFrontmatter,
+  bumpGpVersion,
 } from '../../shared/gp-schema.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -81,4 +82,45 @@ test('crystallize.md GP-writer emits every recall-required key', () => {
 test('crystallize.md no longer writes the dead applicable_archetypes key', () => {
   const block = extractGpWriterBlock(CRYSTALLIZE);
   assert.ok(!/^applicable_archetypes:/m.test(block), 'dead key still emitted');
+});
+
+// ── bumpGpVersion (AgentSpace #4 — knowledge versioning) ──────────────────────
+
+const GP_V1 = `---
+id: GP-0007
+slug: demo
+status: active
+version: 1
+created: 2026-06-01
+last_validated: 2026-06-01
+hits: 1
+---
+
+### GP-0007 — Demo
+body
+`;
+
+test('bumpGpVersion: increments version, refreshes last_validated, appends history', () => {
+  const { text, from, to } = bumpGpVersion(GP_V1, { date: '2026-06-28', source_ke: 'KE-9', reason: 'recurred on web-app' });
+  assert.equal(from, 1);
+  assert.equal(to, 2);
+  assert.match(text, /^version: 2$/m);
+  assert.match(text, /^last_validated: 2026-06-28$/m);
+  assert.match(text, /^## Version history$/m);
+  assert.match(text, /- v2 \(2026-06-28\) · KE-9 — recurred on web-app/);
+});
+
+test('bumpGpVersion: second bump appends, keeps one version line', () => {
+  const once = bumpGpVersion(GP_V1, { date: '2026-06-28' }).text;
+  const twice = bumpGpVersion(once, { date: '2026-06-29', reason: 'again' }).text;
+  assert.match(twice, /^version: 3$/m);
+  assert.equal((twice.match(/^version:/mg) || []).length, 1, 'exactly one version: line');
+  assert.equal((twice.match(/^- v\d /mg) || []).length, 2, 'two history entries');
+});
+
+test('bumpGpVersion: missing version: line defaults from 1 → 2', () => {
+  const noVer = `---\nid: GP-x\nstatus: active\n---\nbody\n`;
+  const { to, text } = bumpGpVersion(noVer, { date: '2026-06-28' });
+  assert.equal(to, 2);
+  assert.match(text, /^version: 2$/m);
 });

--- a/tests/lib/grant-audit.test.mjs
+++ b/tests/lib/grant-audit.test.mjs
@@ -1,0 +1,44 @@
+// tests/lib/grant-audit.test.mjs — AgentSpace #2 grant/credential audit.
+// Run: node --test tests/lib/grant-audit.test.mjs
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { classifyGrants, summarize } from '../../scripts/lib/grant-audit.mjs';
+
+test('classifyGrants: OpenRouter key present → llm ok', () => {
+  const r = classifyGrants({ openrouterKey: true, npmUser: 'u', ghUser: 'g' });
+  const llm = r.find(x => x.grant.startsWith('llm'));
+  assert.equal(llm.status, 'ok');
+  assert.match(llm.grant, /OpenRouter/);
+});
+
+test('classifyGrants: no key → critical missing', () => {
+  const r = classifyGrants({});
+  const llm = r.find(x => x.grant === 'llm provider key');
+  assert.equal(llm.status, 'missing');
+  assert.equal(llm.severity, 'critical');
+});
+
+test('classifyGrants: anthropic fallback when no openrouter', () => {
+  const r = classifyGrants({ anthropicKey: true });
+  assert.ok(r.find(x => x.grant === 'llm: Anthropic' && x.status === 'ok'));
+});
+
+test('classifyGrants: orphan — provider configured but key missing', () => {
+  const r = classifyGrants({ providerConfigured: 'openrouter', anthropicKey: true });
+  const orphan = r.find(x => x.status === 'orphan');
+  assert.ok(orphan, 'should flag orphan');
+  assert.match(orphan.detail, /OpenRouter.*missing/i);
+});
+
+test('classifyGrants: npm + gh missing → med findings', () => {
+  const r = classifyGrants({ openrouterKey: true });
+  assert.equal(r.find(x => x.grant === 'npm auth').status, 'missing');
+  assert.equal(r.find(x => x.grant === 'github auth').status, 'missing');
+});
+
+test('summarize: counts ok/missing/orphan/critical', () => {
+  const s = summarize(classifyGrants({ providerConfigured: 'openrouter' }));
+  assert.equal(s.critical, 1);   // no key at all
+  assert.ok(s.missing >= 1);
+});

--- a/tests/lib/harness-router.test.mjs
+++ b/tests/lib/harness-router.test.mjs
@@ -1,0 +1,51 @@
+// tests/lib/harness-router.test.mjs — AgentSpace #1 harness detection + capabilities.
+// Run: node --test tests/lib/harness-router.test.mjs
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { HARNESSES, detectHarness, capabilities, hasCapability } from '../../scripts/lib/harness-router.mjs';
+
+test('detectHarness: Claude Code from CLAUDECODE env', () => {
+  assert.equal(detectHarness({ CLAUDECODE: '1' }), 'claude-code');
+});
+
+test('detectHarness: Codex from CODEX_HOME', () => {
+  assert.equal(detectHarness({ CODEX_HOME: '/x' }), 'codex');
+});
+
+test('detectHarness: GREAT_CTO_HARNESS override wins', () => {
+  assert.equal(detectHarness({ CLAUDECODE: '1', GREAT_CTO_HARNESS: 'opencode' }), 'opencode');
+});
+
+test('detectHarness: bad override ignored, falls through to signals', () => {
+  assert.equal(detectHarness({ CLAUDECODE: '1', GREAT_CTO_HARNESS: 'nonsense' }), 'claude-code');
+});
+
+test('detectHarness: nothing → unknown', () => {
+  assert.equal(detectHarness({}), 'unknown');
+});
+
+test('capabilities: claude-code has hooks+subagents; codex does not', () => {
+  assert.equal(capabilities('claude-code').hooks, true);
+  assert.equal(capabilities('claude-code').subagents, true);
+  assert.equal(capabilities('codex').hooks, false);
+  assert.equal(capabilities('codex').subagents, false);
+});
+
+test('capabilities: unknown harness → null', () => {
+  assert.equal(capabilities('unknown'), null);
+});
+
+test('hasCapability: degrade-safe — unknown harness/cap → false', () => {
+  assert.equal(hasCapability('claude-code', 'mcp'), true);
+  assert.equal(hasCapability('codex', 'hooks'), false);
+  assert.equal(hasCapability('unknown', 'hooks'), false);
+  assert.equal(hasCapability('claude-code', 'nonexistent'), false);
+});
+
+test('HARNESSES registry is frozen + every entry has caps', () => {
+  assert.ok(Object.isFrozen(HARNESSES));
+  for (const h of Object.values(HARNESSES)) {
+    assert.ok(h.name && h.cli && Array.isArray(h.envSignals) && h.capabilities);
+  }
+});


### PR DESCRIPTION
Adopts three ideas from HKUDS/AgentSpace, scoped to great_cto's lightweight design
(not its monorepo/Postgres/team stack). Plan: docs/strategy/AGENTSPACE-ADOPT.md.

- **#2 Grant/credential audit** — `scripts/lib/grant-audit.mjs` + `/doctor` Check 8e.
  Classifies LLM-key / npm / gh grants, flags provider↔key orphans, critical when no
  LLM key. Pure `classifyGrants()` (6 tests).
- **#4 Knowledge versioning** — `bumpGpVersion()` in `shared/gp-schema.mjs`; crystallize
  now versions a GP + appends a Version-history entry on re-crystallize instead of
  silently overwriting (+3 tests, node-glue verified).
- **#1 Harness router (slice)** — `scripts/lib/harness-router.mjs`: `detectHarness()` +
  capability registry (claude-code/codex/opencode) so great_cto degrades safely off
  Claude Code (hooks/subagents are CC-specific). ADR-006; full cross-harness execution
  deferred (9 tests).

Explicitly NOT adopted: the monorepo/Postgres/daemon, DB-backed agents, team features.

## Test plan
- [x] `scripts/ci-local.sh` — ALL GATES GREEN (Node 22 / macOS)
- [x] grant-audit / gp-schema / harness-router unit tests green
- CI note: GitHub Actions is account-disabled (billing); gated locally via ci-local.