### PR TITLE
v2.76.0 — context-discipline + ship AgentSpace & architect-loop adoptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to great_cto are documented here.
 
 ---
 
+## v2.76.0 — 2026-06-28
+
+### Adopted ideas from AgentSpace + architect-loop (ideas, not the stacks)
+
+- **Grant/credential audit** (`/doctor` Check 8e, `scripts/lib/grant-audit.mjs`) —
+  LLM-key / npm / gh auth + provider↔key orphan detection; critical when no LLM key.
+- **Knowledge versioning** — `bumpGpVersion()`; crystallize versions a global pattern
+  + appends a Version-history entry on re-crystallize instead of overwriting.
+- **Harness router (slice)** — `scripts/lib/harness-router.mjs` detects the current
+  harness (Claude Code / Codex / OpenCode) + capability registry, so great_cto
+  degrades safely off Claude Code (hooks/subagents are CC-specific). ADR-006.
+- **Cross-model adversarial review** (architect-loop R3) —
+  `scripts/lib/cross-model-review.mjs` red-teams the diff with a non-Claude model via
+  OpenRouter (default `openai/gpt-5`); wired into `code-reviewer` for high-stakes
+  changes — fixes the Claude-on-Claude same-model blind spot. + fresh-context review.
+- **Stall-triage (slice)** (architect-loop R9) — `scripts/lib/stall-triage.mjs` flags
+  hung parallel lanes, "kill narrowest first".
+- **Context discipline** — `references/context-discipline.md` (loaded by coordinator):
+  isolate reads in subagents, compact with intent, rewind over correct, respect the
+  ~40% dumb-zone / context-rot budget.
+
 ## v2.75.0 — 2026-06-28
 
 ### DEEPEN — make the self-improvement pipeline real (not just declared)

--- a/agents/coordinator.md
+++ b/agents/coordinator.md
@@ -122,6 +122,9 @@ Rules:
 - Spawn → always specify `subagent_type:` from the routing table
 - Don't peek mid-flight: do not query a background agent before it finishes
 - Don't race: if two spawned agents could modify the same Beads task, serialize them
+- **Protect the window** — isolate file reads / greps / dead-end exploration in
+  Fork'd subagents so only conclusions return to you; keep your own context out of the
+  dumb zone. See `skills/great_cto/references/context-discipline.md`.
 
 ### Phase 4 — MONITOR
 

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "great-cto",
-  "version": "2.75.0",
+  "version": "2.76.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "great-cto",
-      "version": "2.75.0",
+      "version": "2.76.0",
       "funding": [
         {
           "type": "github",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "great-cto",
-  "version": "2.75.0",
+  "version": "2.76.0",
   "description": "One command install for the great_cto Claude Code plugin. Auto-detects your stack, picks the right archetype, bootstraps PROJECT.md.",
   "keywords": [
     "claude-code",

--- a/skills/great_cto/references/context-discipline.md
+++ b/skills/great_cto/references/context-discipline.md
@@ -1,0 +1,38 @@
+# Context discipline — keep the working window sharp
+
+> Source: community Claude Code best-practice (Boris Cherny / Dex / Thariq) + Anthropic
+> long-context guidance. Loaded by `coordinator` (and any agent running long/parallel work).
+
+Model intelligence degrades as the context fills — long before the hard limit. great_cto
+already isolates via subagents; this codifies *when* and *how* to protect the window so
+long runs don't quietly get dumber.
+
+## The budget
+
+- **Dumb zone ≈ 40%.** Quality starts slipping past ~40% of the window; experienced
+  operators keep sensitive work under ~30%. Treat 40% as a soft ceiling, not the limit.
+- **Rot threshold ≈ 300–400k tokens** even on a 1M-token model — don't drift past it for
+  work that must be correct (architecture, migrations, security review).
+
+## Rules for agents & the coordinator
+
+1. **Isolate reads in subagents.** File reads, greps, broad codebase sweeps, and dead-end
+   exploration go to a child agent — only the *conclusion* returns to the parent. This is the
+   single biggest lever; great_cto's `Explore`/subagent pattern exists for exactly this.
+2. **Compact with intent, not on autopilot.** Prefer `/compact <hint>` (name what to keep —
+   the task, the decision, the open gate) over silent auto-compaction, which discards
+   unpredictably. Write a "summarize from here" handoff note before compacting.
+3. **Rewind over correct.** When an attempt goes wrong, `/rewind` (or double-Esc) to the last
+   good point instead of pouring corrections into the window — corrections cost context and
+   leave the failed path as noise.
+4. **New task → new session.** Genuinely new work gets a fresh session; only truly related
+   work should reuse context. Long-running great_cto pipelines persist state in
+   `ARCH-{slug}.md` / `HANDOFF.md` / Beads, so a fresh session re-grounds cheaply.
+5. **Scale the window to the task.** Trivial changes don't need the full pipeline loaded
+   (mirrors the triage gate); don't pull the whole archetype pack for a one-line fix.
+
+## So-what
+
+A coordinator that respects this dispatches reads to subagents, compacts deliberately, and
+re-grounds from artifacts — instead of running a single ever-growing window into the dumb
+zone. Pairs with `phases.md` (what to load per phase) and the three-state completion contract.


### PR DESCRIPTION
Bundles the context-discipline reference (best-practice adoption, wired into coordinator) and cuts **v2.76.0**, releasing the AgentSpace (#111) + architect-loop (#112) work to npm. ci-local ALL GREEN. CI note: GitHub Actions account-disabled (billing); gated locally.