### PR TITLE
fix: telemetry endpoint — documented domain default, env override (great_cto-j9uj)

### DIFF
--- a/packages/cli/src/telemetry.ts
+++ b/packages/cli/src/telemetry.ts
@@ -29,9 +29,9 @@ import * as os from "node:os";
 import * as crypto from "node:crypto";
 
 const TELEMETRY_ENDPOINT = process.env.GREAT_CTO_TELEMETRY_ENDPOINT
-  || "https://great-cto-telemetry.alexander-velikiy.workers.dev/v1/event";
-// Note: workers.dev URL is the temporary default until telemetry.greatcto.systems
-// custom domain is bound. Override anytime with GREAT_CTO_TELEMETRY_ENDPOINT.
+  || "https://telemetry.greatcto.systems/v1/event";
+// Override anytime with GREAT_CTO_TELEMETRY_ENDPOINT (e.g. to point at a
+// workers.dev URL during local worker development).
 const TELEMETRY_TIMEOUT_MS = 1000;
 
 // Allowlist — anything else is dropped client-side and server-side.

--- a/packages/cli/tests/telemetry.test.mjs
+++ b/packages/cli/tests/telemetry.test.mjs
@@ -1,0 +1,41 @@
+// Tests for telemetry.ts — default endpoint must be the documented domain,
+// never a personal-name workers.dev URL. Also covers env override behavior.
+//
+// HOME is redirected to a tmpdir before any module is imported so that
+// telemetrySubcommand("on"/"off") writes to an isolated config file instead
+// of the developer's real ~/.great_cto/telemetry.json.
+//
+// Run: npm run build && node --test tests/telemetry.test.mjs
+
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+const fakeHome = mkdtempSync(join(tmpdir(), "gc-telemetry-home-"));
+process.env.HOME = fakeHome;
+process.env.USERPROFILE = fakeHome; // Windows
+
+const { telemetrySubcommand } = await import("../dist/telemetry.js");
+
+test("default telemetry endpoint uses the documented greatcto.systems domain", () => {
+  delete process.env.GREAT_CTO_TELEMETRY_ENDPOINT;
+  const { output } = telemetrySubcommand("status");
+  assert.match(output, /https:\/\/telemetry\.greatcto\.systems\/v1\/event/);
+});
+
+test("default telemetry endpoint never contains a personal author name", () => {
+  delete process.env.GREAT_CTO_TELEMETRY_ENDPOINT;
+  const { output } = telemetrySubcommand("status");
+  assert.doesNotMatch(output, /alexander-velikiy/i);
+  assert.doesNotMatch(output, /workers\.dev/);
+});
+
+test("telemetry on/off subcommands report the same non-personal endpoint", () => {
+  delete process.env.GREAT_CTO_TELEMETRY_ENDPOINT;
+  const on = telemetrySubcommand("on");
+  assert.match(on.output, /https:\/\/telemetry\.greatcto\.systems\/v1\/event/);
+  assert.doesNotMatch(on.output, /alexander-velikiy/i);
+  telemetrySubcommand("off");
+});


### PR DESCRIPTION
Replaces the personal-name workers.dev default in packages/cli/src/telemetry.ts with the documented (and verified live, HTTP 200) telemetry.greatcto.systems endpoint; GREAT_CTO_TELEMETRY_ENDPOINT override re-documented. 3 new regression tests assert the default never regresses to the personal hostname. CLI suite 197/197.