### PR TITLE
fix: bundle board server into npm package + scan all plugin marketplaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,4 @@ site/.previews/
 tmp/
 .great_cto/autopilot-runs/
 tests/eval/security/results.tsv
+packages/cli/board/

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -70,6 +70,7 @@
     "index.mjs",
     "dist/",
     "assets/",
+    "board/",
     "postinstall.mjs",
     "README.md",
     "scripts/hooks/"
@@ -80,6 +81,7 @@
     "test": "npm run build && node --test tests/*.test.mjs tests/**/*.test.mjs",
     "test:e2e": "npm run build && node ../../tests/run-archetype-e2e.mjs",
     "postinstall": "node postinstall.mjs",
+    "prepack": "node scripts/bundle-board.mjs",
     "prepublishOnly": "npm run build"
   },
   "devDependencies": {

--- a/packages/cli/scripts/bundle-board.mjs
+++ b/packages/cli/scripts/bundle-board.mjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+// Bundle the board server into the npm package (runs on `npm pack` / `npm publish`
+// via the "prepack" script). Without this, `npx great-cto board` only works when
+// the great_cto plugin happens to be in ~/.claude/plugins/cache — a fresh npm
+// install had no board at all (great_cto-hbu3).
+//
+// The bundle mirrors the repo-root layout under packages/cli/board/ because the
+// board resolves its imports relative to that structure:
+//   packages/board/lib/projects.mjs → ../../../scripts/lib/gate-plan.mjs
+//   scripts/lib/gate-plan.mjs       → ../../packages/cli/dist/archetypes.js
+//   packages/board/lib/config.mjs   → ../../../.claude-plugin/plugin.json (version badge)
+import { cpSync, mkdirSync, rmSync, existsSync, copyFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url)); // packages/cli/scripts
+const cliRoot = join(here, "..");                     // packages/cli
+const repoRoot = join(cliRoot, "..", "..");           // repo root
+const out = join(cliRoot, "board");
+
+const boardSrc = join(repoRoot, "packages", "board");
+if (!existsSync(join(boardSrc, "server.mjs"))) {
+  // Packing from a published tarball (no repo around) — keep whatever is there.
+  if (existsSync(join(out, "packages", "board", "server.mjs"))) {
+    console.log("bundle-board: repo sources absent, keeping existing bundle");
+    process.exit(0);
+  }
+  console.error("bundle-board: packages/board/server.mjs not found — run from the repo");
+  process.exit(1);
+}
+
+rmSync(out, { recursive: true, force: true });
+
+// board runtime (skip tests, the cloudflare worker, and stray tarballs)
+const skip = /(\.test\.mjs$|cloudflare-worker|\.tgz$)/;
+cpSync(boardSrc, join(out, "packages", "board"), {
+  recursive: true,
+  filter: (src) => !skip.test(src),
+});
+
+// shared scripts the board imports at runtime
+mkdirSync(join(out, "scripts", "lib"), { recursive: true });
+for (const f of ["gate-plan.mjs", "change-tier.mjs", "judge-model.mjs"]) {
+  copyFileSync(join(repoRoot, "scripts", "lib", f), join(out, "scripts", "lib", f));
+}
+
+// gate-plan.mjs → ../../packages/cli/dist/archetypes.js
+mkdirSync(join(out, "packages", "cli", "dist"), { recursive: true });
+copyFileSync(
+  join(cliRoot, "dist", "archetypes.js"),
+  join(out, "packages", "cli", "dist", "archetypes.js"),
+);
+
+// version badge source for the board UI
+mkdirSync(join(out, ".claude-plugin"), { recursive: true });
+copyFileSync(
+  join(repoRoot, ".claude-plugin", "plugin.json"),
+  join(out, ".claude-plugin", "plugin.json"),
+);
+
+console.log("bundle-board: board bundled into packages/cli/board/");

--- a/packages/cli/src/board-path.ts
+++ b/packages/cli/src/board-path.ts
@@ -1,0 +1,50 @@
+// Board server resolution — extracted from main.ts so it is unit-testable
+// (main.ts self-executes on import). See great_cto-hbu3.
+import { existsSync as fsExistsSync, readdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Locate the board server.mjs. Order:
+ *   1. dev layouts (running from a repo checkout)
+ *   2. installed plugin cache — ANY marketplace under ~/.claude/plugins/cache,
+ *      newest 5 versions each (not just the "local" marketplace)
+ *   3. the copy bundled into the npm package by scripts/bundle-board.mjs —
+ *      guaranteed fallback so a fresh `npm i -g great-cto` can run the board
+ *      without the plugin installed
+ */
+export function findBoardServerPath(baseDir?: string, home?: string): string | undefined {
+  const here = baseDir ?? dirname(fileURLToPath(import.meta.url));
+  const candidates: string[] = [
+    join(here, "..", "..", "board", "server.mjs"),  // packages/cli/dist (dev)
+    join(here, "..", "board", "server.mjs"),         // alt dev layout
+    join(here, "board", "server.mjs"),               // flat layout
+  ];
+
+  // Numeric semver sort — a plain .sort() is lexicographic and would rank
+  // 2.99.0 above 2.100.0 (and once ranked 2.7.0 above 2.69.0).
+  const byVer = (a: string, b: string) => {
+    const pa = a.split(".").map(Number), pb = b.split(".").map(Number);
+    return (pb[0]! - pa[0]!) || (pb[1]! - pa[1]!) || (pb[2]! - pa[2]!) || 0;
+  };
+
+  const cacheRoot = join(home ?? homedir(), ".claude", "plugins", "cache");
+  if (fsExistsSync(cacheRoot)) {
+    try {
+      for (const marketplace of readdirSync(cacheRoot)) {
+        const pluginBase = join(cacheRoot, marketplace, "great_cto");
+        if (!fsExistsSync(pluginBase)) continue;
+        const versions = readdirSync(pluginBase).filter(v => /^\d/.test(v)).sort(byVer);
+        for (const v of versions.slice(0, 5)) {
+          candidates.push(join(pluginBase, v, "packages", "board", "server.mjs"));
+        }
+      }
+    } catch { /* ignore */ }
+  }
+
+  // bundled copy (dist → ../board/packages/board/server.mjs)
+  candidates.push(join(here, "..", "board", "packages", "board", "server.mjs"));
+
+  return candidates.find(fsExistsSync);
+}

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -22,6 +22,7 @@ import { bootstrap } from "./bootstrap.js";
 import { compileFlow } from "./flow.js";
 import { shouldUseLlmFallback, suggestArchetypeFromLlm } from "./llm-fallback.js";
 import { sendUsagePing, sendInstallPing, telemetrySubcommand, isTelemetryEnabled, computeAnonId } from "./telemetry.js";
+import { findBoardServerPath } from "./board-path.js";
 import { readFileSync, writeFileSync, copyFileSync, chmodSync, mkdirSync, readdirSync, unlinkSync, existsSync as fsExistsSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -200,35 +201,6 @@ function boardPidFilePath(surface?: "console"): string {
 }
 
 /**
- * Locate the board server.mjs — checks dev layouts then plugin cache versions
- * in descending order, returning the first path that exists.
- */
-function findBoardServerPath(): string | undefined {
-  const here = dirname(fileURLToPath(import.meta.url));
-  const candidates: string[] = [
-    join(here, "..", "..", "board", "server.mjs"),  // packages/cli/dist (dev)
-    join(here, "..", "board", "server.mjs"),         // alt dev layout
-    join(here, "board", "server.mjs"),               // flat layout
-  ];
-  const pluginBase = join(homedir(), ".claude", "plugins", "cache", "local", "great_cto");
-  if (fsExistsSync(pluginBase)) {
-    try {
-      // Numeric semver sort — a plain .sort() is lexicographic and would rank
-      // 2.99.0 above 2.100.0 (and once ranked 2.7.0 above 2.69.0).
-      const byVer = (a: string, b: string) => {
-        const pa = a.split(".").map(Number), pb = b.split(".").map(Number);
-        return (pb[0]! - pa[0]!) || (pb[1]! - pa[1]!) || (pb[2]! - pa[2]!) || 0;
-      };
-      const versions = readdirSync(pluginBase).filter(v => /^\d/.test(v)).sort(byVer);
-      for (const v of versions.slice(0, 5)) {
-        candidates.push(join(pluginBase, v, "packages", "board", "server.mjs"));
-      }
-    } catch { /* ignore */ }
-  }
-  return candidates.find(fsExistsSync);
-}
-
-/**
  * Kill the board server recorded in the PID file.
  * Returns true if a live process was terminated.
  */
@@ -311,7 +283,7 @@ async function runBoard(args: CliArgs, surface?: "console"): Promise<number> {
 
   const serverPath = findBoardServerPath();
   if (!serverPath) {
-    error("Board server not found. Try reinstalling: npx great-cto@latest");
+    error("Board server not found. Reinstall the CLI (npm i -g great-cto@latest) or install the great_cto plugin (npx great-cto install).");
     return 1;
   }
 

--- a/packages/cli/tests/board-path.test.mjs
+++ b/packages/cli/tests/board-path.test.mjs
@@ -1,0 +1,126 @@
+// Tests for board server resolution (great_cto-hbu3):
+//  - plugin cache scan must cover ANY marketplace dir, not just "local"
+//  - the npm-bundled copy is the guaranteed fallback on a fresh install
+//  - the bundle produced by scripts/bundle-board.mjs is complete and loadable
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { execFileSync } from "node:child_process";
+import { findBoardServerPath } from "../dist/board-path.js";
+
+const here = dirname(fileURLToPath(import.meta.url)); // packages/cli/tests
+const cliRoot = join(here, "..");
+
+function makeTmp() {
+  return mkdtempSync(join(tmpdir(), "gcto-board-path-"));
+}
+
+test("finds server.mjs in a non-'local' marketplace cache dir", () => {
+  const home = makeTmp();
+  const base = makeTmp(); // no dev layouts, no bundle
+  try {
+    const vDir = join(home, ".claude", "plugins", "cache", "claude-plugins-official", "great_cto", "2.77.0", "packages", "board");
+    mkdirSync(vDir, { recursive: true });
+    writeFileSync(join(vDir, "server.mjs"), "// stub");
+    const found = findBoardServerPath(base, home);
+    assert.equal(found, join(vDir, "server.mjs"));
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("picks the highest semver version numerically (2.100.0 > 2.99.0)", () => {
+  const home = makeTmp();
+  const base = makeTmp();
+  try {
+    for (const v of ["2.99.0", "2.100.0"]) {
+      const d = join(home, ".claude", "plugins", "cache", "local", "great_cto", v, "packages", "board");
+      mkdirSync(d, { recursive: true });
+      writeFileSync(join(d, "server.mjs"), "// stub");
+    }
+    const found = findBoardServerPath(base, home);
+    assert.ok(found.includes("2.100.0"), `expected 2.100.0, got ${found}`);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("falls back to the npm-bundled copy when no plugin cache exists", () => {
+  const home = makeTmp(); // empty — no ~/.claude at all
+  const root = makeTmp(); // fake package root: root/dist + root/board
+  try {
+    const base = join(root, "dist"); // pretend this is <pkg>/dist
+    mkdirSync(base, { recursive: true });
+    const bundled = join(root, "board", "packages", "board");
+    mkdirSync(bundled, { recursive: true });
+    writeFileSync(join(bundled, "server.mjs"), "// stub");
+    const found = findBoardServerPath(base, home);
+    assert.equal(found, join(bundled, "server.mjs"));
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("returns undefined when nothing exists anywhere", () => {
+  const home = makeTmp();
+  const root = makeTmp();
+  try {
+    const base = join(root, "dist");
+    mkdirSync(base, { recursive: true });
+    assert.equal(findBoardServerPath(base, home), undefined);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("bundle-board.mjs produces a complete, syntax-valid bundle", () => {
+  execFileSync(process.execPath, [join(cliRoot, "scripts", "bundle-board.mjs")], { cwd: cliRoot });
+  const out = join(cliRoot, "board");
+  for (const rel of [
+    "packages/board/server.mjs",
+    "packages/board/push-adapter.mjs",
+    "packages/board/lib/routes.mjs",
+    "packages/board/public/index.html",
+    "scripts/lib/gate-plan.mjs",
+    "packages/cli/dist/archetypes.js",
+    ".claude-plugin/plugin.json",
+  ]) {
+    assert.ok(existsSync(join(out, rel)), `bundle missing ${rel}`);
+  }
+  // no tests / worker in the shipped bundle
+  assert.ok(!existsSync(join(out, "packages/board/push-adapter.test.mjs")), "tests must not ship");
+  assert.ok(!existsSync(join(out, "packages/board/cloudflare-worker")), "cloudflare-worker must not ship");
+  // the bundled server parses (imports resolve is covered by the boot test below)
+  execFileSync(process.execPath, ["--check", join(out, "packages/board/server.mjs")]);
+});
+
+test("bundled board server boots and serves /api/version", async () => {
+  const out = join(cliRoot, "board");
+  assert.ok(existsSync(join(out, "packages/board/server.mjs")), "run after bundle test");
+  const { spawn } = await import("node:child_process");
+  const port = 3197;
+  const child = spawn(process.execPath, [join(out, "packages/board/server.mjs"), "--no-open"], {
+    env: { ...process.env, BOARD_PORT: String(port) },
+    stdio: "ignore",
+  });
+  try {
+    let ok = false;
+    for (let i = 0; i < 30; i++) {
+      await new Promise(r => setTimeout(r, 200));
+      try {
+        const res = await fetch(`http://127.0.0.1:${port}/api/version`);
+        if (res.ok) { ok = true; break; }
+      } catch { /* not up yet */ }
+    }
+    assert.ok(ok, "bundled server did not answer /api/version within 6s");
+  } finally {
+    child.kill("SIGKILL");
+  }
+});


### PR DESCRIPTION
## Summary

Fixes `great_cto-hbu3` (P1, found in the v2.77.0 bughunt): **`npx great-cto board` failed on any fresh npm install** with "Board server not found" — the board server is not shipped in the npm package, and `findBoardServerPath()` only checked dev-checkout layouts plus the hardcoded `local` marketplace cache. The error message then suggested reinstalling the npm package, which could never help.

### Changes
- **`prepack` bundle** (`packages/cli/scripts/bundle-board.mjs`): copies `packages/board` (server, `lib/`, `public/`, push-adapter — no tests, no cloudflare-worker) plus its runtime import closure (`scripts/lib/gate-plan.mjs` + `change-tier` + `judge-model`, `dist/archetypes.js`, `.claude-plugin/plugin.json`) into `packages/cli/board/`, mirroring the repo layout so all relative imports resolve. Ships in the tarball via `files: ["board/"]` — a clean `npm i -g great-cto` now runs the board with no plugin installed.
- **Marketplace scan**: the plugin-cache lookup iterates every dir under `~/.claude/plugins/cache/`, not just `local`. Resolution order: dev layouts → plugin cache (newest 5 versions per marketplace, numeric semver sort) → bundled fallback.
- **Testability**: resolver extracted to `src/board-path.ts` (`main.ts` self-executes on import so it was untestable) with injectable base/home dirs.
- Honest error message pointing at both real remedies.

Tarball impact: 109 kB → **260 kB** (31 board files).

## Verification
- [x] CLI suite **194/194** (6 new tests: non-`local` marketplace resolution, numeric semver pick, bundled fallback, nothing-found, bundle completeness + `node --check`, bundled-server boot answering `/api/version`)
- [x] Full local CI gate green (`scripts/ci-local.sh`)
- [x] E2E of the original bug scenario: `npm pack` → install tarball into a clean prefix → run `great-cto board --port 3196` with an **empty `$HOME`** (no plugin, no cache) → server boots, `/api/version` returns 2.77.0, static `/` returns 200

## Known non-blockers
- `great-cto board` (CLI wrapper) stays attached instead of detaching in some environments — pre-existing behavior, unrelated to resolution.
- The CLI port-busy check reads only `--port`, not `BOARD_PORT` env — pre-existing.