### PR TITLE
fix: board security hardening — traversal guard, origin dedupe, HOME boundary (great_cto-qvg9)

### DIFF
--- a/packages/board/lib/projects.mjs
+++ b/packages/board/lib/projects.mjs
@@ -4,6 +4,20 @@ import os from 'os';
 import { spawnSync } from 'child_process';
 import { planGates } from '../../../scripts/lib/gate-plan.mjs';
 import { GREAT_CTO_DIR, PROJECTS_FILE } from './config.mjs';
+import { isInsideDir } from './util.mjs';
+
+// Same HOME-boundary policy /api/projects/register enforces (lib/routes.mjs):
+// a raw absolute/tilde path must resolve inside the operator's home directory,
+// no exceptions. Without this, a request like ?project=/etc or ?project=/tmp
+// makes the board read/write project data (.beads, verdicts/, PROJECT.md)
+// at an arbitrary filesystem location the operator never registered. Returns
+// null (not process.cwd()) so callers can distinguish "not a raw path" from
+// "raw path rejected" and fall back explicitly.
+function resolveRawPathWithinHome(slugOrPath) {
+  const raw = slugOrPath.startsWith('~') ? slugOrPath.replace(/^~/, os.homedir()) : slugOrPath;
+  const resolved = path.resolve(raw);
+  return isInsideDir(os.homedir(), resolved) ? resolved : null;
+}
 
 // ── Project registry ───────────────────────────────────────────────────────────
 function readProjectsRegistry() {
@@ -251,12 +265,19 @@ function listProjects() {
 }
 function resolveProjectCwd(slugOrPath) {
   if (!slugOrPath) return process.cwd();
-  // If absolute path or starts with ~, use directly
-  if (slugOrPath.startsWith('/')) return slugOrPath;
-  if (slugOrPath.startsWith('~')) return slugOrPath.replace(/^~/, os.homedir());
+  // If absolute path or starts with ~, it's raw user input — enforce the same
+  // HOME-boundary policy /api/projects/register uses. A path outside HOME
+  // falls back to process.cwd() (same fallback already used below for an
+  // unknown slug) rather than being honored verbatim.
+  if (slugOrPath.startsWith('/') || slugOrPath.startsWith('~')) {
+    const withinHome = resolveRawPathWithinHome(slugOrPath);
+    return withinHome || process.cwd();
+  }
   // Else look up in registry by slug — among duplicate slugs (great_cto-7xfc),
   // prefer the entry whose path exists on disk; among several existing (or
-  // several missing), prefer the most recently added_at.
+  // several missing), prefer the most recently added_at. Registry entries were
+  // already validated at registration time (register enforces the HOME
+  // boundary before writing), so slug resolution is untouched.
   const reg = readProjectsRegistry();
   const matches = reg.projects.filter(p => p.slug === slugOrPath);
   const found = pickBestBySlug(matches);
@@ -271,16 +292,18 @@ function resolveProjectCwd(slugOrPath) {
  *
  * resolved values:
  *   'cwd'      — no project param passed; using server cwd as documented
- *   'path'     — absolute / tilde path passed and used directly
+ *   'path'     — absolute / tilde path passed, resolved inside HOME, used directly
  *   'slug'     — slug found in registry
- *   'fallback' — slug requested but NOT in registry; using cwd as fallback.
- *                Caller should warn the user (header + log).
+ *   'fallback' — slug requested but NOT in registry, OR a raw path was requested
+ *                that resolves outside HOME (great_cto-qvg9); using cwd as
+ *                fallback. Caller should warn the user (header + log).
  */
 function resolveProjectInfo(slugOrPath) {
   if (!slugOrPath) return { cwd: process.cwd(), resolved: 'cwd' };
-  if (slugOrPath.startsWith('/')) return { cwd: slugOrPath, resolved: 'path' };
-  if (slugOrPath.startsWith('~')) {
-    return { cwd: slugOrPath.replace(/^~/, os.homedir()), resolved: 'path' };
+  if (slugOrPath.startsWith('/') || slugOrPath.startsWith('~')) {
+    const withinHome = resolveRawPathWithinHome(slugOrPath);
+    if (withinHome) return { cwd: withinHome, resolved: 'path' };
+    return { cwd: process.cwd(), resolved: 'fallback', requested: slugOrPath };
   }
   const reg = readProjectsRegistry();
   const matches = reg.projects.filter(p => p.slug === slugOrPath);

--- a/packages/board/lib/routes.mjs
+++ b/packages/board/lib/routes.mjs
@@ -6,8 +6,8 @@ import {
   addSubscription,
   removeSubscription,
 } from '../push-adapter.mjs';
-import { PORT, GREAT_CTO_DIR, VAPID_KEYS_FILE, PUSH_SUBS_FILE, BUILD_VERSION } from './config.mjs';
-import { eventSurface, readFileSafe } from './util.mjs';
+import { GREAT_CTO_DIR, VAPID_KEYS_FILE, PUSH_SUBS_FILE, BUILD_VERSION } from './config.mjs';
+import { eventSurface, readFileSafe, originAllowed } from './util.mjs';
 import { sseClients, notifHistory } from './state.mjs';
 import { autoRegisterProject, listProjects, resolveProjectCwd, getChangeTier } from './projects.mjs';
 import { broadcastTasks } from './sse.mjs';
@@ -54,18 +54,12 @@ async function dispatch(req, res, url, cwd) {
   // it MUST reject cross-origin requests. The board listens on 127.0.0.1
   // but a malicious page the user visits can still issue text/plain POSTs
   // (simple CORS request — no preflight) to localhost. Two gates:
-  //   1) Origin / Referer must match http://localhost:PORT or 127.0.0.1:PORT.
+  //   1) Origin / Referer must be same-origin (originAllowed() in lib/util.mjs —
+  //      also enforced as the top-level CSRF guard in server.mjs before dispatch()
+  //      is ever called, so this is defense-in-depth, not the only check).
   //   2) Resolved target path must live inside HOME — no /tmp, no /etc.
   if (pathname === '/api/projects/register' && req.method === 'POST') {
-    const origin = req.headers.origin || req.headers.referer || '';
-    const expectedOrigin = `http://localhost:${PORT}`;
-    const expectedOrigin2 = `http://127.0.0.1:${PORT}`;
-    const originOk = !origin
-      || origin === expectedOrigin
-      || origin === expectedOrigin2
-      || origin.startsWith(expectedOrigin + '/')
-      || origin.startsWith(expectedOrigin2 + '/');
-    if (!originOk) {
+    if (!originAllowed(req)) {
       res.writeHead(403, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify({ error: 'origin not allowed' }));
       return true;
@@ -850,16 +844,10 @@ async function dispatch(req, res, url, cwd) {
   // (DESIGN-agents-fleet-view §9 Top-2 #2: reversible sidecar chosen over
   // filesystem move; founder may revise.)
   if (pathname.startsWith('/api/agents/') && req.method === 'POST') {
-    // Cross-origin guard — same pattern as BH-23 on /api/projects/register.
-    const origin = req.headers.origin || req.headers.referer || '';
-    const expectedOrigin = `http://localhost:${PORT}`;
-    const expectedOrigin2 = `http://127.0.0.1:${PORT}`;
-    const originOk = !origin
-      || origin === expectedOrigin
-      || origin === expectedOrigin2
-      || origin.startsWith(expectedOrigin + '/')
-      || origin.startsWith(expectedOrigin2 + '/');
-    if (!originOk) {
+    // Cross-origin guard — same helper as BH-23 on /api/projects/register
+    // (originAllowed() in lib/util.mjs; also enforced as the top-level CSRF
+    // guard in server.mjs before dispatch() is ever called).
+    if (!originAllowed(req)) {
       res.writeHead(403, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify({ error: 'origin_not_allowed' }));
       return true;

--- a/packages/board/lib/util.mjs
+++ b/packages/board/lib/util.mjs
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import path from 'path';
 import { PORT } from './config.mjs';
 
 /**
@@ -33,4 +34,16 @@ function readFileSafe(p) {
   try { return fs.existsSync(p) ? fs.readFileSync(p, 'utf8') : null; } catch { return null; }
 }
 
-export { csvCell, originAllowed, eventSurface, readFileSafe };
+// Path-containment check used by any handler that joins user-controlled input
+// onto a base directory (static file serving, doc reads, etc.). Resolves both
+// sides and requires `target` to be exactly `base`, or a real descendant of
+// it (base + path.sep prefix) — this is what actually blocks ".." escapes,
+// since a naive startsWith(base) would wrongly allow a sibling directory
+// like "/public-evil" when base is "/public".
+function isInsideDir(base, target) {
+  const resolvedBase = path.resolve(base);
+  const resolvedTarget = path.resolve(target);
+  return resolvedTarget === resolvedBase || resolvedTarget.startsWith(resolvedBase + path.sep);
+}
+
+export { csvCell, originAllowed, eventSurface, readFileSafe, isInsideDir };

--- a/packages/board/registry.test.mjs
+++ b/packages/board/registry.test.mjs
@@ -148,3 +148,70 @@ test('autoRegisterProject updates the existing entry in place when a repo moves 
   assert.equal(matches.length, 1, 'must update in place, not insert a second entry');
   assert.equal(matches[0].path, newDir);
 });
+
+// ── HOME-boundary guard (great_cto-qvg9) ────────────────────────────────────
+// resolveProjectCwd / resolveProjectInfo previously used a raw absolute or
+// `~` path verbatim with no containment check, so `?project=/etc` (or any
+// path outside the operator's home directory) would make the board read
+// project data from an arbitrary filesystem location. Both functions now
+// enforce the same HOME-boundary policy /api/projects/register already used
+// (lib/routes.mjs): a raw path must resolve inside os.homedir(), or the
+// server falls back to process.cwd() — same fallback already used for an
+// unknown slug.
+//
+// tmpDir (from os.tmpdir()) is outside HOME on every CI/dev machine we
+// target (macOS: /private/var/folders/... vs /Users/...; Linux: /tmp vs
+// /home/...), so reusing it here gives a real out-of-HOME path without any
+// extra fixture setup.
+test('resolveProjectCwd falls back to process.cwd() for an absolute path outside HOME', () => {
+  const home = os.homedir();
+  assert.ok(!tmpDir.startsWith(home + path.sep) && tmpDir !== home, 'test fixture must live outside HOME for this test to be meaningful');
+  const outside = path.join(tmpDir, 'outside-home-target');
+  fs.mkdirSync(outside, { recursive: true });
+  assert.equal(resolveProjectCwd(outside), process.cwd());
+});
+
+test('resolveProjectCwd honors an absolute path that resolves inside HOME', () => {
+  const home = os.homedir();
+  // Use HOME itself — always inside-HOME by definition, and doesn't require
+  // creating a fixture under the real ~ (which the test must not touch).
+  assert.equal(resolveProjectCwd(home), home);
+});
+
+test('resolveProjectCwd falls back to process.cwd() for a ~-relative path outside HOME', () => {
+  // ~ always expands to os.homedir() itself, so it can never be "outside
+  // HOME" — this documents that invariant rather than testing a rejection.
+  assert.equal(resolveProjectCwd('~'), os.homedir());
+});
+
+test('resolveProjectInfo marks an out-of-HOME absolute path as fallback, not path', () => {
+  const outside = path.join(tmpDir, 'outside-home-info');
+  fs.mkdirSync(outside, { recursive: true });
+  const info = resolveProjectInfo(outside);
+  assert.equal(info.cwd, process.cwd());
+  assert.equal(info.resolved, 'fallback');
+  assert.equal(info.requested, outside);
+});
+
+test('resolveProjectInfo marks an in-HOME absolute path as path (unchanged behavior)', () => {
+  const home = os.homedir();
+  const info = resolveProjectInfo(home);
+  assert.equal(info.cwd, home);
+  assert.equal(info.resolved, 'path');
+});
+
+test('resolveProjectCwd still resolves registry slugs normally (HOME-boundary does not affect slug lookups)', () => {
+  // Registry entries are validated at registration time (register enforces
+  // the HOME boundary before writing), so slug resolution must be completely
+  // unaffected by this change — including a slug whose registered path
+  // happens to live outside HOME (e.g. a pre-existing/legacy registry entry
+  // from before this guard existed), which must still resolve normally.
+  const legacyDir = makeRealDir('legacy-outside-home-proj');
+  writeProjectsRegistry({
+    projects: [{ slug: 'legacy-proj', path: legacyDir, added_at: '2025-01-01T00:00:00.000Z' }],
+  });
+  assert.equal(resolveProjectCwd('legacy-proj'), legacyDir);
+  const info = resolveProjectInfo('legacy-proj');
+  assert.equal(info.cwd, legacyDir);
+  assert.equal(info.resolved, 'slug');
+});

--- a/packages/board/server.mjs
+++ b/packages/board/server.mjs
@@ -13,7 +13,7 @@ import fs from 'fs';
 import path from 'path';
 import { spawnSync } from 'child_process';
 import { PORT, PUBLIC, HOST } from './lib/config.mjs';
-import { originAllowed } from './lib/util.mjs';
+import { originAllowed, isInsideDir } from './lib/util.mjs';
 import { discoverProjects, resolveProjectInfo } from './lib/projects.mjs';
 import { startAlertCron } from './lib/alerts.mjs';
 import { watchBeads, watchVerdicts } from './lib/watchers.mjs';
@@ -77,7 +77,13 @@ const server = http.createServer(async (req, res) => {
   // Static files
   let filePath = pathname === '/' ? '/index.html' : pathname;
   const fullPath = path.join(PUBLIC, filePath);
-  if (fs.existsSync(fullPath) && fs.statSync(fullPath).isFile()) {
+  // Path-traversal guard (mirrors the /api/doc containment check in lib/routes.mjs):
+  // the joined path must resolve to somewhere inside PUBLIC. Without this, a decoded
+  // pathname like /..%2F..%2Fetc%2Fpasswd can escape the public/ directory via
+  // path.join's ".." collapsing. Reject with 404 (same as the generic static 404
+  // below) so a traversal attempt is indistinguishable from a missing file — no
+  // signal to a prober about what exists outside PUBLIC.
+  if (isInsideDir(PUBLIC, fullPath) && fs.existsSync(fullPath) && fs.statSync(fullPath).isFile()) {
     const ext = path.extname(fullPath);
     const mime = { '.html': 'text/html', '.css': 'text/css', '.js': 'text/javascript', '.svg': 'image/svg+xml' };
     // HTML must never cache — board UI is iterated daily and stale layouts

--- a/packages/board/static-traversal.test.mjs
+++ b/packages/board/static-traversal.test.mjs
@@ -1,0 +1,67 @@
+// Tests for great_cto-qvg9: static file serving in server.mjs joined
+// `path.join(PUBLIC, filePath)` with no containment check, so a request
+// like GET /..%2F..%2Fetc%2Fpasswd (decoded by the URL parser to
+// pathname "/../../etc/passwd") could escape the public/ directory.
+//
+// server.mjs now guards every static-file read with lib/util.mjs's
+// isInsideDir(PUBLIC, fullPath) — same containment primitive used here.
+// Booting the real HTTP server isn't an established pattern in this test
+// suite (no other packages/board/*.test.mjs does it), so this tests the
+// pure containment logic directly, exercised with the same inputs the
+// server actually produces via path.join(PUBLIC, pathname).
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { isInsideDir } from './lib/util.mjs';
+
+const PUBLIC = '/app/packages/board/public';
+
+function joined(pathname) {
+  return path.join(PUBLIC, pathname);
+}
+
+test('isInsideDir allows the PUBLIC root itself', () => {
+  assert.equal(isInsideDir(PUBLIC, PUBLIC), true);
+});
+
+test('isInsideDir allows a normal file inside PUBLIC', () => {
+  assert.equal(isInsideDir(PUBLIC, joined('/index.html')), true);
+  assert.equal(isInsideDir(PUBLIC, joined('/assets/app.js')), true);
+});
+
+test('isInsideDir rejects a simple ../ escape', () => {
+  const fullPath = joined('/../server.mjs');
+  assert.equal(isInsideDir(PUBLIC, fullPath), false);
+});
+
+test('isInsideDir rejects a deep traversal to /etc/passwd', () => {
+  const fullPath = joined('/../../../../../../etc/passwd');
+  assert.equal(isInsideDir(PUBLIC, fullPath), false);
+});
+
+test('isInsideDir rejects the exact traversal path from the smoke test (/assets/../../../etc/passwd)', () => {
+  const fullPath = joined('/assets/../../../etc/passwd');
+  assert.equal(isInsideDir(PUBLIC, fullPath), false);
+});
+
+test('isInsideDir rejects a sibling directory that merely shares the PUBLIC prefix', () => {
+  // Guards against a naive startsWith(base) (no trailing separator) which would
+  // wrongly allow "/app/packages/board/public-evil/secret".
+  const sibling = '/app/packages/board/public-evil/secret';
+  assert.equal(isInsideDir(PUBLIC, sibling), false);
+});
+
+test('URL decoding still resolves %2e%2e (percent-encoded dots) as a literal path segment named "%2e%2e", not a traversal', () => {
+  // Node's URL parser decodes %2F (encoded slash) but the http module's
+  // req.url / URL(pathname) does NOT decode it into an actual path
+  // separator for routing purposes — encoded slashes stay literal percent
+  // sequences in `pathname` unless the runtime decodes them. Either way,
+  // isInsideDir must not be fooled: whatever pathname the server hands it,
+  // containment is re-checked after path.resolve().
+  const fullPath = joined('/%2e%2e/%2e%2e/etc/passwd');
+  // This does NOT collapse via path.join (no literal ".." segments), so it
+  // stays "inside" PUBLIC as a (nonexistent) literally-named file — proving
+  // the guard doesn't over-block legitimate-looking encoded names while
+  // still blocking real ".." segments once decoded by the URL parser.
+  assert.equal(isInsideDir(PUBLIC, fullPath), true);
+});


### PR DESCRIPTION
Three pre-existing hardenings from the PR #124 security review: static path-traversal containment (isInsideDir, 404 w/o contents), deduped origin checks via originAllowed() (inline copies were dead code behind the top-level CSRF guard), HOME-boundary for raw ?project= paths mirroring register's policy (registry slugs untouched). Tests 176/176 (+13 new); live smoke: traversal 404, cross-origin 403, project-scoped tasks unaffected.