### PR TITLE
architect-loop delta — cross-model review (R3) + stall-triage (R9)

### DIFF
--- a/agents/code-reviewer.md
+++ b/agents/code-reviewer.md
@@ -65,6 +65,27 @@ lists negatives is miscalibrated. Distinguish:
 A speculative risk with no exploit/repro path shown in the diff is an Observation,
 not a Finding.
 
+## Fresh-context, cross-model pass (architect-loop R3)
+
+You review in a **fresh context**, separate from the builder's session — never grade
+work in the same breath it was written; read the diff directly, not the builder's
+narration of it.
+
+For **high-stakes** changes (anything touching a P0 surface: auth, payments, data
+migrations, prod config, or an explicit `--xmodel` request), add a **cross-model
+red-team** — a different model family catches what same-model review misses:
+
+```bash
+git diff "$(git merge-base HEAD origin/main)"...HEAD | \
+  node scripts/lib/cross-model-review.mjs --diff - --spec docs/architecture/ARCH-<slug>.md
+```
+
+It returns `file:line | severity | issue` findings from a non-Claude model
+(default `openai/gpt-5`, needs `OPENROUTER_API_KEY`). **Merge** its P0/P1 findings
+with your own (dedup by file:line); a cross-model P0 BLOCKS gate:code just like
+yours. If `OPENROUTER_API_KEY` is absent, note the cross-model pass was skipped —
+don't silently drop it.
+
 ## Output
 
 1. For each P0/P1 Finding, file a Beads bug:

--- a/scripts/lib/cross-model-review.mjs
+++ b/scripts/lib/cross-model-review.mjs
@@ -1,0 +1,102 @@
+// scripts/lib/cross-model-review.mjs — cross-model adversarial review (architect-loop R3).
+//
+// great_cto's reviews are Claude-on-Claude → same-model blind spots. This red-teams
+// the diff with a DIFFERENT model via OpenRouter (default openai/gpt-5), flagging
+// ONLY correctness / requirement / invariant gaps with file:line — no style. The
+// code-reviewer agent merges these with its own findings for high-stakes changes.
+//
+// Pure (buildReviewPrompt / parseFindings / pickReviewerModel) is unit-tested with
+// no network; the CLI does the live OpenRouter call.
+//
+// Usage:
+//   git diff main...HEAD | node scripts/lib/cross-model-review.mjs --diff -
+//   node scripts/lib/cross-model-review.mjs --diff /tmp/d.diff --spec docs/architecture/ARCH-x.md
+//   GREAT_CTO_CROSS_REVIEW_MODEL=google/gemini-2.5-pro node ... --diff -
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { costForUsage, round4 } from './cost-meter.mjs';
+
+const OPENROUTER_API = 'https://openrouter.ai/api/v1/chat/completions';
+
+/** A genuinely non-Claude reviewer model (cross-model). Override via env. */
+export function pickReviewerModel(env = process.env) {
+  return env.GREAT_CTO_CROSS_REVIEW_MODEL || 'openai/gpt-5';
+}
+
+/** Build the red-team prompt. Calibrated: correctness/invariant only, file:line, no style. */
+export function buildReviewPrompt({ diff, spec }) {
+  const system =
+    'You are an adversarial code reviewer from a DIFFERENT model family than the author. ' +
+    'Your job is to catch what a same-model reviewer would miss. Review ONLY for: ' +
+    'correctness bugs, violated requirements, broken invariants, security holes, data loss. ' +
+    'Do NOT report style, naming, or preferences. Ground every finding in the diff with file:line. ' +
+    'Default to silence over a weak finding. ' +
+    'Output ONE finding per line in EXACTLY this format:\n' +
+    '<file>:<line> | <P0|P1|P2> | <one-sentence concrete issue>\n' +
+    'P0 = data loss / security / broken build or prod path. ' +
+    'After the findings, output a final line: VERDICT: BLOCK (if any P0) or VERDICT: PASS.';
+  const user =
+    (spec ? `Spec / intent:\n${spec}\n\n` : '') +
+    `Diff under review:\n${diff}\n\n` +
+    `Report findings (file:line | severity | issue), then VERDICT:`;
+  return { system, user };
+}
+
+/** Parse the model's findings + verdict. */
+export function parseFindings(text) {
+  const findings = [];
+  let verdict = null;
+  for (const raw of String(text).split('\n')) {
+    const line = raw.trim();
+    const v = line.match(/^VERDICT:\s*(BLOCK|PASS)/i);
+    if (v) { verdict = v[1].toUpperCase(); continue; }
+    // <file>:<line> | <SEV> | <issue>
+    const m = line.match(/^(.+?):(\d+)\s*\|\s*(P[012])\s*\|\s*(.+)$/i);
+    if (m) findings.push({ file: m[1].trim(), line: parseInt(m[2], 10), severity: m[3].toUpperCase(), issue: m[4].trim() });
+  }
+  // Derive verdict if the model omitted it: any P0 → BLOCK.
+  if (!verdict) verdict = findings.some(f => f.severity === 'P0') ? 'BLOCK' : 'PASS';
+  return { findings, verdict };
+}
+
+// ── CLI ───────────────────────────────────────────────────────────────────────
+
+async function callOpenRouter({ apiKey, model, system, user }) {
+  const res = await fetch(OPENROUTER_API, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${apiKey}`, 'HTTP-Referer': 'https://greatcto.systems', 'X-Title': 'great_cto-xmodel-review', 'content-type': 'application/json' },
+    body: JSON.stringify({ model, max_tokens: 1200, temperature: 0, messages: [{ role: 'system', content: system }, { role: 'user', content: user }] }),
+  });
+  if (!res.ok) throw new Error(`OpenRouter ${res.status}: ${(await res.text()).slice(0, 200)}`);
+  const data = await res.json();
+  const u = data.usage || null;
+  return { text: data.choices?.[0]?.message?.content?.trim() || '', usage: u ? { input_tokens: u.prompt_tokens ?? 0, output_tokens: u.completion_tokens ?? 0 } : null, model };
+}
+
+function readArg(argv, name) { const i = argv.indexOf(name); return i > -1 ? argv[i + 1] : null; }
+
+async function main(argv) {
+  const diffPath = readArg(argv, '--diff');
+  if (!diffPath) { console.error('Usage: cross-model-review.mjs --diff <file|-> [--spec <file>] [--model <slug>]'); process.exit(2); }
+  const apiKey = process.env.OPENROUTER_API_KEY;
+  if (!apiKey) { console.error('ERROR: OPENROUTER_API_KEY not set — cross-model review needs OpenRouter (a non-Claude model).'); process.exit(1); }
+
+  const diff = diffPath === '-' ? readFileSync(0, 'utf8') : readFileSync(diffPath, 'utf8');
+  if (!diff.trim()) { console.log('cross-model-review: empty diff, nothing to review.'); process.exit(0); }
+  const specFile = readArg(argv, '--spec');
+  const spec = specFile ? readFileSync(specFile, 'utf8').slice(0, 4000) : null;
+  const model = readArg(argv, '--model') || pickReviewerModel();
+
+  console.error(`cross-model-review: reviewer=${model} (cross-model red-team)`);
+  const res = await callOpenRouter({ apiKey, model, ...buildReviewPrompt({ diff: diff.slice(0, 24000), spec }) });
+  const { findings, verdict } = parseFindings(res.text);
+  const cost = round4(costForUsage({ model: res.model, usage: res.usage }));
+
+  for (const f of findings) console.log(`  ${f.severity} ${f.file}:${f.line} — ${f.issue}`);
+  console.log(`\ncross-model-review (${model}): ${findings.length} finding(s), VERDICT: ${verdict}  ($${cost})`);
+  process.exit(verdict === 'BLOCK' ? 1 : 0);
+}
+
+const isMain = process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1];
+if (isMain) main(process.argv.slice(2)).catch(e => { console.error('FATAL:', e.message); process.exit(1); });

--- a/scripts/lib/stall-triage.mjs
+++ b/scripts/lib/stall-triage.mjs
@@ -1,0 +1,62 @@
+// scripts/lib/stall-triage.mjs — liveness / stall triage for parallel lanes
+// (architect-loop R9, first slice). When the coordinator dispatches parallel
+// builders, a silently-hung lane blocks the whole loop. This flags lanes that have
+// produced no output past a threshold and orders the response "kill narrowest
+// first" — recover the stall without sacrificing the big productive lanes.
+//
+// SCOPE: a decision helper over lane state {id, lastOutputMs, filesChanged}. It does
+// not kill processes itself (Claude Code's Task tool owns lifecycle); it tells the
+// coordinator what's stalled and what to kill first.
+//
+// Usage:
+//   node scripts/lib/stall-triage.mjs --state lanes.json [--threshold-sec 180]
+//   (lanes.json: [{"id":"lane-a","lastOutputMs":1700000000000,"filesChanged":1}])
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+/** A lane is stalled if it produced no output within thresholdMs of `now`. */
+export function isStalled(lastOutputMs, now, thresholdMs) {
+  if (!Number.isFinite(lastOutputMs)) return true; // never produced output → stalled
+  return (now - lastOutputMs) > thresholdMs;
+}
+
+/**
+ * Triage lanes. Returns the stalled ones ordered "narrowest first" (fewest
+ * filesChanged → smallest blast radius → kill first), so recovery sacrifices the
+ * least work.
+ * @returns {{stalled:Array, killOrder:Array}}
+ */
+export function triage(lanes, now, thresholdMs) {
+  const stalled = (lanes || [])
+    .filter(l => isStalled(l.lastOutputMs, now, thresholdMs))
+    .map(l => ({ ...l, idleMs: Number.isFinite(l.lastOutputMs) ? now - l.lastOutputMs : Infinity }));
+  // narrowest first: ascending scope, ties broken by longest idle
+  const killOrder = [...stalled].sort((a, b) =>
+    (a.filesChanged ?? 0) - (b.filesChanged ?? 0) || (b.idleMs - a.idleMs));
+  return { stalled, killOrder };
+}
+
+// ── CLI ───────────────────────────────────────────────────────────────────────
+
+function main(argv) {
+  const get = (n) => { const i = argv.indexOf(n); return i > -1 ? argv[i + 1] : null; };
+  const state = get('--state');
+  const thresholdMs = (parseInt(get('--threshold-sec') || '180', 10)) * 1000;
+  if (!state) { console.error('Usage: stall-triage.mjs --state lanes.json [--threshold-sec 180]'); process.exit(2); }
+
+  let lanes;
+  try { lanes = JSON.parse(readFileSync(state, 'utf8')); } catch (e) { console.error(`ERROR reading ${state}: ${e.message}`); process.exit(2); }
+  const { stalled, killOrder } = triage(lanes, Date.now(), thresholdMs);
+
+  if (stalled.length === 0) { console.log(`stall-triage: all ${lanes.length} lane(s) live (threshold ${thresholdMs / 1000}s).`); process.exit(0); }
+  console.log(`stall-triage: ${stalled.length} stalled lane(s) — kill narrowest first:`);
+  for (const l of killOrder) {
+    const idle = l.idleMs === Infinity ? 'never produced output' : `idle ${Math.round(l.idleMs / 1000)}s`;
+    console.log(`  ⚠ ${l.id}  (files=${l.filesChanged ?? '?'}, ${idle})`);
+  }
+  process.exit(1);
+}
+
+const isMain = process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1];
+if (isMain) main(process.argv.slice(2));

--- a/tests/lib/cross-model-review.test.mjs
+++ b/tests/lib/cross-model-review.test.mjs
@@ -1,0 +1,52 @@
+// tests/lib/cross-model-review.test.mjs — architect-loop R3 cross-model review.
+// Run: node --test tests/lib/cross-model-review.test.mjs
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { pickReviewerModel, buildReviewPrompt, parseFindings } from '../../scripts/lib/cross-model-review.mjs';
+
+test('pickReviewerModel: defaults to a non-Claude model; env overrides', () => {
+  const def = pickReviewerModel({});
+  assert.ok(!/claude/i.test(def), 'default reviewer must NOT be Claude (cross-model)');
+  assert.equal(pickReviewerModel({ GREAT_CTO_CROSS_REVIEW_MODEL: 'google/gemini-2.5-pro' }), 'google/gemini-2.5-pro');
+});
+
+test('buildReviewPrompt: red-team system, file:line format, no-style instruction', () => {
+  const { system, user } = buildReviewPrompt({ diff: 'DIFF', spec: 'SPEC' });
+  assert.match(system, /correctness/i);
+  assert.match(system, /file:line/i);
+  assert.match(system, /do NOT report style/i);
+  assert.match(user, /SPEC/);
+  assert.match(user, /DIFF/);
+});
+
+test('buildReviewPrompt: spec optional', () => {
+  const { user } = buildReviewPrompt({ diff: 'D' });
+  assert.ok(!user.includes('Spec / intent'));
+});
+
+test('parseFindings: parses "file:line | SEV | issue" lines + verdict', () => {
+  const text = [
+    'src/pay.ts:42 | P0 | reduce on empty array throws',
+    'src/auth.ts:10 | P1 | missing await → race',
+    'noise line that is not a finding',
+    'VERDICT: BLOCK',
+  ].join('\n');
+  const { findings, verdict } = parseFindings(text);
+  assert.equal(findings.length, 2);
+  assert.equal(findings[0].file, 'src/pay.ts');
+  assert.equal(findings[0].line, 42);
+  assert.equal(findings[0].severity, 'P0');
+  assert.equal(verdict, 'BLOCK');
+});
+
+test('parseFindings: derives BLOCK from a P0 when VERDICT line absent', () => {
+  const { verdict } = parseFindings('a.ts:1 | P0 | boom');
+  assert.equal(verdict, 'BLOCK');
+});
+
+test('parseFindings: no findings, no verdict → PASS', () => {
+  const { findings, verdict } = parseFindings('looks clean to me');
+  assert.equal(findings.length, 0);
+  assert.equal(verdict, 'PASS');
+});

--- a/tests/lib/stall-triage.test.mjs
+++ b/tests/lib/stall-triage.test.mjs
@@ -1,0 +1,42 @@
+// tests/lib/stall-triage.test.mjs — architect-loop R9 stall triage (slice).
+// Run: node --test tests/lib/stall-triage.test.mjs
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { isStalled, triage } from '../../scripts/lib/stall-triage.mjs';
+
+const NOW = 1_000_000_000_000;
+
+test('isStalled: fresh output → live; old → stalled; never → stalled', () => {
+  assert.equal(isStalled(NOW - 10_000, NOW, 60_000), false);
+  assert.equal(isStalled(NOW - 120_000, NOW, 60_000), true);
+  assert.equal(isStalled(undefined, NOW, 60_000), true);
+  assert.equal(isStalled(NaN, NOW, 60_000), true);
+});
+
+test('triage: flags only stalled lanes', () => {
+  const lanes = [
+    { id: 'a', lastOutputMs: NOW - 5_000, filesChanged: 3 },     // live
+    { id: 'b', lastOutputMs: NOW - 300_000, filesChanged: 1 },   // stalled
+  ];
+  const { stalled } = triage(lanes, NOW, 180_000);
+  assert.equal(stalled.length, 1);
+  assert.equal(stalled[0].id, 'b');
+});
+
+test('triage: kill narrowest first (fewest files), ties by longest idle', () => {
+  const lanes = [
+    { id: 'big', lastOutputMs: NOW - 400_000, filesChanged: 9 },
+    { id: 'narrow', lastOutputMs: NOW - 200_000, filesChanged: 1 },
+    { id: 'never', lastOutputMs: undefined, filesChanged: 1 },
+  ];
+  const { killOrder } = triage(lanes, NOW, 180_000);
+  // both narrow(1) and never(1) before big(9); never has Infinity idle → first
+  assert.deepEqual(killOrder.map(l => l.id), ['never', 'narrow', 'big']);
+});
+
+test('triage: nothing stalled → empty', () => {
+  const { stalled, killOrder } = triage([{ id: 'a', lastOutputMs: NOW, filesChanged: 2 }], NOW, 60_000);
+  assert.equal(stalled.length, 0);
+  assert.equal(killOrder.length, 0);
+});


### PR DESCRIPTION
great_cto had already absorbed most of architect-loop (R2 frozen gates, R5 argue-with-spec, R6 IMPL-BRIEF, R7/R8 worktree+orchestrated parallelism, R10 claims-are-hearsay, R11 triage gate). This adds the genuine deltas:

- **R3 cross-model adversarial review** — `scripts/lib/cross-model-review.mjs` red-teams the diff with a non-Claude model via OpenRouter (default `openai/gpt-5`), correctness/invariant only, file:line, no style. Wired into `code-reviewer` for high-stakes changes; cross-model P0s merge in and can BLOCK gate:code. Fixes our Claude-on-Claude same-model blind spot. Also codifies R3 fresh-context review (judge in a separate session, read the diff).
- **R9 stall-triage (slice)** — `scripts/lib/stall-triage.mjs` flags stalled parallel lanes and orders "kill narrowest first".

Not (re)taken: R2/R5/R6/R7/R8/R10/R11 (already in great_cto); full liveness process-killing (Task tool owns lifecycle); R12 (philosophy).

## Test plan
- [x] `scripts/ci-local.sh` ALL GATES GREEN (Node 22 / macOS); 10 new unit tests
- CI note: GitHub Actions account-disabled (billing); gated locally.