### PR TITLE
Deepen quality #1+#2 — executed-quality harness + deploy gate

### DIFF
--- a/agents/devops.md
+++ b/agents/devops.md
@@ -103,6 +103,16 @@ Show deploy plan: archetype-based deploy method, environment vars required, roll
 **Checkpoint B — BEFORE production deploy** (after step 6 staging validation, before production push):
 Show staging results: smoke test pass/fail, perf metrics vs baseline, critical paths verified. CTO approves → push to prod with canary. Comments → debug on staging first → re-checkpoint.
 
+**Quality gate (mandatory, before Checkpoint B).** Run the executed-quality gate on
+the built product — it RUNS the tests/typecheck/lint/audit/secret-scan, not just
+checks they exist:
+```bash
+node scripts/lib/product-eval.mjs <product-dir> --gate --min 70 --baseline docs/quality/SCORE-<slug>.json
+```
+A sub-threshold score **or a regression vs the last baseline** exits non-zero → do
+NOT proceed to the production push (`gate:quality` BLOCK). This makes product quality
+a measured deploy gate, not a report. See `docs/strategy/QUALITY-DEEPEN.md`.
+
 **Checkpoint C — AFTER production deploy** (after canary complete, before handing off to l3-support):
 Show deploy outcome: version deployed, canary metrics (error rate, p95), rollback readiness. CTO approves → hand off to l3-support monitoring. Comments → investigate → consider rollback.
 

--- a/docs/strategy/QUALITY-DEEPEN.md
+++ b/docs/strategy/QUALITY-DEEPEN.md
@@ -1,0 +1,42 @@
+# Deepen product/pipeline quality — from presence floor to executed ceiling
+
+> Status: active · Created 2026-06-29 · Builds on the product-quality harness (89/100 floor)
+
+`product-score.mjs` measures the **presence** of quality machinery (a floor: 89/100).
+The honest gap: presence ≠ excellence — it never runs anything. Deepening quality means
+moving to a **measured ceiling** (does it actually work + meet budgets) that **gates deploy**.
+
+## Axes (by leverage)
+
+| # | Axis | Floor → ceiling |
+|---|------|-----------------|
+| **1** | **Execute, not inspect** | run the product: `npm test` (pass-rate), typecheck, lint, dep-audit, secret-scan → a **measured** execution score. (browser axe/Lighthouse = follow-up) |
+| **2** | **Quality as a blocking gate** | score < threshold or regression vs baseline → block deploy (S6/S7); not a report |
+| **3** | Per-archetype quality contracts | domain tests: escrow-idempotency, entitlement-bypass, double-booking, aggregation-correctness |
+| **4** | Actor-fidelity | tool-using eval actor → learning loop actually improves agents → quality compounds |
+| **5** | Quality trend / regression corpus | per-product SCORE → `metrics-trend`; golden known-bad builds that must be caught |
+| **6** | UX/visual depth | visual-regression + axe + Web Vitals on the generated app |
+
+## This PR — #1 + #2
+
+- `scripts/lib/product-eval.mjs` — **executes** checks in a product dir (`npm test`,
+  typecheck, lint, `npm audit`, secret-scan) → pure `scoreExecution()` (weighted 0–100) +
+  `runEval(dir)`. Complements the static `product-score` (floor) with a **measured** ceiling.
+- **Gate mode** — `--gate --min N [--baseline f]`: exit non-zero on sub-threshold or regression.
+- Run on the generated fleet (A1–A6) for **measured** numbers (tests actually executed).
+
+Browser-based a11y/perf (axe, Lighthouse) and per-archetype contracts (#3) are follow-ups —
+they need a running preview + Playwright. #1 here is the deterministic, Node-only core.
+
+## Empirical (executed) result
+
+Ran `product-eval` on the 6 generated fleet products — it executed `npm test` in each:
+
+| | floor (presence) | **ceiling (executed)** |
+|--|------------------|------------------------|
+| Fleet | 89/100 | **100/100** — tests ran + passed (13/13 … 23/23), secrets clean |
+
+Note: these minimal zero-dep products have no TS/lint/lockfile → typecheck/lint/audit
+score n/a (full credit). A richer product exercises those dims for real. The point:
+quality is now **measured by execution + gateable** (`--gate`, wired into devops Checkpoint B),
+not just inspected. Floor (shape) + ceiling (works) together.

--- a/scripts/lib/product-eval.mjs
+++ b/scripts/lib/product-eval.mjs
@@ -1,0 +1,161 @@
+// scripts/lib/product-eval.mjs — EXECUTED product quality (the ceiling).
+//
+// product-score.mjs measures the *presence* of quality machinery (a floor). This
+// EXECUTES it: runs the product's tests, typecheck, lint, dependency audit and a
+// secret scan, and turns the real results into a measured 0-100 score. Presence ≠
+// excellence — this is "does it actually work + is it clean", not "does it have the shape".
+//
+// Pure scoreExecution(results) is unit-tested; runEval(dir) spawns the real commands.
+//
+// Usage:
+//   node scripts/lib/product-eval.mjs <product-dir> [--json]
+//   node scripts/lib/product-eval.mjs <dir> --gate --min 70 [--baseline prev.json]   # exit 1 if below/regressed
+
+import { readFileSync, readdirSync, existsSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+/** Weights sum to 100. n/a dimensions score full (nothing to fail) so a zero-dep
+ *  .mjs product isn't punished for lacking a tsconfig/lint/lockfile. */
+export const EXEC_RUBRIC = Object.freeze([
+  { key: 'tests',     weight: 45, label: 'Tests pass (executed)' },
+  { key: 'typecheck', weight: 15, label: 'Typecheck clean' },
+  { key: 'lint',      weight: 10, label: 'Lint clean' },
+  { key: 'deps',      weight: 15, label: 'No high/critical vulns' },
+  { key: 'secrets',   weight: 15, label: 'No leaked secrets' },
+]);
+
+/**
+ * Pure. results: { tests:{ran,passed,total,failed}, typecheck:'pass'|'fail'|'na',
+ * lint:'pass'|'fail'|'na', auditHigh:number|null, secretLeak:boolean }
+ * @returns {{total,grade,breakdown}}
+ */
+export function scoreExecution(results = {}) {
+  const sig = {};
+  const t = results.tests || {};
+  sig.tests = !t.ran ? 0 : (t.total > 0 ? (t.total - (t.failed || 0)) / t.total : 0);
+  sig.typecheck = results.typecheck === 'fail' ? 0 : 1;   // pass | na → 1
+  sig.lint = results.lint === 'fail' ? 0 : 1;             // pass | na → 1
+  sig.deps = results.auditHigh == null ? 1 : (results.auditHigh === 0 ? 1 : Math.max(0, 1 - results.auditHigh * 0.34));
+  sig.secrets = results.secretLeak ? 0 : 1;
+
+  const breakdown = EXEC_RUBRIC.map(d => {
+    const s = Math.max(0, Math.min(1, sig[d.key] ?? 0));
+    return { key: d.key, label: d.label, weight: d.weight, signal: round2(s), points: round2(s * d.weight) };
+  });
+  const total = Math.round(breakdown.reduce((a, b) => a + b.points, 0));
+  return { total, grade: grade(total), breakdown };
+}
+
+function round2(n) { return Math.round(n * 100) / 100; }
+function grade(t) { return t >= 90 ? 'A' : t >= 75 ? 'B' : t >= 60 ? 'C' : t >= 45 ? 'D' : 'F'; }
+
+// ── execution (run the real commands in the product dir) ──────────────────────
+
+function run(cmd, args, cwd, timeout = 180000) {
+  return spawnSync(cmd, args, { cwd, encoding: 'utf8', timeout, stdio: ['ignore', 'pipe', 'pipe'] });
+}
+
+/** Parse node:test / TAP counts from stdout. */
+export function parseTestCounts(out) {
+  const grab = (re) => { const m = String(out).match(re); return m ? parseInt(m[1], 10) : null; };
+  const total = grab(/^[#ℹ]\s*tests\s+(\d+)/m);
+  const pass = grab(/^[#ℹ]\s*pass\s+(\d+)/m);
+  const fail = grab(/^[#ℹ]\s*fail\s+(\d+)/m);
+  return { total, pass, fail };
+}
+
+/** Execute checks in a product dir → results for scoreExecution. */
+export function runEval(dir) {
+  const pkgPath = join(dir, 'package.json');
+  let pkg = {};
+  try { pkg = JSON.parse(readFileSync(pkgPath, 'utf8')); } catch { /* none */ }
+  const scripts = pkg.scripts || {};
+
+  // tests — run `npm test` if a test script exists; exit code is the source of truth.
+  let tests = { ran: false, total: 0, passed: 0, failed: 0 };
+  if (scripts.test) {
+    const r = run('npm', ['test', '--silent'], dir);
+    const c = parseTestCounts((r.stdout || '') + (r.stderr || ''));
+    const total = c.total ?? 0, fail = c.fail ?? (r.status === 0 ? 0 : 1);
+    tests = { ran: true, total: total || (r.status === 0 ? 1 : 1), passed: (total || 1) - fail, failed: fail };
+    if (r.status !== 0 && fail === 0) tests.failed = 1; // exit≠0 but no count → mark a failure
+  }
+
+  // typecheck — only if a tsconfig exists
+  let typecheck = 'na';
+  if (existsSync(join(dir, 'tsconfig.json'))) {
+    const r = scripts.typecheck ? run('npm', ['run', 'typecheck', '--silent'], dir) : run('npx', ['--no-install', 'tsc', '--noEmit'], dir);
+    typecheck = r.status === 0 ? 'pass' : 'fail';
+  }
+
+  // lint — only if a lint script exists
+  let lint = 'na';
+  if (scripts.lint) { lint = run('npm', ['run', 'lint', '--silent'], dir).status === 0 ? 'pass' : 'fail'; }
+
+  // deps — npm audit only if a lockfile exists
+  let auditHigh = null;
+  if (existsSync(join(dir, 'package-lock.json'))) {
+    const r = run('npm', ['audit', '--json'], dir, 60000);
+    try { const a = JSON.parse(r.stdout || '{}'); const v = a.metadata?.vulnerabilities || {}; auditHigh = (v.high || 0) + (v.critical || 0); }
+    catch { auditHigh = null; }
+  }
+
+  // secrets — light scan over source
+  const secretLeak = scanSecrets(dir);
+
+  return { tests, typecheck, lint, auditHigh, secretLeak };
+}
+
+function scanSecrets(dir) {
+  const re = /(AKIA[0-9A-Z]{16}|sk-[a-zA-Z0-9]{20,}|-----BEGIN [A-Z ]*PRIVATE KEY|password\s*[=:]\s*['"][^'"]{6,})/;
+  const skip = new Set(['node_modules', '.git', 'dist', '.next']);
+  const stack = [dir]; let n = 0;
+  while (stack.length && n < 400) {
+    let entries; try { entries = readdirSync(stack.pop(), { withFileTypes: true }); } catch { continue; }
+    for (const e of entries) {
+      const p = join(e.path ?? dir, e.name);
+      if (e.isDirectory()) { if (!skip.has(e.name)) stack.push(p); continue; }
+      if (!/\.(ts|tsx|js|jsx|mjs|cjs|py|go|rb|env|json|ya?ml)$/.test(e.name)) continue;
+      if (/\.env\.(example|sample|template)$/.test(e.name)) continue; // placeholders ok
+      if (++n > 400) break;
+      try { if (re.test(readFileSync(p, 'utf8'))) return true; } catch { /* ignore */ }
+    }
+  }
+  return false;
+}
+
+// ── CLI ───────────────────────────────────────────────────────────────────────
+
+function main(argv) {
+  const dir = argv.find(a => !a.startsWith('--'));
+  if (!dir || !existsSync(dir) || !statSync(dir).isDirectory()) { console.error('Usage: product-eval.mjs <dir> [--json] [--gate --min N [--baseline f]]'); process.exit(2); }
+
+  const results = runEval(dir);
+  const res = scoreExecution(results);
+
+  if (argv.includes('--json')) { process.stdout.write(JSON.stringify({ dir, ...res, results }, null, 2)); }
+  else {
+    console.log(`Executed quality — ${dir}`);
+    for (const b of res.breakdown) console.log(`  ${b.label.padEnd(26)} ${'█'.repeat(Math.round(b.signal * 10)).padEnd(10, '·')} ${b.points}/${b.weight}`);
+    console.log(`  tests: ${results.tests.ran ? `${results.tests.passed}/${results.tests.total} pass` : 'no test script'} · typecheck ${results.typecheck} · lint ${results.lint} · vulns ${results.auditHigh ?? 'n/a'} · secrets ${results.secretLeak ? 'LEAK' : 'clean'}`);
+    console.log(`\n  EXECUTED SCORE: ${res.total}/100  (grade ${res.grade})`);
+  }
+
+  // gate mode (#2)
+  if (argv.includes('--gate')) {
+    const get = (n) => { const i = argv.indexOf(n); return i > -1 ? argv[i + 1] : null; };
+    const min = parseFloat(get('--min') || '70');
+    let fail = res.total < min, reason = res.total < min ? `score ${res.total} < min ${min}` : '';
+    const bl = get('--baseline');
+    if (bl && existsSync(bl)) {
+      try { const prev = JSON.parse(readFileSync(bl, 'utf8')).total; if (typeof prev === 'number' && res.total < prev - 2) { fail = true; reason = `regression ${res.total} < baseline ${prev}`; } } catch { /* ignore */ }
+    }
+    if (fail) { console.error(`\ngate:quality BLOCK — ${reason}`); process.exit(1); }
+    console.log('\ngate:quality PASS');
+  }
+}
+
+const isMain = process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1];
+if (isMain) main(process.argv.slice(2));

--- a/tests/lib/product-eval.test.mjs
+++ b/tests/lib/product-eval.test.mjs
@@ -1,0 +1,46 @@
+// tests/lib/product-eval.test.mjs — executed-quality scorer (the ceiling).
+// Run: node --test tests/lib/product-eval.test.mjs
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { EXEC_RUBRIC, scoreExecution, parseTestCounts } from '../../scripts/lib/product-eval.mjs';
+
+test('EXEC_RUBRIC weights sum to 100', () => {
+  assert.equal(EXEC_RUBRIC.reduce((a, d) => a + d.weight, 0), 100);
+});
+
+test('scoreExecution: all green (tests pass, na elsewhere, no vulns/secrets) → 100', () => {
+  const r = scoreExecution({ tests: { ran: true, total: 13, passed: 13, failed: 0 }, typecheck: 'na', lint: 'na', auditHigh: null, secretLeak: false });
+  assert.equal(r.total, 100);
+  assert.equal(r.grade, 'A');
+});
+
+test('scoreExecution: tests not run → tests dimension 0 (big hit)', () => {
+  const r = scoreExecution({ tests: { ran: false }, typecheck: 'na', lint: 'na', auditHigh: 0, secretLeak: false });
+  assert.equal(r.breakdown.find(b => b.key === 'tests').points, 0);
+  assert.equal(r.total, 55); // 100 - 45 (tests)
+});
+
+test('scoreExecution: failing tests scale by pass-rate', () => {
+  const r = scoreExecution({ tests: { ran: true, total: 10, passed: 6, failed: 4 }, typecheck: 'na', lint: 'na', auditHigh: 0, secretLeak: false });
+  // tests signal 0.6 → 27/45
+  assert.equal(r.breakdown.find(b => b.key === 'tests').points, 27);
+});
+
+test('scoreExecution: typecheck/lint fail and a secret leak drop their dims', () => {
+  const r = scoreExecution({ tests: { ran: true, total: 1, passed: 1, failed: 0 }, typecheck: 'fail', lint: 'fail', auditHigh: 0, secretLeak: true });
+  assert.equal(r.breakdown.find(b => b.key === 'typecheck').points, 0);
+  assert.equal(r.breakdown.find(b => b.key === 'lint').points, 0);
+  assert.equal(r.breakdown.find(b => b.key === 'secrets').points, 0);
+});
+
+test('scoreExecution: high vulns scale deps down', () => {
+  assert.equal(scoreExecution({ auditHigh: 1, tests: { ran: true, total: 1, passed: 1 }, typecheck: 'na', lint: 'na' }).breakdown.find(b => b.key === 'deps').signal, 0.66);
+  assert.equal(scoreExecution({ auditHigh: 3, tests: { ran: true, total: 1, passed: 1 }, typecheck: 'na', lint: 'na' }).breakdown.find(b => b.key === 'deps').signal, 0);
+});
+
+test('parseTestCounts: node:test spec + TAP forms', () => {
+  assert.deepEqual(parseTestCounts('ℹ tests 13\nℹ pass 13\nℹ fail 0'), { total: 13, pass: 13, fail: 0 });
+  assert.deepEqual(parseTestCounts('# tests 5\n# pass 4\n# fail 1'), { total: 5, pass: 4, fail: 1 });
+  assert.deepEqual(parseTestCounts('no counts here'), { total: null, pass: null, fail: null });
+});


### PR DESCRIPTION
Moves quality from a presence *floor* to an executed *ceiling* that gates deploy.

- **product-eval.mjs** — EXECUTES the product (npm test pass-rate, typecheck, lint, npm audit, secret scan) → measured 0-100. Complements static product-score (floor).
- **Gate mode** — `--gate --min N --baseline f` blocks on sub-threshold or regression; wired into **devops Checkpoint B** (before prod push) → `gate:quality`.
- **Empirical**: ran on the 6 generated fleet products → executed **100/100** (tests really run + pass 13/13…23/23, secrets clean). Floor 89 + ceiling 100 now both measured.

Honest scope: minimal products score typecheck/lint/audit as n/a (no TS/lint/lockfile) → full credit; richer products exercise them. Browser a11y/perf + per-archetype contracts are follow-ups (#3-6). 7 unit tests; ci-local ALL GREEN.