### PR TITLE
feat(quality): QUALITY-DEEPEN follow-ups #3–#6 (great_cto-482l)

### DIFF
--- a/docs/arch/ARCH-quality-deepen-followups.md
+++ b/docs/arch/ARCH-quality-deepen-followups.md
@@ -1,0 +1,111 @@
+# ARCH — QUALITY-DEEPEN follow-ups (#3-#6)
+
+> Beads: great_cto-482l · Status: scoping · Reader: whoever picks up the next quality wave.
+> Builds on QUALITY-DEEPEN #1+#2 (PR #118), #3 (PR #119), #5 (PR #120). Numbering per
+> `docs/strategy/QUALITY-DEEPEN.md` § Axes.
+
+## Problem
+
+The shipped waves gave us **floor (89)** + **ceiling (100)** + **domain (100 on 6 fleet archetypes)**
++ unified verdict + trend record + deploy gate. But the axes doc lists **6 axes**, only #1/#2/#3/#5
+are landed. Deferred work is fragmented across code comments, gated CI cron, and Beads-a9tp close notes.
+This doc consolidates the follow-ups, cuts what got absorbed, and orders what remains.
+
+## What #4 turned out to be — and its status
+
+**#4 = Actor-fidelity** (row 4 in QUALITY-DEEPEN.md, missed in commit numbering because the wave
+landed as Beads-**a9tp** before axis-numbered PRs started). Substantially **done**:
+
+- `tests/eval/runner.mjs` ships ReAct inspect-loop actor (`--actor-tools`, `--actor-turns`), lifted
+  security-officer holdout rate 0.50→0.64 (a9tp close-note).
+- A/B result: **variance is inherent LLM non-determinism, not fixable by actor structure** — mitigated
+  via `--samples` + variance-aware gate + `eval-drift.mjs` noise-gate.
+- Remaining: enable the scheduled drift cron (see F4 below).
+
+## Follow-up backlog
+
+| ID | Axis | What | Why | Files | Effort | Priority |
+|----|------|------|-----|-------|--------|----------|
+| **F3a** | #3 | Extend `archetype-contracts.mjs` to 8 more real archetypes | Today: 6 web families. Tool ships 14. Gate is a no-op on `ai-system`, `agent-product`, `commerce`, `web3`, `iot-embedded`, `data-platform`, `browser-extension`, `mobile-app`. | `scripts/lib/archetype-contracts.mjs`, `tests/lib/archetype-contracts.test.mjs` | **M** | **P1** |
+| **F3b** | #3 | Fix known archetype-rename drift in `product-score.mjs` tests (great_cto-7nxj: expected `cli-tool`, got `cli`) | 2 failing tests on main. Blocks green CI baseline for further quality work. | `tests/lib/product-score.test.mjs` | S | P1 |
+| **F3c** | #3 | Sharpen contract regex fragility (`/hold/i` matches "household", `/aggregat/i` misses `groupBy`) | Present patterns give false-positives. On richer test suites this quietly inflates domain coverage. | `scripts/lib/archetype-contracts.mjs` | S | P2 |
+| **F4** | #4 | Enable scheduled eval-drift cron | `.github/workflows/scheduled-evals-drift.yml` cron is commented out pending noise-gate confidence. Baseline is now in place; measure stddev over 3 runs; if ≤ 0.1, un-comment. | `.github/workflows/scheduled-evals-drift.yml`, one-page runbook | S | P2 |
+| **F5a** | #5 | Wire `--baseline` into unified `quality.mjs --gate` (parity with `product-eval.mjs`) | `product-eval.mjs` supports regression gate; `quality.mjs` only supports absolute `--min`. A regression in overall score sneaks past. | `scripts/lib/quality.mjs`, `tests/lib/quality.test.mjs` | S | P1 |
+| **F5b** | #5 | `quality.mjs --trend` — read `metrics-history.jsonl`, print sparkline + delta | Record works (--record), read doesn't. `metrics-trend.mjs check` is generic; a quality-scoped view surfaces regressions at a glance. | `scripts/lib/quality.mjs`, reuses `metrics-trend.mjs` | S | P2 |
+| **F6a** | #6 | Browser a11y check via headless Playwright — **only if product declares a preview command** | `axe-core` in a Playwright page → violations count → signal to `product-eval`. Playwright already devDep (^1.60.0). Zero new runtime cost when off; opt-in via `--browser` flag. | `scripts/lib/product-browser.mjs` (new), wired into `product-eval.mjs` optional | **M** | P2 |
+| **F6b** | #6 | Web Vitals (LCP/CLS/INP) via same Playwright harness | Same harness as F6a. Skip Lighthouse (heavy, flaky in CI, needs Chrome). Emit 3 numbers → 1 signal. | `scripts/lib/product-browser.mjs` (extends F6a) | S | P3 |
+| **F6c** | #6 | Visual-regression / screenshot-diff | **CUT** — infra-heavy (needs golden storage, per-viewport baselines, flake tolerance), out of scope for a zero-dep local-first tool. Value < cost. | — | L | **CUT** |
+
+Total in scope: **8 items** (F6c cut). Rough effort: **S×5 + M×2 + docs**.
+
+## Non-goals (explicit)
+
+- ❌ **Not** a browser test harness for the shipping tool itself. Only for the products it *generates*.
+- ❌ **Not** replacing `metrics-trend.mjs` — F5b is a thin quality-scoped view over it.
+- ❌ **Not** rewriting `product-eval.mjs` semantics — F6a/b add signals, don't shift weights.
+- ❌ **Not** adding Lighthouse. Chrome dep + CI flake + Playwright already covers Web Vitals.
+- ❌ **Not** solving inherent LLM variance (settled by a9tp — variance-aware gate is the answer).
+- ❌ **Not** visual regression (F6c).
+- ❌ **Not** contract coverage for `library` / `cli-tool` / `infra` — no user-facing domain invariants; the generic rubric is honest enough.
+
+## Browser a11y/perf — honest cost/value read (F6a/b)
+
+The initial framing said "Playwright" would violate zero-dep/local-first. Reality check:
+
+- **Playwright is already `devDependencies`** (`package.json` ^1.60.0) — used for repo's own tests.
+- **`axe-core`** is ~500KB, no browser download of its own.
+- **Runtime cost = 0** when `--browser` flag not passed. Feature is opt-in and off by default.
+- **Failure mode = graceful skip** if the product has no `dev` / `preview` / `start` script or if
+  the URL doesn't respond within 15s — signal marked `na`, no score penalty (same as tsconfig-less
+  product today).
+
+**Recommendation:** ship F6a (a11y) as the minimal credible browser check. Defer F6b to a
+follow-up once F6a is proven stable in fleet runs. Cut F6c. The whole thing is ~180 LOC in a new
+`scripts/lib/product-browser.mjs` — a11y-only.
+
+## Recommended implementation order
+
+Two independent streams; F3b is the unblocker for both.
+
+```
+F3b (fix drift)  ──►  F3a (contracts x8)   ──►  F3c (regex hardening)
+                                                       │
+                                                       ▼
+                                             F5a (baseline gate)  ──►  F5b (trend view)
+                                                       │
+                                                       ▼
+                                                     F6a (a11y)   ──►  F6b (web vitals)   ──►  F4 (drift cron)
+```
+
+- **F3b first, always.** CI baseline must be green before we add tests.
+- **F3a and F5a can run in parallel** (different files, no shared state).
+- **F4 is safe to do anytime after 3 clean drift-runs measure stddev**. Independent of everything else.
+
+### Decomposition Matrix (3+ streams)
+
+| Stream | Write-zone (files/dirs) | Depends on | Why parallel-safe |
+|--------|-------------------------|------------|-------------------|
+| A: fix drift | `tests/lib/product-score.test.mjs` only | — | test-file only |
+| B: contracts | `scripts/lib/archetype-contracts.mjs` + its `.test.mjs` | A (green baseline) | own module |
+| C: quality gate | `scripts/lib/quality.mjs` + its `.test.mjs` | A | own module, no overlap with B |
+| D: browser check | `scripts/lib/product-browser.mjs` (new) + hook line in `product-eval.mjs` | A | new file; single hook in `product-eval.mjs` is a small merge |
+| E: drift cron | `.github/workflows/scheduled-evals-drift.yml` (uncomment cron line) | measure stddev × 3 runs | orthogonal |
+
+## Requirements checklist (contract to QA)
+
+- [ ] REQ-1 (F3b): `node --test tests/lib/product-score.test.mjs` — 15/15 pass.
+- [ ] REQ-2 (F3a): `CONTRACTS` in `archetype-contracts.mjs` covers 14 archetypes; each has ≥2 invariants + a rubric-documented rationale.
+- [ ] REQ-3 (F5a): `quality.mjs --gate --baseline prev.json` exits 1 on overall regression > 2 points (matches product-eval semantics).
+- [ ] REQ-4 (F5b): `quality.mjs --trend` prints last-N overall scores and Δ vs baseline; exit 0 always (read-only).
+- [ ] REQ-5 (F6a): opt-in `--browser`; graceful `na` when no preview script; a11y signal integrated into `product-eval` scoring.
+
+## Risks
+
+- **F3a regex sprawl** — 14 archetypes × 2-3 invariants = 30-40 patterns. Mitigation: table-driven; tests must include one true-positive + one true-negative per invariant.
+- **F6a CI flake** — Playwright + browser download in CI adds minutes. Mitigation: don't run in unit-test job; run only on `quality --browser` invocation (opt-in).
+- **F4 false-positive alerts** — if 3-run stddev sits at 0.09-0.11, cron will alternately gate and not. Mitigation: bump `--max-noise` cap to 0.12 with rationale doc, or require 2 consecutive drift signals before alerting.
+
+## Would cut entirely with one-line rationale
+
+- **F6c visual-regression** — infra debt (golden storage, viewport matrix, flake tolerance) exceeds value for a local-first tool.
+- (Everything else earns its slot — see F3-F6 rows.)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,26 @@
 {
-  "name": "great_cto",
+  "name": "great-cto-monorepo-tools",
+  "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
+      "name": "great-cto-monorepo-tools",
+      "version": "0.0.1",
       "devDependencies": {
+        "axe-core": "^4.12.1",
         "playwright": "^1.60.0"
-      },
-      "version": "0.0.1"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.12.1.tgz",
+      "integrity": "sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/fsevents": {
       "version": "2.3.2",
@@ -56,6 +69,5 @@
         "node": ">=18"
       }
     }
-  },
-  "version": "0.0.1"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "demo:rebuild": "node scripts/seed-demo.mjs && node scripts/record-demo.mjs"
   },
   "devDependencies": {
+    "axe-core": "^4.12.1",
     "playwright": "^1.60.0"
   },
   "version": "0.0.1"

--- a/scripts/lib/archetype-contracts.mjs
+++ b/scripts/lib/archetype-contracts.mjs
@@ -31,15 +31,24 @@ export const CONTRACTS = Object.freeze({
     { id: 'availability', desc: 'availability filter', pattern: /availab/i },
   ],
   crm: [
-    { id: 'stage-transitions', desc: 'valid pipeline stage transitions', pattern: /stage|advance|pipeline/i },
+    // F3c: bare `advance` false-positives on "in advance of launch" (unrelated to deal
+    // progression) — anchor to a deal/stage/pipeline context within 20 chars.
+    { id: 'stage-transitions', desc: 'valid pipeline stage transitions', pattern: /\bstage\w*|\badvance\w*[\s\S]{0,20}(deal|stage|pipeline)|\bpipeline\w*/i },
     { id: 'referential', desc: 'deal→contact referential integrity', pattern: /(non.?existent|invalid|missing)[\s\S]{0,30}(contact|deal)|referential|\b400\b[\s\S]{0,20}contact/i },
   ],
   dashboard: [
-    { id: 'aggregation', desc: 'aggregation correctness', pattern: /aggregat|\bsum\b|\bcount\b|metric/i },
-    { id: 'window', desc: 'time-window boundaries', pattern: /window|since|until|range|boundary/i },
+    // F3c: bare `aggregat` misses the common `groupBy(...)` idiom (doc example); bare
+    // `metric` false-positives on "asymmetric". Add groupBy alias, word-boundary metric.
+    { id: 'aggregation', desc: 'aggregation correctness', pattern: /\baggregat\w*|group.?by|\bsum\(|\bcount\(|\bmetric\w*/i },
+    // F3c: bare `window` false-positives on "Windows" (the OS); anchor to word boundary
+    // so "Windows" (capital-agnostic \b\w* still ends at the trailing s) needs an explicit
+    // OS exclusion since \bwindow\w* still matches "Windows". Use a negative lookahead.
+    { id: 'window', desc: 'time-window boundaries', pattern: /\bwindow\w*\b(?!\s+(?:os|server|10|11))|\bsince\b|\buntil\b|\brange\b|\bboundary\w*/i },
   ],
   marketplace: [
-    { id: 'escrow-held', desc: 'order holds escrow', pattern: /escrow|hold/i },
+    // F3c: bare `hold` false-positives on "household"/"threshold"/"shareholder" (doc's
+    // headline example). Word-boundary the stem; `held` is a distinct irregular form.
+    { id: 'escrow-held', desc: 'order holds escrow', pattern: /escrow|\bhold\w*|\bheld\b/i },
     { id: 'release-idempotent', desc: 'double-release rejected', pattern: /(double|twice|already|second)[\s\S]{0,30}releas|releas[\s\S]{0,20}(twice|idempot|already)/i },
     { id: 'buyer-not-seller', desc: 'seller cannot order own listing', pattern: /seller[\s\S]{0,40}(buyer|order|\b403\b)|cannot[\s\S]{0,20}order|buyer[\s\S]{0,10}!==?[\s\S]{0,10}seller/i },
   ],

--- a/scripts/lib/archetype-contracts.mjs
+++ b/scripts/lib/archetype-contracts.mjs
@@ -47,6 +47,44 @@ export const CONTRACTS = Object.freeze({
     { id: 'entitlement-gate', desc: 'deliver blocked without entitlement', pattern: /\b403\b|without[\s\S]{0,30}(entitle|access)|deny|unauthor/i },
     { id: 'purchase-grants', desc: 'purchase creates entitlement', pattern: /purchas|subscrib|entitlement[\s\S]{0,20}(creat|grant|add)/i },
   ],
+  // ── F3a: +8 archetypes (docs/arch/ARCH-quality-deepen-followups.md) ──────────
+  'ai-system': [
+    { id: 'prompt-injection', desc: 'prompt-injection / untrusted-input handling tested', pattern: /prompt.?inject|jailbreak|untrusted[\s\S]{0,20}input|ignore (?:previous|all) instructions/i },
+    { id: 'output-validation', desc: 'model output is validated/sanitized before use', pattern: /output[\s\S]{0,20}(valid|sanit|schema)|malformed[\s\S]{0,20}(response|output)|hallucinat/i },
+    { id: 'rate-limit', desc: 'cost/rate limiting on model calls', pattern: /rate.?limit|token.?budget|cost.?cap|max.?tokens/i },
+  ],
+  'agent-product': [
+    { id: 'tool-allowlist', desc: 'tool access is allowlisted/scoped', pattern: /tool.?allowlist|allowed.?tools|tool.?scope|denylist/i },
+    { id: 'cross-user-isolation', desc: 'cross-user/session isolation enforced', pattern: /cross.?(user|tenant|session)|session[\s\S]{0,20}isolat|leak[\s\S]{0,20}(session|user)/i },
+    { id: 'runaway-budget', desc: 'agent loop has a turn/cost budget guard', pattern: /max.?turns|turn.?budget|infinite.?loop|budget.?exceed/i },
+  ],
+  commerce: [
+    { id: 'payment-idempotent', desc: 'duplicate charge/webhook rejected', pattern: /idempot|duplicate[\s\S]{0,20}(charge|payment|webhook)|replay[\s\S]{0,20}webhook/i },
+    { id: 'webhook-signature', desc: 'webhook signature verified', pattern: /webhook[\s\S]{0,30}(signature|verify|valid)|stripe.?signature|invalid.?signature/i },
+    { id: 'refund-flow', desc: 'refund/dispute flow tested', pattern: /refund|chargeback|dispute/i },
+  ],
+  web3: [
+    { id: 'reentrancy', desc: 'reentrancy protection tested', pattern: /reentran/i },
+    { id: 'access-control', desc: 'privileged function access control tested', pattern: /only.?owner|access.?control|unauthorized[\s\S]{0,20}(caller|call)|not.?owner/i },
+    { id: 'oracle-staleness', desc: 'oracle price staleness/manipulation checked', pattern: /stale.?price|oracle[\s\S]{0,20}(stale|manipulat)|price.?feed/i },
+  ],
+  'iot-embedded': [
+    { id: 'ota-signature', desc: 'OTA firmware update signature/integrity verified', pattern: /ota[\s\S]{0,20}(signature|verify|sign)|firmware[\s\S]{0,20}(signature|verify|integrity)/i },
+    { id: 'watchdog', desc: 'watchdog / fail-safe recovery tested', pattern: /watchdog|fail.?safe|fail.?over|reboot[\s\S]{0,20}recover/i },
+  ],
+  'data-platform': [
+    { id: 'schema-drift', desc: 'schema drift / breaking-change detection', pattern: /schema.?drift|breaking.?change|schema[\s\S]{0,20}(mismatch|incompat)/i },
+    { id: 'pipeline-idempotent', desc: 'pipeline re-run / backfill is idempotent', pattern: /idempot|re.?run[\s\S]{0,20}(safe|same|duplicate)|backfill/i },
+    { id: 'pii-handling', desc: 'PII column detection/redaction tested', pattern: /\bpii\b|redact|anonymiz|mask[\s\S]{0,20}(field|column|data)/i },
+  ],
+  'browser-extension': [
+    { id: 'csp-enforced', desc: 'content-security-policy / no unsafe-eval tested', pattern: /\bcsp\b|content.?security.?policy|unsafe.?eval/i },
+    { id: 'permission-scope', desc: 'host/permission scope is minimal & tested', pattern: /host.?permission|permission[\s\S]{0,20}(scope|minim|denied)|manifest[\s\S]{0,20}permission/i },
+  ],
+  'mobile-app': [
+    { id: 'deep-link-validation', desc: 'deep link / universal link input is validated', pattern: /deep.?link|universal.?link|app.?link[\s\S]{0,20}valid/i },
+    { id: 'offline-handling', desc: 'offline / no-connectivity path tested', pattern: /offline|no.?network|no.?connectivity|airplane.?mode/i },
+  ],
 });
 
 /** Map TYPE_MAP/real names to a contract family. */
@@ -59,6 +97,15 @@ export function contractFamily(a) {
   if (/dashboard|analytic|metric/.test(s)) return 'dashboard';
   if (/marketplace|two-?sided|listing/.test(s)) return 'marketplace';
   if (/content|media|catalog|cms/.test(s)) return 'content';
+  // ── F3a: +8 archetypes ──────────────────────────────────────────────────────
+  if (/agent-product|agent-runtime|agentic/.test(s)) return 'agent-product'; // check before ai-system (more specific)
+  if (/ai-system|\bai\b|llm/.test(s)) return 'ai-system';
+  if (/commerce|e-?commerce|shop|checkout/.test(s)) return 'commerce';
+  if (/web3|blockchain|smart-?contract|solidity/.test(s)) return 'web3';
+  if (/iot|embedded|firmware/.test(s)) return 'iot-embedded';
+  if (/data-?platform|data-?pipeline/.test(s)) return 'data-platform';
+  if (/browser-?extension|chrome-?extension/.test(s)) return 'browser-extension';
+  if (/mobile-?app|react-native|ios-app|android-app/.test(s)) return 'mobile-app';
   return s;
 }
 
@@ -99,7 +146,10 @@ function main(argv) {
   if (!dir || !existsSync(dir) || !statSync(dir).isDirectory()) { console.error('Usage: archetype-contracts.mjs <dir> --archetype <a> [--json]'); process.exit(2); }
   const ai = argv.indexOf('--archetype');
   const archetype = ai > -1 ? argv[ai + 1] : null;
-  if (!archetype) { console.error('ERROR: --archetype required (crud|booking|crm|dashboard|marketplace|content)'); process.exit(2); }
+  if (!archetype) {
+    console.error('ERROR: --archetype required (crud|booking|crm|dashboard|marketplace|content|ai-system|agent-product|commerce|web3|iot-embedded|data-platform|browser-extension|mobile-app)');
+    process.exit(2);
+  }
 
   const r = checkContracts(archetype, readTestText(dir));
   if (argv.includes('--json')) { process.stdout.write(JSON.stringify({ dir, archetype, ...r }, null, 2)); return; }

--- a/scripts/lib/product-browser.mjs
+++ b/scripts/lib/product-browser.mjs
@@ -1,0 +1,195 @@
+// scripts/lib/product-browser.mjs — headless browser signals for a shipped product
+// (QUALITY-DEEPEN #6, F6a a11y + F6b Web Vitals). Opt-in via --browser; zero runtime
+// cost when off. See docs/arch/ARCH-quality-deepen-followups.md.
+//
+// F6a — axe-core accessibility scan of the product's preview page.
+// F6b — Web Vitals (LCP / CLS / INP) captured on the same page load, same harness.
+//
+// Both signals degrade to 'na' (no penalty, same convention as product-eval.mjs's
+// tsconfig-less typecheck/lint) whenever a precondition is missing:
+//   • no dev/preview/start script in package.json → 'na', no server to hit
+//   • playwright not installed / browsers not downloaded → 'na', never crash
+//   • server doesn't respond within the timeout → 'na'
+//
+// Pure scoring helpers (scoreA11y, scoreVitals) are unit-tested without a browser;
+// runBrowserChecks(dir) is the impure entrypoint that actually launches Chromium —
+// only exercised manually / in fleet runs, never in the unit-test job (would require
+// a browser download).
+//
+// Usage:
+//   node scripts/lib/product-browser.mjs <product-dir> [--json] [--timeout 15000]
+
+import { readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { spawn } from 'node:child_process';
+import { setTimeout as sleep } from 'node:timers/promises';
+import { fileURLToPath } from 'node:url';
+
+const DEFAULT_TIMEOUT_MS = 15000;
+
+/** Which package.json script to use as the preview command, or null if none exists. */
+export function pickPreviewScript(pkg) {
+  const scripts = pkg?.scripts || {};
+  for (const name of ['preview', 'dev', 'start']) {
+    if (scripts[name]) return name;
+  }
+  return null;
+}
+
+/**
+ * F6a: axe-core violations → a11y signal. Pure.
+ * @param {Array<{impact:string}>|null} violations  axe-core's violations array, or null
+ *        when the scan couldn't run (→ 'na', not 0 — a crash isn't "zero violations").
+ * @returns {{ signal: number|'na', violations: number, critical: number }}
+ */
+export function scoreA11y(violations) {
+  if (violations == null) return { signal: 'na', violations: 0, critical: 0 };
+  const critical = violations.filter(v => v.impact === 'critical' || v.impact === 'serious').length;
+  // Full credit at 0 violations; each critical/serious violation costs 0.2, floor 0.
+  const signal = Math.max(0, 1 - critical * 0.2);
+  return { signal: round2(signal), violations: violations.length, critical };
+}
+
+/**
+ * F6b: Web Vitals → a signal per metric + a blended one. Pure. Thresholds are the
+ * standard "good" boundaries (web.dev/vitals): LCP ≤2.5s, CLS ≤0.1, INP ≤200ms.
+ * @param {{lcp:number,cls:number,inp:number}|null} vitals  ms/unitless/ms, or null → 'na'.
+ */
+export function scoreVitals(vitals) {
+  if (vitals == null) return { signal: 'na', lcp: null, cls: null, inp: null };
+  const lcpOk = typeof vitals.lcp === 'number' ? clamp01(1 - Math.max(0, vitals.lcp - 2500) / 2500) : 1;
+  const clsOk = typeof vitals.cls === 'number' ? clamp01(1 - Math.max(0, vitals.cls - 0.1) / 0.25) : 1;
+  const inpOk = typeof vitals.inp === 'number' ? clamp01(1 - Math.max(0, vitals.inp - 200) / 300) : 1;
+  const signal = round2((lcpOk + clsOk + inpOk) / 3);
+  return { signal, lcp: vitals.lcp ?? null, cls: vitals.cls ?? null, inp: vitals.inp ?? null };
+}
+
+function clamp01(n) { return Math.max(0, Math.min(1, n)); }
+function round2(n) { return Math.round(n * 100) / 100; }
+
+// ── impure: launch the preview server + a real browser ────────────────────────
+
+/** Best-effort: does anything answer at `url` yet? */
+async function waitForServer(url, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(url, { signal: AbortSignal.timeout(2000) });
+      if (res.status < 500) return true;
+    } catch { /* not up yet */ }
+    await sleep(300);
+  }
+  return false;
+}
+
+/** Try to dynamically load playwright; null (not a throw) if it's not installed —
+ *  this is the graceful-degradation seam: a product-eval run in an environment
+ *  without the devDependency (or without `npx playwright install`'d browsers)
+ *  must fall through to 'na', never crash the whole eval. */
+async function loadPlaywright() {
+  try { return await import('playwright'); } catch { return null; }
+}
+
+/**
+ * F6a+F6b: run both browser signals against a product's preview server.
+ * Never throws — every failure mode (no preview script, no playwright, server never
+ * comes up, browser launch fails) resolves to { a11y: 'na', vitals: 'na', reason }.
+ * @param {string} dir
+ * @param {object} [opts]
+ * @param {number} [opts.timeoutMs=15000]
+ * @param {number} [opts.port]  override the port probed (default: pick a free-ish one)
+ */
+export async function runBrowserChecks(dir, opts = {}) {
+  const timeoutMs = Number.isFinite(opts.timeoutMs) ? opts.timeoutMs : DEFAULT_TIMEOUT_MS;
+  const na = { a11y: scoreA11y(null), vitals: scoreVitals(null) };
+
+  let pkg;
+  try { pkg = JSON.parse(readFileSync(join(dir, 'package.json'), 'utf8')); } catch { return { ...na, reason: 'no package.json' }; }
+  const scriptName = pickPreviewScript(pkg);
+  if (!scriptName) return { ...na, reason: 'no dev/preview/start script' };
+
+  const pw = await loadPlaywright();
+  if (!pw) return { ...na, reason: 'playwright not installed' };
+
+  const port = opts.port || 4173;
+  const url = opts.url || `http://localhost:${port}`;
+  let proc;
+  try {
+    proc = spawn('npm', ['run', scriptName, '--silent'], { cwd: dir, stdio: 'ignore', detached: true });
+  } catch {
+    return { ...na, reason: 'failed to start preview server' };
+  }
+
+  try {
+    const up = await waitForServer(url, timeoutMs);
+    if (!up) return { ...na, reason: 'preview server did not respond within timeout' };
+
+    let browser;
+    try {
+      browser = await pw.chromium.launch({ headless: true });
+    } catch {
+      return { ...na, reason: 'chromium not installed (run: npx playwright install chromium)' };
+    }
+    try {
+      const page = await browser.newPage();
+      await page.goto(url, { waitUntil: 'load', timeout: timeoutMs });
+
+      // F6a — axe-core. Injected via addScriptTag from the installed devDependency;
+      // no network fetch, no runtime dependency (axe-core is devDependency-only).
+      let violations = null;
+      try {
+        const axePath = fileURLToPath(new URL('../../node_modules/axe-core/axe.min.js', import.meta.url));
+        if (existsSync(axePath)) {
+          await page.addScriptTag({ path: axePath });
+          const results = await page.evaluate(() => window.axe.run());
+          violations = results.violations || [];
+        }
+      } catch { /* leave violations null → 'na' */ }
+
+      // F6b — Web Vitals via the Performance API (no extra library: LCP/CLS come from
+      // PerformanceObserver entries already buffered by the time `load` fires; INP is
+      // approximated from event timing entries, best-effort).
+      let vitals = null;
+      try {
+        vitals = await page.evaluate(() => new Promise((resolve) => {
+          const out = { lcp: null, cls: 0, inp: null };
+          try {
+            const lcpEntries = performance.getEntriesByType('largest-contentful-paint');
+            if (lcpEntries.length) out.lcp = lcpEntries[lcpEntries.length - 1].startTime;
+            for (const e of performance.getEntriesByType('layout-shift')) {
+              if (!e.hadRecentInput) out.cls += e.value;
+            }
+            const evts = performance.getEntriesByType('event');
+            if (evts.length) out.inp = Math.max(...evts.map(e => e.duration));
+          } catch { /* best-effort only */ }
+          resolve(out);
+        }));
+      } catch { /* leave vitals null → 'na' */ }
+
+      return { a11y: scoreA11y(violations), vitals: scoreVitals(vitals), reason: null };
+    } finally {
+      await browser.close().catch(() => {});
+    }
+  } finally {
+    try { proc && process.kill(-proc.pid); } catch { /* already gone */ }
+  }
+}
+
+// ── CLI ───────────────────────────────────────────────────────────────────────
+
+async function main(argv) {
+  const dir = argv.find(a => !a.startsWith('--'));
+  if (!dir || !existsSync(dir)) { console.error('Usage: product-browser.mjs <product-dir> [--json] [--timeout ms]'); process.exit(2); }
+  const ti = argv.indexOf('--timeout');
+  const timeoutMs = ti > -1 ? parseInt(argv[ti + 1], 10) : DEFAULT_TIMEOUT_MS;
+
+  const r = await runBrowserChecks(dir, { timeoutMs });
+  if (argv.includes('--json')) { process.stdout.write(JSON.stringify(r, null, 2)); return; }
+  console.log(`Browser checks — ${dir}`);
+  console.log(`  a11y (axe-core)   ${r.a11y.signal === 'na' ? ' n/a' : `${Math.round(r.a11y.signal * 100)}/100`}  ${r.a11y.signal === 'na' ? '' : `(${r.a11y.violations} violations, ${r.a11y.critical} critical/serious)`}`);
+  console.log(`  vitals (LCP/CLS/INP) ${r.vitals.signal === 'na' ? ' n/a' : `${Math.round(r.vitals.signal * 100)}/100`}  ${r.vitals.signal === 'na' ? '' : `lcp=${r.vitals.lcp}ms cls=${r.vitals.cls} inp=${r.vitals.inp}ms`}`);
+  if (r.reason) console.log(`  (na reason: ${r.reason})`);
+}
+
+const isMain = process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1];
+if (isMain) main(process.argv.slice(2));

--- a/scripts/lib/product-eval.mjs
+++ b/scripts/lib/product-eval.mjs
@@ -10,11 +10,13 @@
 // Usage:
 //   node scripts/lib/product-eval.mjs <product-dir> [--json]
 //   node scripts/lib/product-eval.mjs <dir> --gate --min 70 [--baseline prev.json]   # exit 1 if below/regressed
+//   node scripts/lib/product-eval.mjs <dir> --browser   # F6a/F6b: opt-in headless a11y + Web Vitals signals
 
 import { readFileSync, readdirSync, existsSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
+import { runBrowserChecks } from './product-browser.mjs';
 
 /** Weights sum to 100. n/a dimensions score full (nothing to fail) so a zero-dep
  *  .mjs product isn't punished for lacking a tsconfig/lint/lockfile. */
@@ -128,19 +130,32 @@ function scanSecrets(dir) {
 
 // ── CLI ───────────────────────────────────────────────────────────────────────
 
-function main(argv) {
+async function main(argv) {
   const dir = argv.find(a => !a.startsWith('--'));
-  if (!dir || !existsSync(dir) || !statSync(dir).isDirectory()) { console.error('Usage: product-eval.mjs <dir> [--json] [--gate --min N [--baseline f]]'); process.exit(2); }
+  if (!dir || !existsSync(dir) || !statSync(dir).isDirectory()) { console.error('Usage: product-eval.mjs <dir> [--json] [--gate --min N [--baseline f]] [--browser]'); process.exit(2); }
 
   const results = runEval(dir);
   const res = scoreExecution(results);
 
-  if (argv.includes('--json')) { process.stdout.write(JSON.stringify({ dir, ...res, results }, null, 2)); }
+  // F6a/F6b: opt-in browser signals (a11y + Web Vitals). Additive report only — never
+  // folds into res.total's fixed EXEC_RUBRIC weights (doc non-goal: "add signals,
+  // don't shift weights"). Zero cost when --browser isn't passed: runBrowserChecks is
+  // never even imported-and-called in that case beyond the static import above, which
+  // has no side effects until invoked.
+  let browser = null;
+  if (argv.includes('--browser')) browser = await runBrowserChecks(dir);
+
+  if (argv.includes('--json')) { process.stdout.write(JSON.stringify({ dir, ...res, results, ...(browser ? { browser } : {}) }, null, 2)); }
   else {
     console.log(`Executed quality — ${dir}`);
     for (const b of res.breakdown) console.log(`  ${b.label.padEnd(26)} ${'█'.repeat(Math.round(b.signal * 10)).padEnd(10, '·')} ${b.points}/${b.weight}`);
     console.log(`  tests: ${results.tests.ran ? `${results.tests.passed}/${results.tests.total} pass` : 'no test script'} · typecheck ${results.typecheck} · lint ${results.lint} · vulns ${results.auditHigh ?? 'n/a'} · secrets ${results.secretLeak ? 'LEAK' : 'clean'}`);
     console.log(`\n  EXECUTED SCORE: ${res.total}/100  (grade ${res.grade})`);
+    if (browser) {
+      const a11y = browser.a11y.signal === 'na' ? 'n/a' : `${Math.round(browser.a11y.signal * 100)}/100 (${browser.a11y.violations} violations)`;
+      const vitals = browser.vitals.signal === 'na' ? 'n/a' : `${Math.round(browser.vitals.signal * 100)}/100`;
+      console.log(`  browser: a11y ${a11y} · vitals ${vitals}${browser.reason ? ` (${browser.reason})` : ''}`);
+    }
   }
 
   // gate mode (#2)

--- a/scripts/lib/quality.mjs
+++ b/scripts/lib/quality.mjs
@@ -8,9 +8,9 @@
 // Optionally records the verdict to metrics-history for trend, and gates deploy.
 //
 // Usage:
-//   node scripts/lib/quality.mjs <dir> [--archetype a] [--json] [--record] [--gate --min N]
+//   node scripts/lib/quality.mjs <dir> [--archetype a] [--json] [--record] [--gate --min N] [--baseline prev.json]
 
-import { existsSync, statSync, appendFileSync } from 'node:fs';
+import { existsSync, statSync, appendFileSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { scoreProduct, inspect, detectArchetype } from './product-score.mjs';
@@ -40,13 +40,44 @@ export function assess(dir, archetypeFlag = null) {
   return { archetype: archetype || 'web', floor, ceiling, contracts, contractDetail: c, ...combined };
 }
 
+/**
+ * F5a: gate decision — parity with product-eval.mjs's --gate --baseline (scripts/lib/
+ * product-eval.mjs main()). Pure so it's unit-testable without a subprocess.
+ *   • fails if `overall < min` (absolute floor, default 70)
+ *   • fails if a baseline is given and `overall < baselineTotal - 2` (regression gate;
+ *     >2-point drop, same threshold/semantics as product-eval)
+ * `readBaseline(path)` reads a JSON file and must return the previous overall/total
+ * (or null/throw if unavailable) — injected so callers can pass the right field name.
+ * @returns {{ ok: boolean, reason: string }}
+ */
+export function evaluateGate(overall, { min = 70, baselineTotal = null } = {}) {
+  if (overall < min) return { ok: false, reason: `score ${overall} < min ${min}` };
+  if (typeof baselineTotal === 'number' && overall < baselineTotal - 2) {
+    return { ok: false, reason: `regression ${overall} < baseline ${baselineTotal}` };
+  }
+  return { ok: true, reason: '' };
+}
+
+/** Read a baseline JSON file's overall score. quality.mjs's own --json output uses
+ *  `overall`; product-eval.mjs's baseline files use `total` — accept either so a
+ *  product-eval baseline file can also be reused here. Returns null on any failure
+ *  (missing file, bad JSON, missing field) — gate then just skips the regression check. */
+export function readBaselineOverall(path) {
+  if (!path) return null;
+  try {
+    const j = JSON.parse(readFileSync(path, 'utf8'));
+    const v = typeof j.overall === 'number' ? j.overall : (typeof j.total === 'number' ? j.total : null);
+    return typeof v === 'number' ? v : null;
+  } catch { return null; }
+}
+
 // ── CLI ───────────────────────────────────────────────────────────────────────
 
 const PROJ_DIR = process.env.GREAT_CTO_DIR || '.great_cto';
 
 function main(argv) {
   const dir = argv.find(a => !a.startsWith('--'));
-  if (!dir || !existsSync(dir) || !statSync(dir).isDirectory()) { console.error('Usage: quality.mjs <dir> [--archetype a] [--json] [--record] [--gate --min N]'); process.exit(2); }
+  if (!dir || !existsSync(dir) || !statSync(dir).isDirectory()) { console.error('Usage: quality.mjs <dir> [--archetype a] [--json] [--record] [--gate --min N] [--baseline prev.json]'); process.exit(2); }
   const ai = argv.indexOf('--archetype');
   const r = assess(dir, ai > -1 ? argv[ai + 1] : null);
 
@@ -68,8 +99,11 @@ function main(argv) {
   }
 
   if (argv.includes('--gate')) {
-    const gi = argv.indexOf('--min'); const min = gi > -1 ? parseFloat(argv[gi + 1]) : 70;
-    if (r.overall < min) { console.error(`\ngate:quality BLOCK — overall ${r.overall} < min ${min}`); process.exit(1); }
+    const get = (n) => { const i = argv.indexOf(n); return i > -1 ? argv[i + 1] : null; };
+    const min = parseFloat(get('--min') || '70');
+    const baselineTotal = readBaselineOverall(get('--baseline'));
+    const { ok, reason } = evaluateGate(r.overall, { min, baselineTotal });
+    if (!ok) { console.error(`\ngate:quality BLOCK — ${reason}`); process.exit(1); }
     if (!argv.includes('--json')) console.log('\ngate:quality PASS');
   }
 }

--- a/scripts/lib/quality.mjs
+++ b/scripts/lib/quality.mjs
@@ -9,6 +9,7 @@
 //
 // Usage:
 //   node scripts/lib/quality.mjs <dir> [--archetype a] [--json] [--record] [--gate --min N] [--baseline prev.json]
+//   node scripts/lib/quality.mjs --trend [--history file] [--last N]
 
 import { existsSync, statSync, appendFileSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
@@ -16,6 +17,7 @@ import { fileURLToPath } from 'node:url';
 import { scoreProduct, inspect, detectArchetype } from './product-score.mjs';
 import { runEval, scoreExecution } from './product-eval.mjs';
 import { checkContracts, readTestText } from './archetype-contracts.mjs';
+import { parseHistory } from './metrics-trend.mjs';
 
 /** Blend the three lenses → overall 0-100. ceiling weighted most (execution > shape);
  *  contracts dropped+renormalized when the archetype has none. */
@@ -71,13 +73,95 @@ export function readBaselineOverall(path) {
   } catch { return null; }
 }
 
+// ── F5b: --trend — quality-scoped view over metrics-trend.mjs's history ───────
+// Not a replacement for metrics-trend.mjs (generic, any metric key) — this is a thin
+// view filtered to the `quality.*` keys quality.mjs --record writes, rendered as a
+// terminal sparkline + delta so a regression is visible at a glance without --json.
+
+const SPARK_TICKS = '▁▂▃▄▅▆▇█';
+
+/** value (0-100 scale expected, but works for any range within [lo,hi]) → one tick char. */
+function sparkChar(v, lo, hi) {
+  if (hi <= lo) return SPARK_TICKS[0];
+  const idx = Math.round(((v - lo) / (hi - lo)) * (SPARK_TICKS.length - 1));
+  return SPARK_TICKS[Math.max(0, Math.min(SPARK_TICKS.length - 1, idx))];
+}
+
+/** Build a sparkline string for a series of 0-1 scale values (metrics-history convention). */
+export function sparkline(values) {
+  if (!values.length) return '';
+  const lo = Math.min(...values), hi = Math.max(...values);
+  return values.map(v => sparkChar(v, lo, hi)).join('');
+}
+
+/**
+ * F5b: quality-scoped trend view. Reads metrics-history rows (as parsed by
+ * metrics-trend.mjs's parseHistory), keeps only `quality.*` keys, and returns one
+ * series per archetype key: last-N overall scores (0-100 scale) + Δ vs the point
+ * before the window. Pure + read-only — never throws, never signals failure; the
+ * caller always exits 0 (REQ-4).
+ * @param {Array<{key,value,ts}>} rows  chronological (oldest→newest), metrics-trend shape
+ * @param {object} [opts]
+ * @param {number} [opts.last=10]  how many most-recent points to show per key
+ * @returns {Array<{key,archetype,points,scores,delta,latest}>}
+ */
+export function buildTrend(rows, opts = {}) {
+  const last = Number.isFinite(opts.last) ? opts.last : 10;
+  const byKey = new Map();
+  for (const r of rows) {
+    if (typeof r.key !== 'string' || !r.key.startsWith('quality.')) continue;
+    if (!byKey.has(r.key)) byKey.set(r.key, []);
+    byKey.get(r.key).push(r.value);
+  }
+  const out = [];
+  for (const [key, values] of byKey) {
+    const scores = values.slice(-last).map(v => Math.round(v * 100)); // stored as 0-1, display 0-100
+    const latest = scores[scores.length - 1];
+    const prev = scores.length >= 2 ? scores[scores.length - 2] : null;
+    const delta = prev === null ? null : latest - prev;
+    out.push({ key, archetype: key.slice('quality.'.length), points: scores.length, scores, delta, latest });
+  }
+  out.sort((a, b) => a.archetype.localeCompare(b.archetype));
+  return out;
+}
+
+/** Render buildTrend() output as a terminal-friendly table + sparkline. */
+export function renderTrendText(trend) {
+  if (!trend.length) return 'quality --trend: no recorded quality.* history yet (run with --record first).';
+  const lines = ['Quality trend (last-N overall scores per archetype)', ''];
+  for (const t of trend) {
+    const spark = sparkline(t.scores.map(s => s / 100));
+    const deltaStr = t.delta === null ? '(first point)' : `Δ${t.delta >= 0 ? '+' : ''}${t.delta}`;
+    lines.push(`  ${t.archetype.padEnd(18)} ${spark}  ${String(t.latest).padStart(3)}/100  ${deltaStr}  (n=${t.points})`);
+  }
+  return lines.join('\n');
+}
+
 // ── CLI ───────────────────────────────────────────────────────────────────────
 
 const PROJ_DIR = process.env.GREAT_CTO_DIR || '.great_cto';
 
+/** F5b: --trend doesn't need a product dir — it's a read-only view over recorded
+ *  history. Handled before the dir-required path. Exit 0 always (read-only report). */
+function cmdTrend(argv) {
+  const get = (n) => { const i = argv.indexOf(n); return i > -1 ? argv[i + 1] : null; };
+  const historyPath = get('--history') || join(PROJ_DIR, 'metrics-history.jsonl');
+  const last = parseInt(get('--last') || '10', 10);
+  let rows = [];
+  if (existsSync(historyPath)) {
+    try { rows = parseHistory(readFileSync(historyPath, 'utf8')); } catch { /* ignore, render empty */ }
+  }
+  const trend = buildTrend(rows, { last });
+  if (argv.includes('--json')) process.stdout.write(JSON.stringify(trend, null, 2) + '\n');
+  else console.log(renderTrendText(trend));
+  process.exit(0);
+}
+
 function main(argv) {
+  if (argv.includes('--trend')) return cmdTrend(argv);
+
   const dir = argv.find(a => !a.startsWith('--'));
-  if (!dir || !existsSync(dir) || !statSync(dir).isDirectory()) { console.error('Usage: quality.mjs <dir> [--archetype a] [--json] [--record] [--gate --min N] [--baseline prev.json]'); process.exit(2); }
+  if (!dir || !existsSync(dir) || !statSync(dir).isDirectory()) { console.error('Usage: quality.mjs <dir> [--archetype a] [--json] [--record] [--gate --min N] [--baseline prev.json]\n       quality.mjs --trend [--history file] [--last N]'); process.exit(2); }
   const ai = argv.indexOf('--archetype');
   const r = assess(dir, ai > -1 ? argv[ai + 1] : null);
 

--- a/tests/lib/archetype-contracts.test.mjs
+++ b/tests/lib/archetype-contracts.test.mjs
@@ -43,3 +43,118 @@ test('checkContracts: unknown archetype family → no contracts', () => {
   assert.equal(r.total, 0);
   assert.equal(r.coverage, null);
 });
+
+// ── F3a: +8 archetypes (docs/arch/ARCH-quality-deepen-followups.md, REQ-2) ────
+
+test('CONTRACTS covers 14 archetypes total (6 web families + 8 F3a families)', () => {
+  assert.equal(Object.keys(CONTRACTS).length, 14);
+});
+
+test('contractFamily maps the 8 new real archetype names to their families', () => {
+  assert.equal(contractFamily('ai-system'), 'ai-system');
+  assert.equal(contractFamily('agent-product'), 'agent-product');
+  assert.equal(contractFamily('commerce'), 'commerce');
+  assert.equal(contractFamily('web3'), 'web3');
+  assert.equal(contractFamily('iot-embedded'), 'iot-embedded');
+  assert.equal(contractFamily('data-platform'), 'data-platform');
+  assert.equal(contractFamily('browser-extension'), 'browser-extension');
+  assert.equal(contractFamily('mobile-app'), 'mobile-app');
+});
+
+test('contractFamily: agent-product is checked before the looser ai-system pattern', () => {
+  // agent-product stack names often also match /ai|llm/ loosely; the more specific
+  // family must win so agent-specific invariants (tool-allowlist, isolation) apply.
+  assert.equal(contractFamily('agent-runtime'), 'agent-product');
+  assert.equal(contractFamily('agentic-workflow'), 'agent-product');
+});
+
+test('checkContracts: ai-system — prompt-injection + output-validation + rate-limit all covered → 100%', () => {
+  const txt = 'blocks prompt injection attempts; validates output against schema before use; enforces a token budget per request';
+  const r = checkContracts('ai-system', txt);
+  assert.equal(r.total, 3);
+  assert.equal(r.covered, 3);
+  assert.equal(r.coverage, 100);
+});
+
+test('checkContracts: ai-system missing rate-limit → flagged', () => {
+  const txt = 'rejects prompt injection; validates model output schema'; // no cost/rate-limit test
+  const r = checkContracts('ai-system', txt);
+  assert.equal(r.results.find(c => c.id === 'rate-limit').covered, false);
+  assert.ok(r.coverage < 100);
+});
+
+test('checkContracts: agent-product — tool-allowlist + isolation + budget all covered → 100%', () => {
+  const txt = 'tool allowlist restricts unsafe tools; enforces cross-user session isolation; caps agent loop at max turns to prevent runaway budget';
+  const r = checkContracts('agent-product', txt);
+  assert.equal(r.covered, 3);
+  assert.equal(r.coverage, 100);
+});
+
+test('checkContracts: commerce — idempotent payment + webhook signature + refund flow covered', () => {
+  const txt = 'duplicate charge rejected (idempotent); invalid stripe signature rejected; refund flow issues a credit';
+  const r = checkContracts('commerce', txt);
+  assert.equal(r.covered, 3);
+  assert.equal(r.coverage, 100);
+});
+
+test('checkContracts: commerce missing webhook-signature → flagged', () => {
+  const txt = 'duplicate charge is idempotent; refund flow tested'; // no webhook signature check
+  const r = checkContracts('commerce', txt);
+  assert.equal(r.results.find(c => c.id === 'webhook-signature').covered, false);
+  assert.ok(r.coverage < 100);
+});
+
+test('checkContracts: web3 — reentrancy + access-control + oracle-staleness covered', () => {
+  const txt = 'reentrancy guard blocks recursive call; onlyOwner reverts for unauthorized caller; stale price from oracle feed rejected';
+  const r = checkContracts('web3', txt);
+  assert.equal(r.covered, 3);
+  assert.equal(r.coverage, 100);
+});
+
+test('checkContracts: iot-embedded — OTA signature + watchdog covered', () => {
+  const txt = 'OTA update rejects invalid firmware signature; watchdog reboot recovers from hang';
+  const r = checkContracts('iot-embedded', txt);
+  assert.equal(r.total, 2);
+  assert.equal(r.covered, 2);
+  assert.equal(r.coverage, 100);
+});
+
+test('checkContracts: data-platform — schema drift + idempotent pipeline + PII covered', () => {
+  const txt = 'detects schema drift as a breaking change; backfill re-run is idempotent (safe to run twice); PII columns are masked';
+  const r = checkContracts('data-platform', txt);
+  assert.equal(r.covered, 3);
+  assert.equal(r.coverage, 100);
+});
+
+test('checkContracts: browser-extension — CSP + permission scope covered', () => {
+  const txt = 'content security policy blocks unsafe-eval; host permission scope is minimal, extra origins denied';
+  const r = checkContracts('browser-extension', txt);
+  assert.equal(r.total, 2);
+  assert.equal(r.covered, 2);
+  assert.equal(r.coverage, 100);
+});
+
+test('checkContracts: mobile-app — deep link validation + offline handling covered', () => {
+  const txt = 'deep link payload is validated before navigation; offline mode falls back to cached data';
+  const r = checkContracts('mobile-app', txt);
+  assert.equal(r.total, 2);
+  assert.equal(r.covered, 2);
+  assert.equal(r.coverage, 100);
+});
+
+test('checkContracts: mobile-app missing offline handling → flagged', () => {
+  const txt = 'deep link payload validated on open'; // no offline/no-connectivity path
+  const r = checkContracts('mobile-app', txt);
+  assert.equal(r.results.find(c => c.id === 'offline-handling').covered, false);
+  assert.ok(r.coverage < 100);
+});
+
+test('every new F3a archetype has ≥2 invariants with a rubric-documented rationale', () => {
+  const newFamilies = ['ai-system', 'agent-product', 'commerce', 'web3', 'iot-embedded', 'data-platform', 'browser-extension', 'mobile-app'];
+  for (const fam of newFamilies) {
+    assert.ok(CONTRACTS[fam].length >= 2, `${fam} needs ≥2 invariants`);
+    for (const item of CONTRACTS[fam]) {
+      assert.ok(item.desc && item.desc.length > 0, `${fam}/${item.id} needs a non-empty rationale (desc)`);
+    }
+  }
+});

--- a/tests/lib/archetype-contracts.test.mjs
+++ b/tests/lib/archetype-contracts.test.mjs
@@ -149,6 +149,51 @@ test('checkContracts: mobile-app missing offline handling → flagged', () => {
   assert.ok(r.coverage < 100);
 });
 
+// ── F3c: regex hardening — false-positive regression tests (ARCH doc example: /hold/
+// matching "household") ────────────────────────────────────────────────────────
+
+test('F3c regression: marketplace escrow-held does NOT false-positive on "household"/"threshold"/"shareholder"', () => {
+  assert.equal(checkContracts('marketplace', 'test household chores workflow').results.find(c => c.id === 'escrow-held').covered, false);
+  assert.equal(checkContracts('marketplace', 'checks the threshold value').results.find(c => c.id === 'escrow-held').covered, false);
+  assert.equal(checkContracts('marketplace', 'validates the shareholder record').results.find(c => c.id === 'escrow-held').covered, false);
+});
+
+test('F3c regression: marketplace escrow-held still true-positives on "hold"/"held"/"holding"', () => {
+  assert.equal(checkContracts('marketplace', 'creates escrow hold on order').results.find(c => c.id === 'escrow-held').covered, true);
+  assert.equal(checkContracts('marketplace', 'the funds are held until release').results.find(c => c.id === 'escrow-held').covered, true);
+  assert.equal(checkContracts('marketplace', 'holding period enforced').results.find(c => c.id === 'escrow-held').covered, true);
+});
+
+test('F3c regression: dashboard aggregation catches groupBy(...) idiom (doc example: bare /aggregat/ misses it)', () => {
+  assert.equal(checkContracts('dashboard', 'groupBy(items).sum() returns totals').results.find(c => c.id === 'aggregation').covered, true);
+});
+
+test('F3c regression: dashboard aggregation metric does NOT false-positive on "asymmetric"', () => {
+  const r = checkContracts('dashboard', 'asymmetric routing test for the load balancer');
+  assert.equal(r.results.find(c => c.id === 'aggregation').covered, false);
+});
+
+test('F3c regression: dashboard window does NOT false-positive on "Windows OS"', () => {
+  assert.equal(checkContracts('dashboard', 'Windows OS compatibility test').results.find(c => c.id === 'window').covered, false);
+});
+
+test('F3c regression: dashboard window still true-positives on "time-window boundaries"', () => {
+  assert.equal(checkContracts('dashboard', 'time-window boundaries respected').results.find(c => c.id === 'window').covered, true);
+});
+
+test('F3c regression: crm stage-transitions does NOT false-positive on "backstage"', () => {
+  assert.equal(checkContracts('crm', 'backstage pass area rendering').results.find(c => c.id === 'stage-transitions').covered, false);
+});
+
+test('F3c regression: crm stage-transitions does NOT false-positive on "in advance of launch" (unrelated to deal progression)', () => {
+  assert.equal(checkContracts('crm', 'ships the feature in advance of launch day').results.find(c => c.id === 'stage-transitions').covered, false);
+});
+
+test('F3c regression: crm stage-transitions still true-positives on "advances the deal" / pipeline stage moves', () => {
+  assert.equal(checkContracts('crm', 'advances the deal to negotiation').results.find(c => c.id === 'stage-transitions').covered, true);
+  assert.equal(checkContracts('crm', 'valid pipeline stage transitions').results.find(c => c.id === 'stage-transitions').covered, true);
+});
+
 test('every new F3a archetype has ≥2 invariants with a rubric-documented rationale', () => {
   const newFamilies = ['ai-system', 'agent-product', 'commerce', 'web3', 'iot-embedded', 'data-platform', 'browser-extension', 'mobile-app'];
   for (const fam of newFamilies) {

--- a/tests/lib/fixtures/metrics-history.jsonl
+++ b/tests/lib/fixtures/metrics-history.jsonl
@@ -1,0 +1,8 @@
+{"ts":"2026-06-01T00:00:00Z","key":"quality.cli","value":0.70,"source":"quality"}
+{"ts":"2026-06-08T00:00:00Z","key":"quality.cli","value":0.74,"source":"quality"}
+{"ts":"2026-06-15T00:00:00Z","key":"quality.cli","value":0.72,"source":"quality"}
+{"ts":"2026-06-22T00:00:00Z","key":"quality.cli","value":0.80,"source":"quality"}
+{"ts":"2026-06-29T00:00:00Z","key":"quality.cli","value":0.85,"source":"quality"}
+{"ts":"2026-06-01T00:00:00Z","key":"quality.crud","value":0.90,"source":"quality"}
+{"ts":"2026-06-15T00:00:00Z","key":"quality.crud","value":0.65,"source":"quality"}
+{"ts":"2026-06-01T00:00:00Z","key":"eval_pass_rate","value":0.92,"source":"runner"}

--- a/tests/lib/product-browser.test.mjs
+++ b/tests/lib/product-browser.test.mjs
@@ -1,0 +1,120 @@
+// tests/lib/product-browser.test.mjs — QUALITY-DEEPEN #6 headless browser signals
+// (F6a a11y + F6b Web Vitals). No browser download happens in this file: the pure
+// scoring helpers are tested directly, and the na-path (graceful degradation) is
+// tested via runBrowserChecks against fixture dirs that lack a preview script /
+// don't have playwright available — the exact same code path a CI box without
+// `npx playwright install` would hit.
+// Run: node --test tests/lib/product-browser.test.mjs
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  pickPreviewScript, scoreA11y, scoreVitals, runBrowserChecks,
+} from '../../scripts/lib/product-browser.mjs';
+
+// ── pure: pickPreviewScript ─────────────────────────────────────────────────
+
+test('pickPreviewScript: prefers preview > dev > start', () => {
+  assert.equal(pickPreviewScript({ scripts: { preview: 'x', dev: 'y', start: 'z' } }), 'preview');
+  assert.equal(pickPreviewScript({ scripts: { dev: 'y', start: 'z' } }), 'dev');
+  assert.equal(pickPreviewScript({ scripts: { start: 'z' } }), 'start');
+});
+
+test('pickPreviewScript: no matching script → null', () => {
+  assert.equal(pickPreviewScript({ scripts: { build: 'tsc', test: 'node --test' } }), null);
+  assert.equal(pickPreviewScript({}), null);
+  assert.equal(pickPreviewScript(null), null);
+});
+
+// ── pure: scoreA11y (F6a) ────────────────────────────────────────────────────
+
+test('scoreA11y: null violations (scan did not run) → na, not 0', () => {
+  const r = scoreA11y(null);
+  assert.equal(r.signal, 'na');
+});
+
+test('scoreA11y: zero violations → full credit', () => {
+  const r = scoreA11y([]);
+  assert.equal(r.signal, 1);
+  assert.equal(r.violations, 0);
+});
+
+test('scoreA11y: critical/serious violations reduce the signal', () => {
+  const r = scoreA11y([{ impact: 'critical' }, { impact: 'serious' }, { impact: 'minor' }]);
+  assert.equal(r.critical, 2);
+  assert.equal(r.violations, 3);
+  assert.ok(r.signal < 1);
+});
+
+test('scoreA11y: signal floors at 0, never negative', () => {
+  const many = Array.from({ length: 20 }, () => ({ impact: 'critical' }));
+  assert.equal(scoreA11y(many).signal, 0);
+});
+
+// ── pure: scoreVitals (F6b) ──────────────────────────────────────────────────
+
+test('scoreVitals: null vitals (scan did not run) → na', () => {
+  assert.equal(scoreVitals(null).signal, 'na');
+});
+
+test('scoreVitals: good LCP/CLS/INP → signal near 1', () => {
+  const r = scoreVitals({ lcp: 1200, cls: 0.02, inp: 80 });
+  assert.equal(r.signal, 1);
+});
+
+test('scoreVitals: poor LCP degrades the signal', () => {
+  const r = scoreVitals({ lcp: 8000, cls: 0.02, inp: 80 });
+  assert.ok(r.signal < 1);
+});
+
+test('scoreVitals: poor CLS degrades the signal', () => {
+  const r = scoreVitals({ lcp: 1200, cls: 0.5, inp: 80 });
+  assert.ok(r.signal < 1);
+});
+
+test('scoreVitals: signal clamps to [0,1]', () => {
+  const r = scoreVitals({ lcp: 999999, cls: 999, inp: 999999 });
+  assert.ok(r.signal >= 0 && r.signal <= 1);
+});
+
+// ── na-path integration: runBrowserChecks graceful degradation ──────────────
+// These exercise the real function but never reach a browser launch — either
+// because there's no preview script (fails before playwright is even imported)
+// or because playwright isn't installed in the test environment (this repo's root
+// node_modules is not populated in CI's unit-test job — --browser is opt-in and
+// only exercised in fleet runs where the devDependency is actually installed).
+
+test('runBrowserChecks: no package.json → na with a reason, does not throw', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'browser-nopkg-'));
+  const r = await runBrowserChecks(dir, { timeoutMs: 500 });
+  assert.equal(r.a11y.signal, 'na');
+  assert.equal(r.vitals.signal, 'na');
+  assert.equal(r.reason, 'no package.json');
+  rmSync(dir, { recursive: true, force: true });
+});
+
+test('runBrowserChecks: package.json with no dev/preview/start script → na, no server spawned', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'browser-noscript-'));
+  writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'x', scripts: { build: 'tsc' } }));
+  const r = await runBrowserChecks(dir, { timeoutMs: 500 });
+  assert.equal(r.a11y.signal, 'na');
+  assert.equal(r.vitals.signal, 'na');
+  assert.equal(r.reason, 'no dev/preview/start script');
+  rmSync(dir, { recursive: true, force: true });
+});
+
+test('runBrowserChecks: has a preview script but playwright is unavailable → na, never crashes', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'browser-nopw-'));
+  writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'x', scripts: { dev: 'echo up' } }));
+  const r = await runBrowserChecks(dir, { timeoutMs: 500 });
+  assert.equal(r.a11y.signal, 'na');
+  assert.equal(r.vitals.signal, 'na');
+  // Either playwright genuinely isn't installed in this environment (most CI/unit-test
+  // boxes) or it is but the fake server never comes up in 500ms — both are legitimate
+  // na outcomes and neither should ever throw.
+  assert.ok(['playwright not installed', 'preview server did not respond within timeout'].includes(r.reason), r.reason);
+  rmSync(dir, { recursive: true, force: true });
+});

--- a/tests/lib/product-browser.test.mjs
+++ b/tests/lib/product-browser.test.mjs
@@ -80,6 +80,20 @@ test('scoreVitals: signal clamps to [0,1]', () => {
   assert.ok(r.signal >= 0 && r.signal <= 1);
 });
 
+test('scoreVitals: F6b — a partially-unsupported metric (e.g. INP on a browser without the Event Timing API) does not penalize', () => {
+  // The Performance API's INP support is Chromium-only in practice; a harness running
+  // against WebKit/Firefox would legitimately get inp: null. Missing ≠ bad — only a
+  // measured value that exceeds the "good" threshold should cost signal.
+  const withInp = scoreVitals({ lcp: 1200, cls: 0.02, inp: null });
+  assert.equal(withInp.signal, 1);
+  assert.equal(withInp.inp, null);
+});
+
+test('scoreVitals: F6b — each metric degrades independently (LCP fine, CLS bad, INP fine)', () => {
+  const r = scoreVitals({ lcp: 1000, cls: 0.4, inp: 50 });
+  assert.ok(r.signal < 1 && r.signal > 0, `expected a partial hit, got ${r.signal}`);
+});
+
 // ── na-path integration: runBrowserChecks graceful degradation ──────────────
 // These exercise the real function but never reach a browser launch — either
 // because there's no preview script (fails before playwright is even imported)

--- a/tests/lib/product-eval.test.mjs
+++ b/tests/lib/product-eval.test.mjs
@@ -4,6 +4,13 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { EXEC_RUBRIC, scoreExecution, parseTestCounts } from '../../scripts/lib/product-eval.mjs';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const TOOL = join(dirname(fileURLToPath(import.meta.url)), '..', '..', 'scripts', 'lib', 'product-eval.mjs');
 
 test('EXEC_RUBRIC weights sum to 100', () => {
   assert.equal(EXEC_RUBRIC.reduce((a, d) => a + d.weight, 0), 100);
@@ -43,4 +50,40 @@ test('parseTestCounts: node:test spec + TAP forms', () => {
   assert.deepEqual(parseTestCounts('ℹ tests 13\nℹ pass 13\nℹ fail 0'), { total: 13, pass: 13, fail: 0 });
   assert.deepEqual(parseTestCounts('# tests 5\n# pass 4\n# fail 1'), { total: 5, pass: 4, fail: 1 });
   assert.deepEqual(parseTestCounts('no counts here'), { total: null, pass: null, fail: null });
+});
+
+// ── F6a/F6b: --browser opt-in hook — additive, never shifts EXEC_RUBRIC's total ────
+
+test('CLI: --browser is opt-in — EXECUTED SCORE is identical with and without it', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'eval-browser-'));
+  writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'x', scripts: { build: 'true' } }));
+  const without = spawnSync(process.execPath, [TOOL, dir, '--json'], { encoding: 'utf8' });
+  const withBrowser = spawnSync(process.execPath, [TOOL, dir, '--browser', '--json'], { encoding: 'utf8' });
+  assert.equal(without.status, 0, without.stdout + without.stderr);
+  assert.equal(withBrowser.status, 0, withBrowser.stdout + withBrowser.stderr);
+  const a = JSON.parse(without.stdout);
+  const b = JSON.parse(withBrowser.stdout);
+  assert.equal(a.total, b.total, 'the a11y/vitals signals must not shift the fixed-weight executed score');
+  rmSync(dir, { recursive: true, force: true });
+});
+
+test('CLI: --browser --json includes a browser field with na signals (no preview script)', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'eval-browser-noscript-'));
+  writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'x', scripts: { build: 'true' } }));
+  const res = spawnSync(process.execPath, [TOOL, dir, '--browser', '--json'], { encoding: 'utf8' });
+  assert.equal(res.status, 0, res.stdout + res.stderr);
+  const parsed = JSON.parse(res.stdout);
+  assert.equal(parsed.browser.a11y.signal, 'na');
+  assert.equal(parsed.browser.vitals.signal, 'na');
+  assert.equal(parsed.browser.reason, 'no dev/preview/start script');
+  rmSync(dir, { recursive: true, force: true });
+});
+
+test('CLI: without --browser, --json has no browser field at all', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'eval-nobrowser-'));
+  writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'x', scripts: { build: 'true' } }));
+  const res = spawnSync(process.execPath, [TOOL, dir, '--json'], { encoding: 'utf8' });
+  assert.equal(res.status, 0);
+  assert.ok(!('browser' in JSON.parse(res.stdout)));
+  rmSync(dir, { recursive: true, force: true });
 });

--- a/tests/lib/product-eval.test.mjs
+++ b/tests/lib/product-eval.test.mjs
@@ -87,3 +87,12 @@ test('CLI: without --browser, --json has no browser field at all', () => {
   assert.ok(!('browser' in JSON.parse(res.stdout)));
   rmSync(dir, { recursive: true, force: true });
 });
+
+test('CLI: F6b — text-mode --browser output prints a "vitals" field on its own report line (not folded into EXECUTED SCORE)', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'eval-browser-vitals-'));
+  writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'x', scripts: { build: 'true' } }));
+  const res = spawnSync(process.execPath, [TOOL, dir, '--browser'], { encoding: 'utf8' });
+  assert.equal(res.status, 0, res.stdout + res.stderr);
+  assert.match(res.stdout, /browser: a11y .* vitals /);
+  rmSync(dir, { recursive: true, force: true });
+});

--- a/tests/lib/product-score.test.mjs
+++ b/tests/lib/product-score.test.mjs
@@ -81,9 +81,13 @@ test('archetype-aware: a CLI is not penalized for no UI/deploy (scores higher as
   assert.ok(asCli > asWeb, `cli (${asCli}) should beat web (${asWeb}) when UI/deploy legitimately absent`);
 });
 
-test('detectArchetype: packages/cli → its real archetype (cli-tool), normalizes to cli family', () => {
+test('detectArchetype: packages/cli → bin-fallback detects cli family directly', () => {
+  // packages/cli has no .great_cto/PROJECT.md, so detectArchetype falls through to the
+  // package.json `bin` heuristic, which returns the scoring-family name 'cli' directly
+  // (not the canonical archetypes.ts id 'cli-tool' — that only comes from a PROJECT.md
+  // archetype: line). normalizeArchetype is idempotent on an already-normalized family.
   const a = detectArchetype(join(ROOT, 'packages', 'cli'));
-  assert.equal(a, 'cli-tool');
+  assert.equal(a, 'cli');
   assert.equal(normalizeArchetype(a), 'cli');
 });
 
@@ -99,7 +103,7 @@ import { scoreDir, renderScoreMarkdown } from '../../scripts/lib/product-score.m
 test('scoreDir: end-to-end on a real codebase returns a total + archetype', () => {
   const r = scoreDir(join(ROOT, 'packages', 'cli'));
   assert.ok(r.total >= 0 && r.total <= 100);
-  assert.equal(r.archetype, 'cli-tool'); // detected from PROJECT.md, normalized internally
+  assert.equal(r.archetype, 'cli'); // bin-fallback detection (no PROJECT.md present)
 });
 
 test('renderScoreMarkdown: emits a SCORE artifact with total + table', () => {

--- a/tests/lib/quality.test.mjs
+++ b/tests/lib/quality.test.mjs
@@ -3,9 +3,11 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { combinedScore, assess } from '../../scripts/lib/quality.mjs';
+import { combinedScore, assess, evaluateGate, readBaselineOverall } from '../../scripts/lib/quality.mjs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
 
@@ -35,4 +37,75 @@ test('assess: real codebase returns all three lenses + overall', () => {
   assert.ok(typeof r.floor === 'number' && typeof r.ceiling === 'number');
   assert.ok(r.overall >= 0 && r.overall <= 100);
   assert.ok(r.archetype);
+});
+
+// ── F5a: gate parity with product-eval.mjs --gate --baseline ──────────────────
+
+test('evaluateGate: below min → BLOCK with score-vs-min reason', () => {
+  const r = evaluateGate(65, { min: 70 });
+  assert.equal(r.ok, false);
+  assert.equal(r.reason, 'score 65 < min 70');
+});
+
+test('evaluateGate: at/above min, no baseline → PASS', () => {
+  assert.equal(evaluateGate(70, { min: 70 }).ok, true);
+  assert.equal(evaluateGate(100, { min: 70 }).ok, true);
+});
+
+test('evaluateGate: regression > 2 points vs baseline → BLOCK (product-eval parity)', () => {
+  const r = evaluateGate(80, { min: 70, baselineTotal: 85 }); // 85-80=5 > 2
+  assert.equal(r.ok, false);
+  assert.equal(r.reason, 'regression 80 < baseline 85');
+});
+
+test('evaluateGate: regression exactly 2 points → still PASS (product-eval uses strict < prev-2)', () => {
+  const r = evaluateGate(83, { min: 70, baselineTotal: 85 }); // 85-2=83, 83 < 83 is false
+  assert.equal(r.ok, true);
+});
+
+test('evaluateGate: 3-point regression → BLOCK (boundary just past the >2 threshold)', () => {
+  const r = evaluateGate(82, { min: 70, baselineTotal: 85 }); // 82 < 83 → true
+  assert.equal(r.ok, false);
+});
+
+test('evaluateGate: score improved vs baseline → PASS', () => {
+  assert.equal(evaluateGate(90, { min: 70, baselineTotal: 85 }).ok, true);
+});
+
+test('evaluateGate: min failure takes precedence even with a passing baseline delta', () => {
+  const r = evaluateGate(50, { min: 70, baselineTotal: 50 }); // no regression vs itself, but below min
+  assert.equal(r.ok, false);
+  assert.equal(r.reason, 'score 50 < min 70');
+});
+
+test('readBaselineOverall: reads `overall` field (quality.mjs --json shape)', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'quality-baseline-'));
+  const f = join(dir, 'prev.json');
+  writeFileSync(f, JSON.stringify({ overall: 77 }));
+  assert.equal(readBaselineOverall(f), 77);
+  rmSync(dir, { recursive: true, force: true });
+});
+
+test('readBaselineOverall: falls back to `total` field (product-eval.mjs baseline file shape)', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'quality-baseline-'));
+  const f = join(dir, 'prev.json');
+  writeFileSync(f, JSON.stringify({ total: 82 }));
+  assert.equal(readBaselineOverall(f), 82);
+  rmSync(dir, { recursive: true, force: true });
+});
+
+test('readBaselineOverall: missing file → null (gate skips regression check, never crashes)', () => {
+  assert.equal(readBaselineOverall('/nonexistent/prev.json'), null);
+});
+
+test('readBaselineOverall: no path given → null', () => {
+  assert.equal(readBaselineOverall(null), null);
+});
+
+test('readBaselineOverall: malformed JSON → null, not a throw', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'quality-baseline-'));
+  const f = join(dir, 'bad.json');
+  writeFileSync(f, '{ not json');
+  assert.equal(readBaselineOverall(f), null);
+  rmSync(dir, { recursive: true, force: true });
 });

--- a/tests/lib/quality.test.mjs
+++ b/tests/lib/quality.test.mjs
@@ -3,11 +3,14 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { combinedScore, assess, evaluateGate, readBaselineOverall } from '../../scripts/lib/quality.mjs';
+import { combinedScore, assess, evaluateGate, readBaselineOverall, sparkline, buildTrend, renderTrendText } from '../../scripts/lib/quality.mjs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { mkdtempSync, writeFileSync, rmSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
+import { spawnSync } from 'node:child_process';
+
+const TOOL = join(dirname(fileURLToPath(import.meta.url)), '..', '..', 'scripts', 'lib', 'quality.mjs');
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
 
@@ -109,3 +112,109 @@ test('readBaselineOverall: malformed JSON → null, not a throw', () => {
   assert.equal(readBaselineOverall(f), null);
   rmSync(dir, { recursive: true, force: true });
 });
+
+// ── F5b: --trend — quality-scoped view over metrics-history.jsonl ─────────────
+
+const FIXTURE_HISTORY = join(ROOT, 'tests', 'lib', 'fixtures', 'metrics-history.jsonl');
+
+test('sparkline: empty series → empty string', () => {
+  assert.equal(sparkline([]), '');
+});
+
+test('sparkline: one tick per value, length matches input', () => {
+  const s = sparkline([0.1, 0.5, 0.9]);
+  assert.equal(s.length, 3);
+});
+
+test('sparkline: flat series (no range) still renders without throwing', () => {
+  assert.equal(sparkline([0.5, 0.5, 0.5]).length, 3);
+});
+
+test('buildTrend: keeps only quality.* keys, ignores other metrics-history rows', () => {
+  const rows = [
+    { key: 'quality.cli', value: 0.8 },
+    { key: 'eval_pass_rate', value: 0.92 },
+  ];
+  const t = buildTrend(rows);
+  assert.equal(t.length, 1);
+  assert.equal(t[0].archetype, 'cli');
+});
+
+test('buildTrend: fixture history — cli trend has 5 points, latest 85, delta +5', () => {
+  const rows = parseHistoryFixture();
+  const t = buildTrend(rows);
+  const cli = t.find(x => x.archetype === 'cli');
+  assert.equal(cli.points, 5);
+  assert.equal(cli.latest, 85);
+  assert.equal(cli.delta, 5);
+  assert.deepEqual(cli.scores, [70, 74, 72, 80, 85]);
+});
+
+test('buildTrend: fixture history — crud trend has 2 points, regression delta -25', () => {
+  const rows = parseHistoryFixture();
+  const t = buildTrend(rows);
+  const crud = t.find(x => x.archetype === 'crud');
+  assert.equal(crud.points, 2);
+  assert.equal(crud.latest, 65);
+  assert.equal(crud.delta, -25);
+});
+
+test('buildTrend: single point → delta null (first point)', () => {
+  const t = buildTrend([{ key: 'quality.web', value: 0.5 }]);
+  assert.equal(t[0].delta, null);
+});
+
+test('buildTrend: --last caps the window to the most recent N points', () => {
+  const rows = parseHistoryFixture();
+  const t = buildTrend(rows, { last: 2 });
+  const cli = t.find(x => x.archetype === 'cli');
+  assert.equal(cli.points, 2);
+  assert.deepEqual(cli.scores, [80, 85]);
+});
+
+test('buildTrend: results sorted by archetype name', () => {
+  const t = buildTrend(parseHistoryFixture());
+  const names = t.map(x => x.archetype);
+  assert.deepEqual(names, [...names].sort());
+});
+
+test('renderTrendText: no data → friendly message, not an error', () => {
+  const s = renderTrendText([]);
+  assert.match(s, /no recorded quality/);
+});
+
+test('renderTrendText: includes archetype, score, and delta sign for each series', () => {
+  const t = buildTrend(parseHistoryFixture());
+  const s = renderTrendText(t);
+  assert.match(s, /cli/);
+  assert.match(s, /85\/100/);
+  assert.match(s, /Δ\+5/);
+  assert.match(s, /crud/);
+  assert.match(s, /Δ-25/);
+});
+
+test('CLI: --trend reads --history fixture, prints table, always exits 0', () => {
+  const res = spawnSync(process.execPath, [TOOL, '--trend', '--history', FIXTURE_HISTORY], { encoding: 'utf8' });
+  assert.equal(res.status, 0, res.stdout + res.stderr);
+  assert.match(res.stdout, /Quality trend/);
+  assert.match(res.stdout, /cli/);
+});
+
+test('CLI: --trend --json emits parseable JSON', () => {
+  const res = spawnSync(process.execPath, [TOOL, '--trend', '--history', FIXTURE_HISTORY, '--json'], { encoding: 'utf8' });
+  assert.equal(res.status, 0);
+  const parsed = JSON.parse(res.stdout);
+  assert.ok(Array.isArray(parsed));
+  assert.ok(parsed.find(t => t.archetype === 'cli'));
+});
+
+test('CLI: --trend with a missing history file exits 0 with a friendly message (read-only, never crashes)', () => {
+  const res = spawnSync(process.execPath, [TOOL, '--trend', '--history', '/nonexistent/metrics-history.jsonl'], { encoding: 'utf8' });
+  assert.equal(res.status, 0, res.stdout + res.stderr);
+  assert.match(res.stdout, /no recorded quality/);
+});
+
+function parseHistoryFixture() {
+  const text = readFileSync(FIXTURE_HISTORY, 'utf8');
+  return text.split('\n').filter(Boolean).map(l => JSON.parse(l));
+}


### PR DESCRIPTION
Implements docs/arch/ARCH-quality-deepen-followups.md (architect-scoped from PR #118–120 archaeology):

- **F3b** — fixed 2 stale test expectations (cli vs cli-tool archetype family) — closes the great_cto-7nxj drift bug; main is fully green again
- **F3a** — archetype contracts 6 → 14 (ai-system, agent-product, commerce, web3, iot-embedded, data-platform, browser-extension, mobile-app); library/cli-tool/infra excluded by design
- **F3c** — contract regex hardening (/hold/ vs "household" class of false positives) with TP+FP regression pairs
- **F5a** — `quality.mjs --gate --baseline` with product-eval parity semantics
- **F5b** — `quality.mjs --trend` sparkline over metrics-history.jsonl
- **F6a/F6b** — opt-in `--browser` harness: axe-core a11y + Web Vitals (LCP/CLS/INP), dynamic playwright import, graceful `na` on every failure path, zero runtime deps (axe-core is devDependency)
- **F4** (drift cron) deliberately skipped: Actions billing-locked, precondition unmeetable

Tests: lib suite 285 → 355, full suite 176/176, ci-local --quick all gates green.